### PR TITLE
Fix HUD overlay clipping and scrollbar on Windows

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -28,7 +28,7 @@ export function createHudOverlayWindow(): BrowserWindow {
   const { workArea } = primaryDisplay;
 
 
-  const windowWidth = 500;
+  const windowWidth = 600;
   const windowHeight = 155;
 
   const x = Math.floor(workArea.x + (workArea.width - windowWidth) / 2);
@@ -37,8 +37,8 @@ export function createHudOverlayWindow(): BrowserWindow {
   const win = new BrowserWindow({
     width: windowWidth,
     height: windowHeight,
-    minWidth: 500,
-    maxWidth: 500,
+    minWidth: 600,
+    maxWidth: 600,
     minHeight: 155,
     maxHeight: 155,
     x: x,

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -152,7 +152,7 @@ export function LaunchWindow() {
   };
 
   return (
-    <div className="w-full h-full flex items-end justify-center bg-transparent">
+    <div className="w-full h-full flex items-end justify-center bg-transparent overflow-hidden">
       <div className={`flex flex-col items-center gap-2 mx-auto ${styles.electronDrag}`}>
         {showMicControls && (
           <div
@@ -177,7 +177,7 @@ export function LaunchWindow() {
         )}
 
         <div
-          className={`w-full max-w-[560px] mx-auto flex items-center gap-1.5 px-3 py-2 ${styles.electronDrag} ${styles.hudBar}`}
+          className={`w-full mx-auto flex items-center gap-1.5 px-3 py-2 ${styles.electronDrag} ${styles.hudBar}`}
           style={{
             borderRadius: 9999,
             background: "linear-gradient(135deg, rgba(28,28,36,0.97) 0%, rgba(18,18,26,0.96) 100%)",


### PR DESCRIPTION
On Windows, the HUD overlay window (500px) is narrower than the HUD bar content, causing both sides to clip and a horizontal scrollbar to appear.

**What changed:**
- HUD overlay window: 500px → 600px
- Root container: added `overflow-hidden`
- HUD bar: removed `max-w-[560px]`

---

Before

<img width="588" height="185" alt="image" src="https://github.com/user-attachments/assets/bda838a7-f2ea-4d59-8718-df93cf39de4c" />

---

After

<img width="675" height="117" alt="image" src="https://github.com/user-attachments/assets/1660cff9-79d3-4d2f-b5fb-949b75b78dfe" />