### PR TITLE
Arch / AUR: README install docs; packaging in recordly-aur

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Language: EN | [简中](README.zh-CN.md)
 <p align="center">
   <img src="https://img.shields.io/badge/macOS%20%7C%20Windows%20%7C%20Linux-111827?style=for-the-badge" alt="macOS Windows Linux" />
   <img src="https://img.shields.io/badge/open%20source-MIT-2563eb?style=for-the-badge" alt="MIT license" />
+  <a href="https://aur.archlinux.org/packages/recordly-bin"><img src="https://img.shields.io/aur/version/recordly-bin?label=AUR&style=for-the-badge" alt="AUR recordly-bin" /></a>
 </p>
 
 ### Create polished, pro-grade screen recordings.
@@ -129,6 +130,18 @@ On Windows, builds older than 19041 fall back to Electron capture and the cursor
 Prebuilt releases are available here:
 
 https://github.com/webadderall/Recordly/releases
+
+---
+
+## Arch Linux / Manjaro (yay)
+
+Install from the AUR ([recordly-bin](https://aur.archlinux.org/packages/recordly-bin)):
+
+```bash
+yay -S recordly-bin
+```
+
+PKGBUILD, desktop entry, release sync, and optional **local-from-source** packaging live in **[recordly-aur](https://github.com/firtoz/recordly-aur)** so this repository stays free of Arch release chores. For maintainer contact and how the package is updated, see that repo or the AUR package page.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **user-facing Arch / Manjaro documentation** in this repo (AUR badge + install section) so people can install via [`yay -S recordly-bin`](https://aur.archlinux.org/packages/recordly-bin).

**Packaging is not maintained in this tree.** The canonical PKGBUILD, `.desktop` file, checksum automation, and AUR git pushes live in **[firtoz/recordly-aur](https://github.com/firtoz/recordly-aur)**. That keeps **upstream free of per-release Arch chores** (no `pkgver` / `sha256sums` bumps here).

The AUR package applies maintainer review items there, for example:

- Maintainer line and packaging hygiene
- Upstream **MIT** (`LICENSE.md` at the release tag) installed under `/usr/share/licenses/$pkgname/`
- `Icon=dev.recordly.app`, no empty `MimeType=`
- **Pinned** AppImage + license `sha256sums`, updated by [`update-aur.ts`](https://github.com/firtoz/recordly-aur/blob/main/update-aur.ts) (Bun) + scheduled GitHub Actions

**Local install from a self-built AppImage** is documented in recordly-aur (`PKGBUILD.from-source`), not via `npm` scripts in this repo.

## Motivation

Arch users get a clear path: AUR helper + link to how the package is built. Maintainers own release sync in recordly-aur without asking upstream to touch packaging on every release.

## Type of change

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [x] Documentation Update
- [x] Other — **distribution docs + external packaging home (recordly-aur)**

## Related issues

None.

## For upstream maintainers

Nothing required on each release for Arch beyond normal **tag + GitHub Release** (AppImage + `LICENSE.md` at the tag). recordly-aur automation consumes that.

## Screenshots / video

<img width="1036" height="125" alt="AUR badge and install docs" src="https://github.com/user-attachments/assets/ea4afa6b-eef1-48da-a7bf-c0ed765af130" />

## How to verify

- README: Arch section points to `yay -S recordly-bin` and [recordly-aur](https://github.com/firtoz/recordly-aur).
- Install on Arch: `yay -S recordly-bin` (or build from templates in recordly-aur, not from `packaging/arch` in this repo).

## Checklist

- [x] Self-review
- [x] Screenshots / video (N/A beyond existing)
- [x] Related issues / changelog (N/A)
