### PR TITLE
fix(tray): single-click opens window and brings it to front; Linux/Wayland focus workaround

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -84,10 +84,25 @@ function focusOrCreateMainWindow() {
   }
 
   if (mainWindow && !mainWindow.isDestroyed()) {
-    if (mainWindow.isMinimized()) mainWindow.restore()
+    // On Linux/Wayland, focus() often doesn't take effect (compositor ignores it). Apps like Telegram
+    // work because they receive an XDG activation token via StatusNotifierItem.ProvideXdgActivationToken;
+    // Electron's tray doesn't handle that yet. Workaround: destroy and recreate the HUD so the new
+    // window gets focus (creation path works). Only for HUD, not editor.
+    if (
+      process.platform === 'linux' &&
+      !mainWindow.isFocused() &&
+      !isEditorWindow(mainWindow)
+    ) {
+      const win = mainWindow
+      mainWindow = null
+      win.once('closed', () => createWindow())
+      win.destroy()
+      return
+    }
     mainWindow.show()
-    mainWindow.focus()
+    if (mainWindow.isMinimized()) mainWindow.restore()
     mainWindow.moveTop()
+    mainWindow.focus()
   }
 }
 
@@ -204,6 +219,7 @@ function setupApplicationMenu() {
 
 function createTray() {
   tray = new Tray(defaultTrayIcon);
+  tray.on('click', () => focusOrCreateMainWindow())
 }
 
 function getPublicAssetPath(filename: string) {


### PR DESCRIPTION
## Description
Makes the system tray icon respond to a single left-click: clicking the tray icon now opens or brings the Recordly window to the front, instead of requiring right-click → Open. The tray click handler applies on all platforms (Windows, macOS, Linux). On Linux (e.g. Manjaro KDE Plasma) a destroy/recreate workaround ensures the window actually receives focus when the compositor ignores `focus()`; that workaround is Linux/Wayland-only.

## Motivation
On Linux (especially KDE/Wayland), tapping/clicking the systray icon did nothing; users had to right-click and choose "Open". This PR adds a tray `click` handler so left-click calls the same focus/show logic on all platforms, and adds a Linux/Wayland-only workaround so the window actually receives focus (destroy-and-recreate HUD when unfocused, since Electron's tray does not yet handle `ProvideXdgActivationToken`).

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Upstream: electron/electron#43709 (activation from tray on Wayland; Telegram uses `ProvideXdgActivationToken`).

## Screenshots / Video
No UI change beyond behavior: single-click on tray icon now opens/focuses the window. No screenshot required.

## Testing Guide
1. Run the app on Linux (e.g. Manjaro KDE Plasma, or any Linux with a systray).
2. Minimize or cover the Recordly HUD with another window.
3. Left-click the Recordly tray icon once.
4. **Expected:** The Recordly window comes to the front and has focus (no need to click the taskbar).
5. Right-click tray → Open / Quit should still work as before.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.
