### PR TITLE
fix: correct button hover background color to white with 10% opacity

### DIFF
--- a/src/components/video-editor/ShortcutsConfigDialog.tsx
+++ b/src/components/video-editor/ShortcutsConfigDialog.tsx
@@ -199,7 +199,7 @@ export function ShortcutsConfigDialog() {
           <Button
             variant="ghost"
             size="sm"
-            className="text-slate-400 hover:text-white gap-1.5"
+            className="text-slate-400 hover:text-white hover:bg-white/10 gap-1.5"
             onClick={handleReset}
           >
             <RotateCcw className="w-3 h-3" />


### PR DESCRIPTION
## Problem - Preview
![Problem - Preview](https://github.com/user-attachments/assets/4d1a6b4e-890e-45fd-8de9-7b0ce9547bc3)


## Fix - Preview
![Fix - Preview](https://github.com/user-attachments/assets/f4c6d09d-0826-4483-b7f0-bbc7f05b1099)
