### PR TITLE
Fix/windows10 wgc border crash

### DIFF
--- a/electron/native/wgc-capture/src/wgc_session.cpp
+++ b/electron/native/wgc-capture/src/wgc_session.cpp
@@ -129,7 +129,6 @@ bool WgcSession::initializeWithItem(int fps) {
     try {
         session_.IsBorderRequired(false);
     } catch (winrt::hresult_error const& e) {
-        std::cerr << "WARNING: IsBorderRequired not supported on this OS (hr=0x" << std::hex << static_cast<uint32_t>(e.code()) << ")" << std::endl;
     }
 
     return true;


### PR DESCRIPTION
When runing the app on window 10 , the Native Windows capture fails resulting in cursor not beign hidden

cause : IsBorderRequired is only available on Windows 11+ (build 22000), on windows 10 it causes hresult_error and the Faluire happens because of the uncaught expetion 

Adding a try-catch block fixed the problem

