### PR TITLE
fix: shortcuts overflow when text of reset button is large

### DIFF
--- a/src/components/video-editor/ShortcutsConfigDialog.tsx
+++ b/src/components/video-editor/ShortcutsConfigDialog.tsx
@@ -197,6 +197,7 @@ export function ShortcutsConfigDialog() {
 
         <DialogFooter className="flex gap-2 sm:justify-between mt-2">
           <Button
+            title={t('shortcutsConfig.resetToDefaults')}
             variant="ghost"
             size="sm"
             className="text-slate-400 hover:text-white hover:bg-white/10 gap-1.5 max-w-[200px]"


### PR DESCRIPTION
When the reset button text is too long, the shortcuts dialog content overflows its bounds. This occurs in the Spanish language.

### Problem - Preview:
<img width="685" height="894" alt="Problem" src="https://github.com/user-attachments/assets/137ac72e-5320-48c2-b9dd-5df0889806e8" />

### Fix:
- Increased the dialog max width slightly (from 420px to 460px)
- Set a max width on the button (200px)
- Wrapped the button text in a `<span>` with `truncate`
- Added tooltip support for longer texts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the shortcuts configuration dialog layout with enhanced spacing for better content display.
  * Enhanced text overflow handling to prevent label truncation issues within the dialog.
  * Added tooltip support and refined button styling for improved usability of the reset-to-defaults action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->