### PR TITLE
feat: add pulse indicator when has unsaved changes

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -2378,8 +2378,8 @@ export default function VideoEditor() {
 						className="inline-flex h-8 min-w-[96px] items-center justify-center gap-1.5 rounded-[5px] bg-white px-4 text-black transition-colors hover:bg-white/92"
 					>
 						<span className={`${hasUnsavedChanges ? "flex" : "hidden"} size-2 relative`}>
- 							<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-400 opacity-75"></span>
-  							<span className="relative inline-flex size-2 rounded-full bg-sky-500"></span>
+ 							<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#2563EB] opacity-75"></span>
+  							<span className="relative inline-flex size-2 rounded-full bg-[#2563EB]"></span>
 						</span>
 						<Save className="h-4 w-4" />
 						<span className="text-sm font-semibold tracking-tight">{t("common.actions.save")}</span>


### PR DESCRIPTION
This PR adds a visual indicator to the "Save" button to inform the user that there are pending changes to be saved.

### Preview
![Demo](https://github.com/user-attachments/assets/a864745c-c9d2-447d-b325-4f43b9f0726d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save button now shows a small, pulsing sky‑blue dot when there are unsaved changes, making it easier to notice and resume editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->