### PR TITLE
fix: display app version in More menu

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -286,6 +286,8 @@ interface Window {
 			message?: string;
 			error?: string;
 		}>;
+		/** Returns the app version from package.json */
+		getAppVersion: () => Promise<string>;
 		/** Hide the OS cursor before browser capture starts. */
 		hideOsCursor: () => Promise<{ success: boolean }>;
 		/** Countdown timer before recording */

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -4474,5 +4474,9 @@ body{background:transparent;overflow:hidden;width:100vw;height:100vh}
       seconds: countdownInProgress ? countdownRemaining : null,
     }
   })
+
+  ipcMain.handle('app:getVersion', () => {
+    return app.getVersion()
+  })
 }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -296,6 +296,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	isNativeWindowsCaptureAvailable: () => ipcRenderer.invoke("is-native-windows-capture-available"),
 	muxNativeWindowsRecording: () => ipcRenderer.invoke("mux-native-windows-recording"),
 	hideOsCursor: () => ipcRenderer.invoke("hide-cursor"),
+	getAppVersion: () => ipcRenderer.invoke("app:getVersion"),
 	getCountdownDelay: () => ipcRenderer.invoke("get-countdown-delay"),
 	setCountdownDelay: (delay: number) => ipcRenderer.invoke("set-countdown-delay", delay),
 	startCountdown: (seconds: number) => ipcRenderer.invoke("start-countdown", seconds),

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -188,6 +188,7 @@ export function LaunchWindow() {
 	const [sourcesLoading, setSourcesLoading] = useState(false);
 	const [hideHudFromCapture, setHideHudFromCapture] = useState(true);
 	const [platform, setPlatform] = useState<string | null>(null);
+	const [appVersion, setAppVersion] = useState<string | null>(null);
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const hudContentRef = useRef<HTMLDivElement>(null);
 	const hudBarRef = useRef<HTMLDivElement>(null);
@@ -367,6 +368,22 @@ export function LaunchWindow() {
 			}
 		};
 		void loadPlatform();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+		const loadVersion = async () => {
+			try {
+				const version = await window.electronAPI.getAppVersion();
+				if (!cancelled) setAppVersion(version);
+			} catch (error) {
+				console.error("Failed to load app version:", error);
+			}
+		};
+		void loadVersion();
 		return () => {
 			cancelled = true;
 		};
@@ -1006,6 +1023,20 @@ export function LaunchWindow() {
 											{LOCALE_LABELS[code] ?? code}
 										</DropdownItem>
 									))}
+									{appVersion && (
+										<div
+											style={{
+												marginTop: 8,
+												padding: "4px 12px",
+												fontSize: 11,
+												color: "#6b6b78",
+												textAlign: "center",
+												userSelect: "text",
+											}}
+										>
+											v{appVersion}
+										</div>
+									)}
 								</>
 							)}
 						</div>


### PR DESCRIPTION
## Summary
- Add `app:getVersion` IPC handler in `electron/ipc/handlers.ts` to expose `app.getVersion()` to the renderer process
- Expose `getAppVersion` in the preload bridge and add its type definition
- Display the version string (e.g. "v1.1.4") at the bottom of the "More" dropdown menu in the launch window — small, gray, unobtrusive

## Test plan
- [ ] Open Recordly and click the "More" (vertical dots) button in the HUD bar
- [ ] Verify the version number appears at the bottom of the dropdown, below the language options
- [ ] Verify the displayed version matches the `version` field in `package.json`

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The launcher’s "more" menu now shows the app version (displayed as a small, centered, selectable "vX.Y.Z" label) for quick reference.
  * Version display is loaded when the launcher opens and fails gracefully if unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->