### PR TITLE
Fix corrupted MP4 recordings on Windows

### DIFF
--- a/electron/native/wgc-capture/src/mf_encoder.cpp
+++ b/electron/native/wgc-capture/src/mf_encoder.cpp
@@ -124,6 +124,7 @@ bool MFEncoder::initialize(const std::wstring& outputPath, int width, int height
 }
 
 bool MFEncoder::writeFrame(ID3D11Texture2D* texture, int64_t timestampHns) {
+    std::lock_guard<std::mutex> lock(writeMutex_);
     if (!initialized_ || !sinkWriter_) return false;
 
     context_->CopyResource(stagingTexture_.Get(), texture);
@@ -190,6 +191,7 @@ bool MFEncoder::writeFrame(ID3D11Texture2D* texture, int64_t timestampHns) {
 }
 
 bool MFEncoder::finalize() {
+    std::lock_guard<std::mutex> lock(writeMutex_);
     if (!initialized_) return false;
     initialized_ = false;
 

--- a/electron/native/wgc-capture/src/mf_encoder.h
+++ b/electron/native/wgc-capture/src/mf_encoder.h
@@ -8,6 +8,7 @@
 #include <wrl/client.h>
 #include <string>
 #include <vector>
+#include <mutex>
 
 using Microsoft::WRL::ComPtr;
 
@@ -32,4 +33,5 @@ private:
     int height_ = 0;
     int fps_ = 60;
     bool initialized_ = false;
+    std::mutex writeMutex_;
 };


### PR DESCRIPTION
## Summary

- Fix a thread-safety issue in the native Windows capture encoder (`wgc-capture`) that causes corrupted/unplayable MP4 files
- The `Direct3D11CaptureFramePool::CreateFreeThreaded` frame pool dispatches `FrameArrived` callbacks on thread pool threads **concurrently**, but `MFEncoder::writeFrame()` accesses non-thread-safe resources (`ID3D11DeviceContext`, `IMFSinkWriter`, shared staging texture and NV12 buffer) without synchronization
- At 60fps, when frame processing takes longer than ~16.7ms (GPU map stall + CPU BGRA→NV12 conversion), callbacks overlap and corrupt the MP4 container
- Add a `std::mutex` to serialize `writeFrame()` and `finalize()` calls

## Test plan

- [ ] Record a 30s–1min video on Windows using native capture
- [ ] Verify the resulting MP4 opens in VLC and other players
- [ ] Record multiple videos in succession to confirm consistency
- [ ] Test with system audio and microphone enabled (muxing path)

Fixes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety in the encoder to prevent potential concurrent access issues during frame writing and finalization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->