### PR TITLE
feat(editor): add 3× and 4× playback speed options

### DIFF
--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -307,7 +307,9 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 						region.speed === 1.25 ||
 						region.speed === 1.5 ||
 						region.speed === 1.75 ||
-						region.speed === 2
+						region.speed === 2 ||
+						region.speed === 3 ||
+						region.speed === 4
 							? region.speed
 							: DEFAULT_PLAYBACK_SPEED;
 

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -292,7 +292,7 @@ export const DEFAULT_AUTO_CAPTION_SETTINGS: AutoCaptionSettings = {
   backgroundOpacity: 0.9,
 };
 
-export type PlaybackSpeed = 0.25 | 0.5 | 0.75 | 1.25 | 1.5 | 1.75 | 2;
+export type PlaybackSpeed = 0.25 | 0.5 | 0.75 | 1.25 | 1.5 | 1.75 | 2 | 3 | 4;
 
 export interface SpeedRegion {
   id: string;
@@ -309,6 +309,8 @@ export const SPEED_OPTIONS: Array<{ speed: PlaybackSpeed; label: string }> = [
   { speed: 1.5, label: "1.5×" },
   { speed: 1.75, label: "1.75×" },
   { speed: 2, label: "2×" },
+  { speed: 3, label: "3×" },
+  { speed: 4, label: "4×" },
 ];
 
 export const DEFAULT_PLAYBACK_SPEED: PlaybackSpeed = 1.5;


### PR DESCRIPTION
## Summary
- Extend `PlaybackSpeed` type to include `3` and `4`
- Add 3× and 4× entries to `SPEED_OPTIONS` in the settings panel
- Update speed validation in project persistence to accept the new values

No technical limitation — HTML5 `playbackRate` and `AudioContext` handle these speeds natively.

## Test plan
- [ ] Open a project, add a speed region, verify 3× and 4× appear in the dropdown
- [ ] Set a region to 4×, play back, confirm video and audio play at correct speed
- [ ] Export a video with a 4× speed region, verify output is correct
- [ ] Save/reload a project with 3× or 4× regions, confirm they persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for 3x and 4x playback speeds in the video editor. Users can now select from an expanded range of playback speeds, with the maximum speed increased from 2x to 4x for customized viewing experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->