### PR TITLE
fix(recording): preserve mic audio when recovering mac capture

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -2651,25 +2651,32 @@ async function finalizeStoredVideo(videoPath: string) {
 }
 
 async function recoverNativeMacCaptureOutput() {
-  const diagnosticsPath =
+  const macDiagnostics =
     lastNativeCaptureDiagnostics?.backend === 'mac-screencapturekit'
-      ? lastNativeCaptureDiagnostics.outputPath ?? null
+      ? lastNativeCaptureDiagnostics
       : null
+  const diagnosticsPath = macDiagnostics?.outputPath ?? null
   const candidatePath = nativeCaptureTargetPath ?? diagnosticsPath
+  const systemAudioPath = nativeCaptureSystemAudioPath ?? macDiagnostics?.systemAudioPath ?? null
+  const microphonePath = nativeCaptureMicrophonePath ?? macDiagnostics?.microphonePath ?? null
 
   if (!candidatePath) {
     return null
   }
 
   try {
+    if (systemAudioPath || microphonePath) {
+      await muxNativeMacRecordingWithAudio(candidatePath, systemAudioPath, microphonePath)
+    }
+
     return await finalizeStoredVideo(candidatePath)
   } catch (error) {
     recordNativeCaptureDiagnostics({
       backend: 'mac-screencapturekit',
       phase: 'stop',
       outputPath: candidatePath,
-      systemAudioPath: nativeCaptureSystemAudioPath,
-      microphonePath: nativeCaptureMicrophonePath,
+      systemAudioPath,
+      microphonePath,
       processOutput: nativeCaptureOutputBuffer.trim() || undefined,
       fileSizeBytes: await getFileSizeIfPresent(candidatePath),
       error: String(error),
@@ -4899,4 +4906,3 @@ body{background:transparent;overflow:hidden;width:100vw;height:100vh}
     }
   })
 }
-


### PR DESCRIPTION
## Description
Fixes a macOS native recording issue where microphone audio could be missing after a screen recording opens in the editor, even though mic capture was enabled and the microphone sidecar audio file was created.

## Motivation
On macOS, native ScreenCaptureKit recordings can go through a recovery path before the editor opens. In that path, the app finalized the recovered video file directly and skipped muxing any existing microphone/system-audio sidecar files back into the final `.mp4`. As a result, users could complete a recording with mic input enabled, but hear no voice audio in the editor.

This change makes the recovery path reuse the recorded audio sidecars and mux them before finalizing the recovered video.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
N/A

## Screenshots / Video
N/A - audio-only bugfix, no UI changes.

## Testing Guide
1. On macOS, grant Recordly microphone permission.
2. Start a screen or window recording with microphone enabled.
3. Speak during the recording, then stop the recording.
4. Let the recording open in the editor.
5. Verify the recorded voice audio is audible in the editor.

Optional regression check:
1. Confirm recovered native recordings still open successfully in the editor.
2. Confirm recovered recordings include microphone audio instead of opening as video-only.

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced native macOS screen capture audio handling to better locate and synchronize audio with recovered video.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->