### PR TITLE
Fix Linux HUD input handling

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -45,6 +45,10 @@ function isHudOverlayCaptureProtectionSupported(): boolean {
 	return process.platform !== "linux";
 }
 
+function isHudOverlayMousePassthroughSupported(): boolean {
+	return process.platform !== "linux";
+}
+
 function loadHudOverlayCaptureProtectionSetting(): boolean {
 	if (hudOverlayCaptureProtectionLoaded) {
 		return hudOverlayHiddenFromCapture;
@@ -174,11 +178,17 @@ function positionUpdateToastWindow() {
 
 ipcMain.on("hud-overlay-set-ignore-mouse", (_event, ignore: boolean) => {
 	if (hudOverlayWindow && !hudOverlayWindow.isDestroyed()) {
+		if (!isHudOverlayMousePassthroughSupported()) {
+			hudOverlayWindow.setIgnoreMouseEvents(false);
+			return;
+		}
+
 		if (ignore) {
 			hudOverlayWindow.setIgnoreMouseEvents(true, { forward: true });
-		} else {
-			hudOverlayWindow.setIgnoreMouseEvents(false);
+			return;
 		}
+
+		hudOverlayWindow.setIgnoreMouseEvents(false);
 	}
 });
 
@@ -320,7 +330,9 @@ export function createHudOverlayWindow(): BrowserWindow {
 		win.setContentProtection(hudOverlayHiddenFromCapture);
 	}
 
-	win.setIgnoreMouseEvents(true, { forward: true });
+	if (isHudOverlayMousePassthroughSupported()) {
+		win.setIgnoreMouseEvents(true, { forward: true });
+	}
 
 	// On Windows 10, focus changes (e.g. showing a native notification) can break
 	// setIgnoreMouseEvents forwarding on a transparent always-on-top window, making


### PR DESCRIPTION
## Summary
- disable HUD mouse passthrough on Linux where Electron's forwarded hover path leaves the transparent overlay permanently click-through
- keep the existing passthrough behavior on macOS and Windows
- preserve the renderer-side hover toggles while forcing the Linux HUD window to remain interactive

## Verification
- npx tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD overlay mouse passthrough behavior by preventing activation on unsupported platforms.
  * Enhanced platform-specific compatibility checks for more reliable mouse interaction handling.
  * Refined mouse event control flow for consistent cross-platform overlay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->