### PR TITLE
[codex] fix(windows): force interactive HUD fallback on Windows 10

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,8 +8,8 @@ import {
 	dialog,
 	ipcMain,
 	Menu,
-	nativeImage,
 	Notification,
+	nativeImage,
 	session,
 	systemPreferences,
 	Tray,
@@ -21,27 +21,28 @@ import {
 	killWindowsCaptureProcess,
 	registerIpcHandlers,
 } from "./ipc/handlers";
+import type { UpdateToastPayload } from "./updater";
 import {
 	checkForAppUpdates,
+	deferUpdateReminder,
 	dismissUpdateToast,
 	downloadAvailableUpdate,
-	deferUpdateReminder,
 	getCurrentUpdateToastPayload,
 	getUpdaterLogPath,
 	getUpdateStatusSummary,
 	installDownloadedUpdateNow,
 	previewUpdateToast,
-	skipAvailableUpdateVersion,
 	setupAutoUpdates,
+	skipAvailableUpdateVersion,
 } from "./updater";
-import type { UpdateToastPayload } from "./updater";
 import {
 	createEditorWindow,
 	createHudOverlayWindow,
 	createSourceSelectorWindow,
-	getUpdateToastWindow,
 	getHudOverlayWindow,
+	getUpdateToastWindow,
 	hideUpdateToastWindow,
+	shouldForceInteractiveHudOverlay,
 	showUpdateToastWindow,
 } from "./windows";
 
@@ -201,6 +202,11 @@ function reassertHudOverlayMouseState() {
 	// Toggle off then back on so the native WS_EX_TRANSPARENT flag is fully
 	// re-initialised rather than merely re-asserted in a potentially broken state.
 	hud.setIgnoreMouseEvents(false);
+
+	if (shouldForceInteractiveHudOverlay()) {
+		return;
+	}
+
 	setTimeout(() => {
 		if (!hud.isDestroyed()) {
 			hud.setIgnoreMouseEvents(true, { forward: true });
@@ -408,7 +414,9 @@ function sendUpdateToastToWindows(channel: "update-toast-state", payload: unknow
 			return false;
 		}
 
-		const notificationKey = [updatePayload.phase, updatePayload.version, updatePayload.detail].join(":");
+		const notificationKey = [updatePayload.phase, updatePayload.version, updatePayload.detail].join(
+			":",
+		);
 		if (activeUpdateNotificationKey === notificationKey) {
 			return true;
 		}
@@ -682,10 +690,14 @@ app.whenReady().then(async () => {
 		const cameraStatus = systemPreferences.getMediaAccessStatus("camera");
 		const micStatus = systemPreferences.getMediaAccessStatus("microphone");
 		if (cameraStatus !== "granted") {
-			console.warn(`[permissions] Camera access is "${cameraStatus}" — webcam may not work. Check Windows Settings > Privacy > Camera.`);
+			console.warn(
+				`[permissions] Camera access is "${cameraStatus}" — webcam may not work. Check Windows Settings > Privacy > Camera.`,
+			);
 		}
 		if (micStatus !== "granted") {
-			console.warn(`[permissions] Microphone access is "${micStatus}" — mic recording may not work. Check Windows Settings > Privacy > Microphone.`);
+			console.warn(
+				`[permissions] Microphone access is "${micStatus}" — mic recording may not work. Check Windows Settings > Privacy > Microphone.`,
+			);
 		}
 	}
 

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app, BrowserWindow, ipcMain } from "electron";
@@ -40,6 +41,33 @@ let hudOverlayExpanded = false;
 let hudOverlayCompactWidth = HUD_MIN_WINDOW_WIDTH;
 let hudOverlayCompactHeight = HUD_COMPACT_HEIGHT;
 let hudOverlayExpandedHeight = HUD_MIN_EXPANDED_HEIGHT;
+
+function getWindowsBuildNumber(): number | null {
+	if (process.platform !== "win32") {
+		return null;
+	}
+
+	const build = Number.parseInt(os.release().split(".")[2] ?? "", 10);
+	return Number.isFinite(build) ? build : null;
+}
+
+export function shouldForceInteractiveHudOverlay(): boolean {
+	const build = getWindowsBuildNumber();
+	return build !== null && build < 22000;
+}
+
+function setHudOverlayMousePassthrough(win: BrowserWindow, ignore: boolean) {
+	if (shouldForceInteractiveHudOverlay()) {
+		win.setIgnoreMouseEvents(false);
+		return;
+	}
+
+	if (ignore) {
+		win.setIgnoreMouseEvents(true, { forward: true });
+	} else {
+		win.setIgnoreMouseEvents(false);
+	}
+}
 
 function isHudOverlayCaptureProtectionSupported(): boolean {
 	return process.platform !== "linux";
@@ -83,7 +111,9 @@ function persistHudOverlayCaptureProtectionSetting(enabled: boolean): void {
 
 function getScreen() {
 	if (!app.isReady()) {
-		throw new Error("getScreen() called before app is ready. Ensure all screen access happens after app.whenReady().");
+		throw new Error(
+			"getScreen() called before app is ready. Ensure all screen access happens after app.whenReady().",
+		);
 	}
 	return nodeRequire("electron").screen as typeof import("electron").screen;
 }
@@ -174,11 +204,7 @@ function positionUpdateToastWindow() {
 
 ipcMain.on("hud-overlay-set-ignore-mouse", (_event, ignore: boolean) => {
 	if (hudOverlayWindow && !hudOverlayWindow.isDestroyed()) {
-		if (ignore) {
-			hudOverlayWindow.setIgnoreMouseEvents(true, { forward: true });
-		} else {
-			hudOverlayWindow.setIgnoreMouseEvents(false);
-		}
+		setHudOverlayMousePassthrough(hudOverlayWindow, ignore);
 	}
 });
 
@@ -320,7 +346,7 @@ export function createHudOverlayWindow(): BrowserWindow {
 		win.setContentProtection(hudOverlayHiddenFromCapture);
 	}
 
-	win.setIgnoreMouseEvents(true, { forward: true });
+	setHudOverlayMousePassthrough(win, true);
 
 	// On Windows 10, focus changes (e.g. showing a native notification) can break
 	// setIgnoreMouseEvents forwarding on a transparent always-on-top window, making
@@ -330,10 +356,10 @@ export function createHudOverlayWindow(): BrowserWindow {
 	if (process.platform === "win32") {
 		win.on("focus", () => {
 			if (!win.isDestroyed()) {
-				win.setIgnoreMouseEvents(false);
+				setHudOverlayMousePassthrough(win, false);
 				setTimeout(() => {
 					if (!win.isDestroyed()) {
-						win.setIgnoreMouseEvents(true, { forward: true });
+						setHudOverlayMousePassthrough(win, true);
 					}
 				}, 50);
 			}
@@ -347,10 +373,10 @@ export function createHudOverlayWindow(): BrowserWindow {
 				win.show();
 				win.moveTop();
 				if (process.platform === "win32") {
-					win.setIgnoreMouseEvents(false);
+					setHudOverlayMousePassthrough(win, false);
 					setTimeout(() => {
 						if (!win.isDestroyed()) {
-							win.setIgnoreMouseEvents(true, { forward: true });
+							setHudOverlayMousePassthrough(win, true);
 						}
 					}, 50);
 				}


### PR DESCRIPTION
## Summary
- add a Windows 10 fallback that keeps the HUD interactive instead of relying on click-through forwarding recovery
- centralize HUD mouse passthrough handling behind a helper in `electron/windows.ts`
- skip passthrough reassertion in `electron/main.ts` when the Windows 10 fallback is active

## Why
On Windows 10, the transparent HUD can remain in a native click-through state even while the renderer still looks interactive. In that state, the `Screen` dropdown can open visually, but physical clicks are routed to the window behind Recordly instead of the HUD.

This change keeps the existing behavior on other platforms and newer Windows builds, but forces `setIgnoreMouseEvents(false)` on Windows 10 as a safer fallback.

## Validation
- `npx @biomejs/biome check electron/main.ts electron/windows.ts`
- `npx tsc --noEmit`
- local Windows 10 verification against the packaged app: `Screen` opened, source selection worked, and native hit-testing no longer passed clicks through to the underlying window


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HUD overlay mouse event handling on Windows to correctly respond based on system version, ensuring proper interaction behavior across different Windows builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->