### PR TITLE
fix(hud): resolve overlay snap to primary on multi-monitor

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -165,9 +165,16 @@ function getScreen() {
 	return nodeRequire("electron").screen as typeof import("electron").screen;
 }
 
+function getHudOverlayDisplay() {
+	const hudWindow = getHudOverlayWindow();
+	if (hudWindow) {
+		return getScreen().getDisplayMatching(hudWindow.getBounds());
+	}
+	return getScreen().getPrimaryDisplay();
+}
+
 function getHudOverlayBounds(expanded: boolean) {
-	const primaryDisplay = getScreen().getPrimaryDisplay();
-	const { bounds, workArea } = primaryDisplay;
+	const { bounds, workArea } = getHudOverlayDisplay();
 	const maxWindowWidth = Math.max(HUD_MIN_WINDOW_WIDTH, workArea.width - HUD_EDGE_MARGIN_DIP * 2);
 	const windowWidth = Math.min(
 		maxWindowWidth,
@@ -318,10 +325,9 @@ ipcMain.on("set-hud-overlay-compact-width", (_event, width: number) => {
 		return;
 	}
 
-	const primaryDisplay = getScreen().getPrimaryDisplay();
 	const maxWindowWidth = Math.max(
 		HUD_MIN_WINDOW_WIDTH,
-		primaryDisplay.workArea.width - HUD_EDGE_MARGIN_DIP * 2,
+		getHudOverlayDisplay().workArea.width - HUD_EDGE_MARGIN_DIP * 2,
 	);
 	const nextWidth = Math.min(maxWindowWidth, Math.max(HUD_MIN_WINDOW_WIDTH, Math.round(width)));
 
@@ -338,10 +344,9 @@ ipcMain.on("set-hud-overlay-measured-height", (_event, height: number, expanded:
 		return;
 	}
 
-	const primaryDisplay = getScreen().getPrimaryDisplay();
 	const maxWindowHeight = Math.max(
 		HUD_COMPACT_HEIGHT,
-		primaryDisplay.workArea.height - HUD_EDGE_MARGIN_DIP * 2,
+		getHudOverlayDisplay().workArea.height - HUD_EDGE_MARGIN_DIP * 2,
 	);
 	const nextHeight = Math.min(maxWindowHeight, Math.max(HUD_COMPACT_HEIGHT, Math.round(height)));
 
@@ -399,7 +404,7 @@ export function createHudOverlayWindow(): BrowserWindow {
 		minHeight: HUD_COMPACT_HEIGHT,
 		maxHeight: Math.max(
 			HUD_COMPACT_HEIGHT,
-			getScreen().getPrimaryDisplay().workArea.height - HUD_EDGE_MARGIN_DIP * 2,
+			getHudOverlayDisplay().workArea.height - HUD_EDGE_MARGIN_DIP * 2,
 		),
 		x: initialBounds.x,
 		y: initialBounds.y,


### PR DESCRIPTION
## Summary

Fix the HUD overlay snapping to the primary monitor when recording
starts on a multi-monitor setup. The positioning logic now detects
which display the HUD is on using `screen.getDisplayMatching()`
instead of always defaulting to `getPrimaryDisplay()`.

## Context / Motivation

- On multi-monitor setups, users position the HUD on the external
  monitor (typically the screen being recorded)
- Clicking Record triggers a React re-render that swaps idle controls
  for recording controls, firing the ResizeObserver
- The ResizeObserver sends `set-hud-overlay-compact-width` and
  `set-hud-overlay-measured-height` IPC messages to the main process
- These handlers call `applyHudOverlayBounds()`, which computes x,y
  from the primary display's `workArea` — always re-centering on
  primary regardless of where the user placed the HUD
- The fix follows the same `getDisplayMatching()` pattern already
  used by `getUpdateToastBounds()` in this file

## Changes

- [windows] Add `getHudOverlayDisplay()` helper that uses
  `getDisplayMatching(hudWindow.getBounds())` with fallback to
  `getPrimaryDisplay()` when the window doesn't exist yet
- [windows] Replace `getPrimaryDisplay()` in `getHudOverlayBounds()`
- [windows] Replace `getPrimaryDisplay()` in
  `set-hud-overlay-compact-width` IPC handler
- [windows] Replace `getPrimaryDisplay()` in
  `set-hud-overlay-measured-height` IPC handler
- [windows] Replace `getPrimaryDisplay()` in
  `createHudOverlayWindow()` maxHeight constraint

## Testing

- [x] Manual testing on Windows 11 Pro dual-monitor setup
- [x] Verified HUD stays on external monitor through recording
  start/stop cycle
- [x] Verified dropdown expand/collapse on external monitor
- [x] Verified single-monitor — zero behavior change
- [ ] Automated tests (N/A — Electron window positioning)

**Manual test — Windows 11 Pro (Build 26200):**
1. Built with `npx vite build && npx electron-builder --win --dir`
2. Moved HUD to external monitor (positioned left of primary)
3. Clicked Record — HUD stayed on external after countdown
4. Opened/closed dropdowns — HUD stayed on external
5. Stopped recording — HUD collapsed on external correctly
6. Diagnostic logging confirmed `getDisplayMatching()` returned
  the correct display throughout the entire cycle

**Single monitor:** `getDisplayMatching()` with one display
always returns that display — identical to `getPrimaryDisplay()`.
No behavioral change.

**Cross-platform:** `screen.getDisplayMatching()` is a core Electron
API on Windows, macOS, and Linux. No platform-specific code added.

## Risks & Impact

- No breaking changes
- No renderer or IPC protocol changes
- Single-monitor setups: zero behavioral difference
- `getDisplayMatching()` returns the display with largest overlap —
  same behavior as Electron's own transparent window positioning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HUD overlay positioning and sizing for multi-display setups. The HUD now correctly identifies which display it's on and adjusts layout accordingly, rather than always defaulting to the primary display, ensuring proper alignment and dimensions when using multiple monitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->