### PR TITLE
fix(export): preserve stream-start offsets during decode

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -5,7 +5,6 @@ import {
 	Download,
 	FolderOpen,
 	MousePointer2,
-	Puzzle,
 	Redo2,
 	Save,
 	Sparkles,

--- a/src/lib/exporter/forwardFrameSource.ts
+++ b/src/lib/exporter/forwardFrameSource.ts
@@ -1,5 +1,6 @@
 import { WebDemuxer } from "web-demuxer";
 import { getEffectiveVideoStreamDurationSeconds } from "@/lib/mediaTiming";
+import { getDecodedFrameTimelineOffsetUs } from "./streamingDecoder";
 
 const DEFAULT_MAX_DECODE_QUEUE = 12;
 const DEFAULT_MAX_PENDING_FRAMES = 32;
@@ -35,6 +36,7 @@ export class ForwardFrameSource {
   private heldFrameSec = 0;
   private lastTargetTimeSec = 0;
   private firstFrameTimestampUs: number | null = null;
+  private frameTimelineOffsetUs = 0;
 
   private toLocalFilePath(resourceUrl: string): string | null {
     if (!resourceUrl.startsWith("file:")) {
@@ -292,8 +294,12 @@ export class ForwardFrameSource {
         return null;
       }
       this.firstFrameTimestampUs = firstFrame.timestamp;
+      this.frameTimelineOffsetUs = getDecodedFrameTimelineOffsetUs(
+        firstFrame.timestamp,
+        this.metadata,
+      );
       this.heldFrame = firstFrame;
-      this.heldFrameSec = 0;
+      this.heldFrameSec = Math.max(0, this.frameTimelineOffsetUs / 1_000_000);
     }
 
     while (!this.cancelled) {
@@ -308,7 +314,10 @@ export class ForwardFrameSource {
         this.heldFrameSec,
         Math.max(
           0,
-          (nextFrame.timestamp - (this.firstFrameTimestampUs ?? nextFrame.timestamp)) / 1_000_000,
+          (
+            nextFrame.timestamp - (this.firstFrameTimestampUs ?? nextFrame.timestamp) +
+            this.frameTimelineOffsetUs
+          ) / 1_000_000,
         ),
       );
       const handoffBoundarySec = (this.heldFrameSec + nextFrameSec) / 2;
@@ -387,5 +396,6 @@ export class ForwardFrameSource {
     this.decodeError = null;
     this.lastTargetTimeSec = 0;
     this.firstFrameTimestampUs = null;
+    this.frameTimelineOffsetUs = 0;
   }
 }

--- a/src/lib/exporter/streamingDecoder.test.ts
+++ b/src/lib/exporter/streamingDecoder.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getDecodedFrameStartupOffsetUs } from './streamingDecoder';
+import {
+  getDecodedFrameStartupOffsetUs,
+  getDecodedFrameTimelineOffsetUs,
+} from './streamingDecoder';
 
 describe('getDecodedFrameStartupOffsetUs', () => {
   it('ignores positive stream start metadata when the first decoded frame matches it', () => {
@@ -26,5 +29,33 @@ describe('getDecodedFrameStartupOffsetUs', () => {
     ).toBe(150_000);
 
     expect(getDecodedFrameStartupOffsetUs(250_000, {})).toBe(250_000);
+  });
+});
+
+describe('getDecodedFrameTimelineOffsetUs', () => {
+  it('preserves a non-zero stream start time when decoded timestamps match the stream start', () => {
+    expect(
+      getDecodedFrameTimelineOffsetUs(6_741_667, {
+        mediaStartTime: 0,
+        streamStartTime: 6.741667,
+      }),
+    ).toBe(6_741_667);
+  });
+
+  it('includes both the stream start offset and any startup gap beyond it', () => {
+    expect(
+      getDecodedFrameTimelineOffsetUs(5_128_000, {
+        mediaStartTime: 0,
+        streamStartTime: 4.978,
+      }),
+    ).toBe(5_128_000);
+  });
+
+  it('falls back to a media-relative startup gap when stream metadata is missing', () => {
+    expect(
+      getDecodedFrameTimelineOffsetUs(250_000, {
+        mediaStartTime: 0.1,
+      }),
+    ).toBe(150_000);
   });
 });

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -37,6 +37,21 @@ export function getDecodedFrameStartupOffsetUs(
   return Math.max(0, firstDecodedFrameTimestampUs - streamStartTimeUs);
 }
 
+export function getDecodedFrameTimelineOffsetUs(
+  firstDecodedFrameTimestampUs: number,
+  metadata: Pick<DecodedVideoInfo, 'mediaStartTime' | 'streamStartTime'>
+): number {
+  const mediaStartTimeUs = Math.round((metadata.mediaStartTime ?? 0) * 1_000_000);
+  const streamStartTimeUs = Math.round(
+    (metadata.streamStartTime ?? metadata.mediaStartTime ?? 0) * 1_000_000
+  );
+
+  return (
+    Math.max(0, streamStartTimeUs - mediaStartTimeUs) +
+    getDecodedFrameStartupOffsetUs(firstDecodedFrameTimestampUs, metadata)
+  );
+}
+
 /**
  * Decodes video frames via web-demuxer + VideoDecoder in a single forward pass.
  * Way faster than seeking an HTMLVideoElement per frame.
@@ -221,6 +236,7 @@ export class StreamingVideoDecoder {
     let decodeError: Error | null = null;
     let decodeDone = false;
     let firstDecodedFrameTimestampUs: number | null = null;
+    let decodedFrameTimelineOffsetUs = 0;
 
     this.decoder = new VideoDecoder({
       output: (frame: VideoFrame) => {
@@ -365,11 +381,16 @@ export class StreamingVideoDecoder {
 
       if (firstDecodedFrameTimestampUs === null) {
         firstDecodedFrameTimestampUs = frame.timestamp;
+        decodedFrameTimelineOffsetUs = getDecodedFrameTimelineOffsetUs(
+          firstDecodedFrameTimestampUs,
+          this.metadata
+        );
       }
 
       const normalizedFrameTimeSec = Math.max(
         0,
-        (frame.timestamp - firstDecodedFrameTimestampUs) / 1_000_000,
+        (frame.timestamp - firstDecodedFrameTimestampUs + decodedFrameTimelineOffsetUs) /
+          1_000_000,
       );
       const frameTimeSec: number =
         lastDecodedFrameSec === null


### PR DESCRIPTION
## Summary
- preserve the video stream start offset when mapping decoded frames onto the export timeline
- apply the same timeline offset correction in `ForwardFrameSource` so preview and export stay aligned on offset streams
- add regression coverage for non-zero stream starts and startup gaps, and remove the stale `Puzzle` import that currently breaks `tsc --noEmit`

## Why
Affected recordings can report a longer container/audio timeline than the actual decodable video stream, while also starting the video stream at a non-zero timestamp. The export path was comparing trim regions in media-relative time against decoded frames normalized to the first decoded frame, which shifted the video timeline earlier and could fail with:

`Video decode ended early at 110.387s (needed 113.442s; rendered 1909/2000 frames).`

## Verification
- `npx vitest --run src/lib/exporter/streamingDecoder.test.ts`
- `npx tsc --noEmit`
- manually re-exported the previously failing project from the local app after rebuilding, and the export completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced frame timing accuracy during video export by incorporating decoded frame timeline offset calculations, ensuring exported videos maintain proper frame synchronization and timing alignment.

* **Tests**
  * Added comprehensive test coverage for timeline offset computation under various stream and metadata conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->