### PR TITLE
fix(hud): preserve user-dragged position across recording state changes

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -520,9 +520,9 @@ export function createHudOverlayWindow(): BrowserWindow {
 			);
 			if (!onScreen) {
 				hudUserPosition = null;
-				applyHudOverlayBounds(hudOverlayExpanded);
 			}
 		}
+		applyHudOverlayBounds(hudOverlayExpanded);
 	});
 
 	if (VITE_DEV_SERVER_URL) {

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -496,19 +496,13 @@ export function createHudOverlayWindow(): BrowserWindow {
 
 	hudOverlayWindow = win;
 
-	win.on("closed", () => {
-		if (hudOverlayWindow === win) {
-			hudOverlayWindow = null;
-		}
-	});
-
 	// Reset the user's saved HUD position when displays change so the bar
 	// doesn't end up stranded off-screen after a monitor is disconnected.
 	const screen = getScreen();
-	screen.on("display-removed", () => {
+	const handleDisplayRemoved = () => {
 		hudUserPosition = null;
-	});
-	screen.on("display-metrics-changed", () => {
+	};
+	const handleDisplayMetricsChanged = () => {
 		if (hudUserPosition) {
 			const displays = screen.getAllDisplays();
 			const onScreen = displays.some(
@@ -523,6 +517,16 @@ export function createHudOverlayWindow(): BrowserWindow {
 			}
 		}
 		applyHudOverlayBounds(hudOverlayExpanded);
+	};
+	screen.on("display-removed", handleDisplayRemoved);
+	screen.on("display-metrics-changed", handleDisplayMetricsChanged);
+
+	win.on("closed", () => {
+		screen.removeListener("display-removed", handleDisplayRemoved);
+		screen.removeListener("display-metrics-changed", handleDisplayMetricsChanged);
+		if (hudOverlayWindow === win) {
+			hudOverlayWindow = null;
+		}
 	});
 
 	if (VITE_DEV_SERVER_URL) {

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -210,7 +210,25 @@ function applyHudOverlayBounds(expanded: boolean) {
 
 	hudOverlayExpanded = expanded;
 
-	hudOverlayWindow.setBounds(getHudOverlayBounds(expanded), false);
+	const computed = getHudOverlayBounds(expanded);
+
+	if (hudUserPosition) {
+		// Resize in-place at the user's dragged position, clamped so the
+		// window stays fully within the current display's work area.
+		const { workArea } = getHudOverlayDisplay();
+		const x = Math.max(
+			workArea.x,
+			Math.min(hudUserPosition.x, workArea.x + workArea.width - computed.width),
+		);
+		const y = Math.max(
+			workArea.y,
+			Math.min(hudUserPosition.y, workArea.y + workArea.height - computed.height),
+		);
+		hudOverlayWindow.setBounds({ x, y, width: computed.width, height: computed.height }, false);
+	} else {
+		hudOverlayWindow.setBounds(computed, false);
+	}
+
 	positionUpdateToastWindow();
 	if (!hudOverlayWindow.isVisible()) {
 		return;
@@ -272,6 +290,10 @@ ipcMain.on("hud-overlay-set-ignore-mouse", (_event, ignore: boolean) => {
 	}
 });
 
+// When the user drags the HUD, remember their chosen position so that
+// subsequent size changes (e.g. idle → recording UI swap) resize in-place
+// instead of snapping back to the default centered location.
+let hudUserPosition: { x: number; y: number } | null = null;
 let hudDragOffset: { x: number; y: number } | null = null;
 let hudDragLastCursor: { x: number; y: number } | null = null;
 let hudDragFixedSize: { width: number; height: number } | null = null;
@@ -304,6 +326,9 @@ ipcMain.on("hud-overlay-drag", (_event, phase: string, screenX: number, screenY:
 			false,
 		);
 	} else if (phase === "end") {
+		const finalBounds = hudOverlayWindow.getBounds();
+		hudUserPosition = { x: finalBounds.x, y: finalBounds.y };
+
 		hudDragOffset = null;
 		hudDragLastCursor = null;
 		hudDragFixedSize = null;
@@ -474,6 +499,29 @@ export function createHudOverlayWindow(): BrowserWindow {
 	win.on("closed", () => {
 		if (hudOverlayWindow === win) {
 			hudOverlayWindow = null;
+		}
+	});
+
+	// Reset the user's saved HUD position when displays change so the bar
+	// doesn't end up stranded off-screen after a monitor is disconnected.
+	const screen = getScreen();
+	screen.on("display-removed", () => {
+		hudUserPosition = null;
+	});
+	screen.on("display-metrics-changed", () => {
+		if (hudUserPosition) {
+			const displays = screen.getAllDisplays();
+			const onScreen = displays.some(
+				(d) =>
+					hudUserPosition!.x >= d.workArea.x &&
+					hudUserPosition!.x < d.workArea.x + d.workArea.width &&
+					hudUserPosition!.y >= d.workArea.y &&
+					hudUserPosition!.y < d.workArea.y + d.workArea.height,
+			);
+			if (!onScreen) {
+				hudUserPosition = null;
+				applyHudOverlayBounds(hudOverlayExpanded);
+			}
 		}
 	});
 


### PR DESCRIPTION
# Pull Request Template

## Description
This preserves the location of the recording hud bar when recording starts.
Without this the recording start state change snaps the bar back to the same spot, and this can be in the way of your recording.


## Motivation
This solves a minor UX issue where the hud bar snaps back to a center location as the recording starts.  I had tried a work around where I would use the timer delay start and clear the bar out of the way during the countdown, but as soon as the countdown finishes it snaps back on top of the app I need to record.
Of course, I can just drag it a way but that disrupts the flow/concentration of the task at hand.

## Type of Change
- [x] Other (please specify).   Minor UX improvement

## Related Issue(s)
none found

## Screenshots / Video
none 

**Video** (wherever possible):

```html
<video src="path/to/video.mp4" controls width="600"></video>
```

## Testing Guide
I tested this by building and running the app.
I would then start a recording and observe that the location of the hud bar does not snap back to the center location as the video starts.

## Checklist
- [x] I have performed a self-review of my code.
- [x] NA,IMO I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.
     (I skimmed issue list after and didn't see them)
     (didn't touch release log)
---
*Thank you for contributing!*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * HUD window now remembers the last position you dragged it to and preserves that custom position during resizing and bounds adjustments.
  * Window placement is clamped to the current display work area so the HUD remains fully visible.
  * Display changes (removal or metric changes) automatically clear or revalidate the saved HUD position to keep it on-screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->