### PR TITLE
Fix silent MP4 exports with FFmpeg audio fallback

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -178,6 +178,20 @@ interface Window {
 		nativeVideoExportCancel: (
 			sessionId: string,
 		) => Promise<{ success: boolean; error?: string }>;
+		muxExportedVideoAudio: (
+			videoData: ArrayBuffer,
+			options?: {
+				audioMode?: "none" | "copy-source" | "trim-source" | "edited-track";
+				audioSourcePath?: string | null;
+				trimSegments?: Array<{ startMs: number; endMs: number }>;
+				editedAudioData?: ArrayBuffer;
+				editedAudioMimeType?: string | null;
+			},
+		) => Promise<{
+			success: boolean;
+			data?: Uint8Array;
+			error?: string;
+		}>;
 		getVideoAudioFallbackPaths: (
 			videoPath: string,
 		) => Promise<{ success: boolean; paths: string[]; error?: string }>;

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1152,6 +1152,25 @@ function loadFfmpegStatic() {
   return null
 }
 
+function resolveSystemFfmpegBinaryPath() {
+  const locator = process.platform === 'win32' ? 'where' : 'which'
+  const result = spawnSync(locator, ['ffmpeg'], {
+    encoding: 'utf-8',
+    windowsHide: true,
+  })
+
+  if (result.status !== 0) {
+    return null
+  }
+
+  const candidate = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0)
+
+  return candidate || null
+}
+
 function loadUiohookModule() {
   const moduleExports = nodeRequire('uiohook-napi')
   return (
@@ -1167,15 +1186,22 @@ function loadUiohookModule() {
 
 function getFfmpegBinaryPath() {
   const ffmpegStatic = loadFfmpegStatic()
-  if (!ffmpegStatic || typeof ffmpegStatic !== 'string') {
-    throw new Error('FFmpeg binary is unavailable. Install ffmpeg-static for this platform.')
+  if (ffmpegStatic && typeof ffmpegStatic === 'string') {
+    const bundledPath = app.isPackaged
+      ? ffmpegStatic.replace(/\.asar([\/\\])/, '.asar.unpacked$1')
+      : ffmpegStatic
+
+    if (existsSync(bundledPath)) {
+      return bundledPath
+    }
   }
 
-  if (app.isPackaged) {
-    return ffmpegStatic.replace(/\.asar([\/\\])/, '.asar.unpacked$1')
+  const systemFfmpeg = resolveSystemFfmpegBinaryPath()
+  if (systemFfmpeg) {
+    return systemFfmpeg
   }
 
-  return ffmpegStatic
+  throw new Error('FFmpeg binary is unavailable. Install ffmpeg-static for this platform or make ffmpeg available on PATH.')
 }
 
 type NativeVideoExportSession = {
@@ -1583,6 +1609,34 @@ async function muxNativeVideoExportAudio(
     await Promise.allSettled(
       tempArtifacts.map((artifactPath) => removeTemporaryExportFile(artifactPath)),
     )
+  }
+}
+
+async function muxExportedVideoAudioBuffer(
+  videoData: ArrayBuffer,
+  options: NativeVideoExportFinishOptions,
+) {
+  const tempVideoPath = path.join(
+    app.getPath('temp'),
+    `recordly-export-video-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.mp4`,
+  )
+
+  try {
+    await fs.writeFile(tempVideoPath, Buffer.from(videoData))
+    const finalizedPath = await muxNativeVideoExportAudio(tempVideoPath, options)
+    const muxedData = await fs.readFile(finalizedPath)
+    return new Uint8Array(muxedData)
+  } finally {
+    await Promise.allSettled([
+      removeTemporaryExportFile(tempVideoPath),
+      removeTemporaryExportFile(`${tempVideoPath}.muxed.mp4`),
+      removeTemporaryExportFile(
+        path.join(
+          path.dirname(tempVideoPath),
+          `${path.basename(tempVideoPath, path.extname(tempVideoPath))}-final.mp4`,
+        ),
+      ),
+    ])
   }
 }
 
@@ -5523,6 +5577,24 @@ body{background:transparent;overflow:hidden;width:100vw;height:100vh}
         await removeTemporaryExportFile(session.outputPath)
         const finalizedSuffix = session.outputPath.replace(/\.mp4$/, '-final.mp4')
         await removeTemporaryExportFile(finalizedSuffix)
+        return {
+          success: false,
+          error: String(error),
+        }
+      }
+    },
+  )
+
+  ipcMain.handle(
+    'mux-exported-video-audio',
+    async (_, videoData: ArrayBuffer, options?: NativeVideoExportFinishOptions) => {
+      try {
+        const data = await muxExportedVideoAudioBuffer(videoData, options ?? {})
+        return {
+          success: true,
+          data,
+        }
+      } catch (error) {
         return {
           success: false,
           error: String(error),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -161,6 +161,18 @@ contextBridge.exposeInMainWorld("electronAPI", {
 			});
 		});
 	},
+	muxExportedVideoAudio: (
+		videoData: ArrayBuffer,
+		options?: {
+			audioMode?: "none" | "copy-source" | "trim-source" | "edited-track";
+			audioSourcePath?: string | null;
+			trimSegments?: Array<{ startMs: number; endMs: number }>;
+			editedAudioData?: ArrayBuffer;
+			editedAudioMimeType?: string | null;
+		},
+	) => {
+		return ipcRenderer.invoke("mux-exported-video-audio", videoData, options);
+	},
 	getVideoAudioFallbackPaths: (videoPath: string) => {
 		return ipcRenderer.invoke("get-video-audio-fallback-paths", videoPath);
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recordly",
-	"version": "1.1.18",
+	"version": "1.1.22",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recordly",
-			"version": "1.1.18",
+			"version": "1.1.22",
 			"hasInstallScript": true,
 			"dependencies": {
 				"capturekit": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/webadderall/Recordly/issues"
 	},
 	"private": true,
-	"version": "1.1.21",
+	"version": "1.1.22",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/src/lib/exporter/audioEncoder.ts
+++ b/src/lib/exporter/audioEncoder.ts
@@ -14,6 +14,23 @@ const ENCODE_BACKPRESSURE_LIMIT = 20
 const MIN_SPEED_REGION_DELTA_MS = 0.0001
 const MP4_AUDIO_CODEC = 'mp4a.40.2'
 
+export async function isAacAudioEncodingSupported(
+  sampleRate = 48_000,
+  numberOfChannels = 2,
+): Promise<boolean> {
+  try {
+    const support = await AudioEncoder.isConfigSupported({
+      codec: MP4_AUDIO_CODEC,
+      sampleRate,
+      numberOfChannels,
+      bitrate: AUDIO_BITRATE,
+    })
+    return support.supported === true
+  } catch {
+    return false
+  }
+}
+
 type TrimLikeRegion = TrimRegion | ClipRegion
 
 export class AudioProcessor {

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -292,6 +292,8 @@ export class ModernVideoExporter {
 			const videoInfo = await this.streamingDecoder.loadMetadata(this.config.videoUrl);
 			this.metadataLoadTimeMs = this.getNowMs() - stageStartedAt;
 			const nativeAudioPlan = this.buildNativeAudioPlan(videoInfo);
+			const shouldUseFfmpegAudioFallback =
+				!useNativeEncoder && nativeAudioPlan.audioMode !== "none";
 			const effectiveDuration = this.streamingDecoder.getEffectiveDuration(
 				this.config.trimRegions,
 				this.config.speedRegions,
@@ -352,7 +354,7 @@ export class ModernVideoExporter {
 
 			if (!useNativeEncoder) {
 				const hasAudio = nativeAudioPlan.audioMode !== "none";
-				this.muxer = new VideoMuxer(this.config, hasAudio);
+				this.muxer = new VideoMuxer(this.config, hasAudio && !shouldUseFfmpegAudioFallback);
 				await this.muxer.initialize();
 			}
 
@@ -451,7 +453,7 @@ export class ModernVideoExporter {
 			this.reportFinalizingProgress(totalFrames, 98);
 			await this.awaitWithFinalizationTimeout(this.pendingMuxing, "muxing queued video chunks");
 
-			if (nativeAudioPlan.audioMode !== "none" && !this.cancelled) {
+			if (nativeAudioPlan.audioMode !== "none" && !shouldUseFfmpegAudioFallback && !this.cancelled) {
 				const demuxer = this.streamingDecoder.getDemuxer();
 				if (
 					demuxer ||
@@ -482,6 +484,26 @@ export class ModernVideoExporter {
 			this.reportFinalizingProgress(totalFrames, 99);
 			const blob = await this.awaitWithFinalizationTimeout(this.muxer!.finalize(), "muxer finalization");
 			this.finalizationTimeMs = this.getNowMs() - stageStartedAt;
+
+			if (shouldUseFfmpegAudioFallback) {
+				console.warn(
+					`[VideoExporter] Browser AAC encoding is unavailable; falling back to FFmpeg audio muxing.`,
+				);
+				const muxedResult = await this.finalizeExportWithFfmpegAudio(blob, nativeAudioPlan);
+				if (!muxedResult.success || !muxedResult.blob) {
+					return {
+						success: false,
+						error: muxedResult.error || "Failed to mux audio with FFmpeg",
+						metrics: muxedResult.metrics ?? this.buildExportMetrics(),
+					};
+				}
+
+				return {
+					success: true,
+					blob: muxedResult.blob,
+					metrics: muxedResult.metrics ?? this.buildExportMetrics(),
+				};
+			}
 
 			return { success: true, blob, metrics: this.buildExportMetrics() };
 		} catch (error) {
@@ -922,6 +944,68 @@ export class ModernVideoExporter {
 
 		const videoBytes = result.data.slice();
 
+		return {
+			success: true,
+			blob: new Blob([videoBytes.buffer], { type: "video/mp4" }),
+		};
+	}
+
+	private async finalizeExportWithFfmpegAudio(
+		videoBlob: Blob,
+		audioPlan: NativeAudioPlan,
+	): Promise<ExportResult> {
+		if (typeof window === "undefined" || !window.electronAPI?.muxExportedVideoAudio) {
+			return {
+				success: false,
+				error: "FFmpeg audio fallback is unavailable in this environment.",
+			};
+		}
+
+		let editedAudioBuffer: ArrayBuffer | undefined;
+		let editedAudioMimeType: string | null = null;
+
+		if (audioPlan.audioMode === "edited-track") {
+			this.audioProcessor = new AudioProcessor();
+			this.audioProcessor.setOnProgress((progress) => {
+				this.reportFinalizingProgress(this.processedFrameCount, 99, progress);
+			});
+			const audioBlob = await this.awaitWithFinalizationTimeout(
+				this.audioProcessor.renderEditedAudioTrack(
+					this.config.videoUrl,
+					this.config.trimRegions,
+					this.config.speedRegions,
+					this.config.audioRegions,
+					this.config.sourceAudioFallbackPaths,
+				),
+				"FFmpeg edited audio rendering",
+			);
+			editedAudioBuffer = await audioBlob.arrayBuffer();
+			editedAudioMimeType = audioBlob.type || null;
+		}
+
+		const videoBuffer = await videoBlob.arrayBuffer();
+		const result = await this.awaitWithFinalizationTimeout(
+			window.electronAPI.muxExportedVideoAudio(videoBuffer, {
+				audioMode: audioPlan.audioMode,
+				audioSourcePath:
+					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
+						? audioPlan.audioSourcePath
+						: null,
+				trimSegments: audioPlan.audioMode === "trim-source" ? audioPlan.trimSegments : undefined,
+				editedAudioData: editedAudioBuffer,
+				editedAudioMimeType,
+			}),
+			"FFmpeg audio muxing",
+		);
+
+		if (!result.success || !result.data) {
+			return {
+				success: false,
+				error: result.error || "Failed to mux exported audio with FFmpeg",
+			};
+		}
+
+		const videoBytes = result.data.slice();
 		return {
 			success: true,
 			blob: new Blob([videoBytes.buffer], { type: "video/mp4" }),

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -124,12 +124,12 @@ export class VideoExporter {
 			});
 			const videoInfo = await this.streamingDecoder.loadMetadata(this.config.videoUrl);
 			const shouldUseExperimentalNativeExport = this.shouldUseExperimentalNativeExport();
-			const nativeAudioPlan = shouldUseExperimentalNativeExport
-				? this.buildNativeAudioPlan(videoInfo)
-				: null;
+			const audioPlan = this.buildNativeAudioPlan(videoInfo);
+			const nativeAudioPlan = shouldUseExperimentalNativeExport ? audioPlan : null;
 			let useNativeEncoder = shouldUseExperimentalNativeExport
 				? await this.tryStartNativeVideoExport()
 				: false;
+			const shouldUseFfmpegAudioFallback = !useNativeEncoder && audioPlan.audioMode !== "none";
 
 			if (!useNativeEncoder) {
 				await this.initializeEncoder();
@@ -187,7 +187,7 @@ export class VideoExporter {
 			const hasAudio = videoInfo.hasAudio || hasAudioRegions || hasSourceAudioFallback;
 
 			if (!useNativeEncoder) {
-				this.muxer = new VideoMuxer(this.config, hasAudio);
+				this.muxer = new VideoMuxer(this.config, hasAudio && !shouldUseFfmpegAudioFallback);
 				await this.muxer.initialize();
 			}
 
@@ -262,7 +262,7 @@ export class VideoExporter {
 			this.reportFinalizingProgress(totalFrames, 98);
 			await this.awaitWithFinalizationTimeout(this.pendingMuxing, "muxing queued video chunks");
 
-			if (hasAudio && !this.cancelled) {
+			if (hasAudio && !shouldUseFfmpegAudioFallback && !this.cancelled) {
 				const demuxer = this.streamingDecoder.getDemuxer();
 				if (demuxer || hasAudioRegions || hasSourceAudioFallback) {
 					this.audioProcessor = new AudioProcessor();
@@ -289,6 +289,13 @@ export class VideoExporter {
 			// Finalize muxer and get output blob
 			this.reportFinalizingProgress(totalFrames, 99);
 			const blob = await this.awaitWithFinalizationTimeout(this.muxer!.finalize(), "muxer finalization");
+
+			if (shouldUseFfmpegAudioFallback) {
+				console.warn(
+					"[VideoExporter] Browser AAC encoding is unavailable; falling back to FFmpeg audio muxing.",
+				);
+				return await this.finalizeExportWithFfmpegAudio(blob, audioPlan, totalFrames);
+			}
 
 			return { success: true, blob };
 		} catch (error) {
@@ -561,6 +568,70 @@ export class VideoExporter {
 		const blobData = new Uint8Array(result.data.byteLength);
 		blobData.set(result.data);
 
+		return {
+			success: true,
+			blob: new Blob([blobData.buffer], { type: "video/mp4" }),
+		};
+	}
+
+	private async finalizeExportWithFfmpegAudio(
+		videoBlob: Blob,
+		audioPlan: NativeAudioPlan,
+		totalFrames: number,
+	): Promise<ExportResult> {
+		if (typeof window === "undefined" || !window.electronAPI?.muxExportedVideoAudio) {
+			return {
+				success: false,
+				error: "FFmpeg audio fallback is unavailable in this environment.",
+			};
+		}
+
+		let editedAudioBuffer: ArrayBuffer | undefined;
+		let editedAudioMimeType: string | null = null;
+
+		if (audioPlan.audioMode === "edited-track") {
+			this.audioProcessor = new AudioProcessor();
+			this.audioProcessor.setOnProgress((progress) => {
+				this.reportFinalizingProgress(totalFrames, 99, progress);
+			});
+			const audioBlob = await this.awaitWithFinalizationTimeout(
+				this.audioProcessor.renderEditedAudioTrack(
+					this.config.videoUrl,
+					this.config.trimRegions,
+					this.config.speedRegions,
+					this.config.audioRegions,
+					this.config.sourceAudioFallbackPaths,
+				),
+				"ffmpeg edited audio rendering",
+			);
+			editedAudioBuffer = await audioBlob.arrayBuffer();
+			editedAudioMimeType = audioBlob.type || null;
+		}
+
+		const videoBuffer = await videoBlob.arrayBuffer();
+		const result = await this.awaitWithFinalizationTimeout(
+			window.electronAPI.muxExportedVideoAudio(videoBuffer, {
+				audioMode: audioPlan.audioMode,
+				audioSourcePath:
+					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
+						? audioPlan.audioSourcePath
+						: null,
+				trimSegments: audioPlan.audioMode === "trim-source" ? audioPlan.trimSegments : undefined,
+				editedAudioData: editedAudioBuffer,
+				editedAudioMimeType,
+			}),
+			"ffmpeg audio muxing",
+		);
+
+		if (!result.success || !result.data) {
+			return {
+				success: false,
+				error: result.error || "Failed to mux exported audio with FFmpeg",
+			};
+		}
+
+		const blobData = new Uint8Array(result.data.byteLength);
+		blobData.set(result.data);
 		return {
 			success: true,
 			blob: new Blob([blobData.buffer], { type: "video/mp4" }),


### PR DESCRIPTION
## Summary
- fix silent MP4 exports on Windows/Electron by routing WebCodecs exports with audio through FFmpeg audio muxing
- add a shared renderer-to-main-process audio mux fallback for both legacy and modern exporters
- fall back to system `ffmpeg` on PATH when bundled `ffmpeg-static` is missing from the packaged app
- bump the app version to `1.1.22`

## Problem
I could reproduce a case where Recordly exported MP4 files without any audio track even though the source `.webm` recording contained an `opus` audio stream.

On my machine:
- the source recording had audio (`ffmpeg` detected an `Audio: opus` stream)
- `legacy + webcodecs` export produced an MP4 with video only
- `modern + webcodecs` export produced an MP4 with video only
- the bundled native/Breeze path was also unavailable because the packaged app could not resolve `ffmpeg-static\\ffmpeg.exe`

The current browser-side audio path can silently skip/lose audio in Electron/Windows environments, which leads to a successful export result with no MP4 audio track.

## Fix
Instead of relying on browser-side MP4 audio muxing for WebCodecs exports, this patch:
- renders/muxes video as before
- routes any non-native export that includes audio through a main-process FFmpeg audio mux step
- reuses the existing audio plan (`copy-source`, `trim-source`, `edited-track`) so trim and edited timeline audio still behave correctly
- lets packaged builds use bundled `ffmpeg-static` when present, but falls back to a system `ffmpeg` binary on PATH if the bundled binary is missing

## Validation
I validated this locally with a real recording stored under the Recordly recordings directory, e.g.:
`C:\Users\<redacted>\AppData\Roaming\Recordly\recordings\recording-<timestamp>.webm`

Before this patch:
- the source `.webm` had audio
- exported `.mp4` files had no audio stream

After this patch:
- the exported MP4 contains an `aac` audio track
- FFmpeg can read/decode `0:a:0` successfully from the export

## Notes
- this keeps the fix scoped to the export audio reliability issue instead of changing unrelated export behavior
- I did not change the native/Breeze encoder path beyond making FFmpeg resolution more robust