### PR TITLE
fix(highlight): screen highlight clipping on macOS

### DIFF
--- a/electron/ipc/recording/ffmpeg.ts
+++ b/electron/ipc/recording/ffmpeg.ts
@@ -16,6 +16,14 @@ export function getDisplayBoundsForSource(source: SelectedSource) {
 	).bounds;
 }
 
+export function getDisplayWorkAreaForSource(source: SelectedSource) {
+	const allDisplays = getScreen().getAllDisplays();
+	const primaryDisplay = getScreen().getPrimaryDisplay();
+	const { displayId } = resolveWindowsCaptureDisplay(source, allDisplays, primaryDisplay);
+	const matched = allDisplays.find((d) => d.id === displayId) ?? primaryDisplay;
+	return matched.workArea;
+}
+
 export async function buildFfmpegCaptureArgs(source: SelectedSource, outputPath: string) {
 	const commonOutputArgs = [
 		"-an",

--- a/electron/ipc/register/sources.ts
+++ b/electron/ipc/register/sources.ts
@@ -5,7 +5,7 @@ import { ALLOW_RECORDLY_WINDOW_CAPTURE } from "../constants";
 import { selectedSource, setSelectedSource } from "../state";
 import type { SelectedSource } from "../types";
 import { getScreen, parseWindowId } from "../utils";
-import { getDisplayBoundsForSource } from "../recording/ffmpeg";
+import { getDisplayBoundsForSource, getDisplayWorkAreaForSource } from "../recording/ffmpeg";
 import {
 	getNativeMacWindowSources,
 	resolveMacWindowBounds,
@@ -337,7 +337,10 @@ export function registerSourceHandlers({
 			let bounds: { x: number; y: number; width: number; height: number } | null = null;
 
 			if (source.id?.startsWith("screen:")) {
-				bounds = getDisplayBoundsForSource(source);
+				bounds =
+					process.platform === "darwin"
+						? getDisplayWorkAreaForSource(source)
+						: getDisplayBoundsForSource(source);
 			} else if (isWindow) {
 				if (process.platform === "darwin") {
 					bounds = await resolveMacWindowBounds(source);
@@ -363,7 +366,12 @@ export function registerSourceHandlers({
 			const resolvedBounds = bounds;
 
 			// ── 3. Show traveling wave highlight ──
-			const pad = 6;
+			// On macOS, screen highlights use workArea and no outward padding —
+			// macOS clamps window positions below the menu bar so outward
+			// padding only works on the left/top while right/bottom run off-screen.
+			const isScreen = source.id?.startsWith("screen:");
+			const isMacScreen = isScreen && process.platform === "darwin";
+			const pad = isMacScreen ? 0 : 6;
 			const highlightWin = new BrowserWindow({
 				x: resolvedBounds.x - pad,
 				y: resolvedBounds.y - pad,
@@ -381,13 +389,18 @@ export function registerSourceHandlers({
 
 			highlightWin.setIgnoreMouseEvents(true);
 
+			const borderRadius = isMacScreen ? 0 : 10;
+			const glowInset = isMacScreen ? 0 : -4;
+			const glowRadius = isMacScreen ? 0 : 14;
+			const glowPad = isMacScreen ? 3 : 6;
+
 			const html = `<!DOCTYPE html>
 <html><head><style>
 *{margin:0;padding:0;box-sizing:border-box}
 body{background:transparent;overflow:hidden;width:100vw;height:100vh}
 
 .border-wrap{
-  position:fixed;inset:0;border-radius:10px;padding:3px;
+  position:fixed;inset:0;border-radius:${borderRadius}px;padding:3px;
   background:conic-gradient(from var(--angle,0deg),
     transparent 0%,
     transparent 60%,
@@ -405,7 +418,7 @@ body{background:transparent;overflow:hidden;width:100vw;height:100vh}
 }
 
 .glow-wrap{
-  position:fixed;inset:-4px;border-radius:14px;padding:6px;
+  position:fixed;inset:${glowInset}px;border-radius:${glowRadius}px;padding:${glowPad}px;
   background:conic-gradient(from var(--angle,0deg),
     transparent 0%,
     transparent 65%,


### PR DESCRIPTION
## Summary
On macOS, the screen highlight overlay's right and bottom edges were running off-screen. macOS clamps window positions below the menu bar, so the outward padding only appeared on the left/top while the right/bottom extended beyond the visible area.

Related to [this issue](https://github.com/webadderall/Recordly/issues/144) - this is why i thought there wasn't any highlighting

### Changes
- Use display `workArea` instead of full `bounds` for screen highlights on macOS, keeping the overlay within the visible screen area
- Keep the border and glow flush within the overlay window (no outward padding for screen sources on macOS)
- Scoped to macOS only — Windows and Linux behavior is unchanged

## Test plan
Unfortunately i don't have a windows machine on hand to check this myself
- [ ] Select a screen source and verify the highlight border is visible on all four edges
- [ ] Verify window highlights still show the padded glow on all sides
- [ ] Test on a multi-monitor setup to confirm highlight appears on the correct display
- [ ] Verify no regressions on Windows/Linux screen highlights

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source highlight display accuracy on macOS by better aligning with system display boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->