### PR TITLE
fix: add fallback paths for ffmpeg binary on macOS

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1199,16 +1199,32 @@ function resolveSystemFfmpegBinaryPath() {
     windowsHide: true,
   })
 
-  if (result.status !== 0) {
-    return null
+  if (result.status === 0) {
+    const candidate = result.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0)
+
+    if (candidate) {
+      return candidate
+    }
   }
 
-  const candidate = result.stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find((line) => line.length > 0)
+  // Fallback: check common install paths directly (Electron's shell may lack full PATH)
+  if (process.platform !== 'win32') {
+    const commonPaths = [
+      '/opt/homebrew/bin/ffmpeg',
+      '/usr/local/bin/ffmpeg',
+      '/usr/bin/ffmpeg',
+    ]
+    for (const p of commonPaths) {
+      if (existsSync(p)) {
+        return p
+      }
+    }
+  }
 
-  return candidate || null
+  return null
 }
 
 function loadUiohookModule() {


### PR DESCRIPTION
## Problem

On macOS, when ffmpeg is installed via Homebrew (`/opt/homebrew/bin/ffmpeg`), the packaged Electron app fails to find it. Two things go wrong:

1. **`ffmpeg-static`** — the npm package installs but the binary never downloads, so `loadFfmpegStatic()` returns a path that doesn't exist on disk
2. **`which ffmpeg`** — Electron's `spawnSync` runs in a sandboxed shell with a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), which excludes `/opt/homebrew/bin`

This results in: `Error: FFmpeg binary is unavailable. Install ffmpeg-static for this platform or make ffmpeg available on PATH.`

## Fix

Adds a direct filesystem check for common macOS/Linux ffmpeg install paths as a fallback when `which` fails:

- `/opt/homebrew/bin/ffmpeg` (Homebrew on Apple Silicon)
- `/usr/local/bin/ffmpeg` (Homebrew on Intel / manual installs)
- `/usr/bin/ffmpeg` (system package managers)

Only runs on non-Windows platforms. Zero behavior change on Windows or when `which` already succeeds.

## Test plan

- [ ] Verify ffmpeg resolves correctly on macOS with Homebrew-installed ffmpeg
- [ ] Verify no regression on systems where `which ffmpeg` already works
- [ ] Verify no regression on Windows builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced FFmpeg detection to properly validate system command responses and fallback to common installation paths on supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->