### PR TITLE
fix: Linux GPU fallback and HUD window show safety net

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -69,14 +69,11 @@ function configureGpuAccelerationSwitches() {
 		return;
 	}
 
-	// Linux: prefer EGL over GLX for better Wayland compatibility.
+	// Linux (and other Unix): prefer EGL over GLX for better Wayland compatibility.
 	// Disable VAAPI — many distros ship broken drivers that cause
 	// "vaInitialize failed" and prevent the renderer from loading.
-	if (process.platform === "linux") {
-		app.commandLine.appendSwitch("use-gl", "egl");
-		app.commandLine.appendSwitch("disable-features", "VaapiVideoDecoder,VaapiVideoEncoder");
-		return;
-	}
+	app.commandLine.appendSwitch("use-gl", "egl");
+	app.commandLine.appendSwitch("disable-features", "VaapiVideoDecoder,VaapiVideoEncoder");
 }
 
 async function logSmokeExportGpuDiagnostics() {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -68,6 +68,15 @@ function configureGpuAccelerationSwitches() {
 		app.commandLine.appendSwitch("use-angle", "d3d11");
 		return;
 	}
+
+	// Linux: prefer EGL over GLX for better Wayland compatibility.
+	// Disable VAAPI — many distros ship broken drivers that cause
+	// "vaInitialize failed" and prevent the renderer from loading.
+	if (process.platform === "linux") {
+		app.commandLine.appendSwitch("use-gl", "egl");
+		app.commandLine.appendSwitch("disable-features", "VaapiVideoDecoder,VaapiVideoEncoder");
+		return;
+	}
 }
 
 async function logSmokeExportGpuDiagnostics() {

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -498,6 +498,17 @@ export function createHudOverlayWindow(): BrowserWindow {
 		}, 100);
 	});
 
+	// Safety net: on Linux the renderer may fail to fire did-finish-load
+	// (e.g. GPU/VAAPI errors). Show the window after ready-to-show as fallback.
+	win.once("ready-to-show", () => {
+		setTimeout(() => {
+			if (!win.isDestroyed() && !win.isVisible()) {
+				win.show();
+				win.moveTop();
+			}
+		}, 500);
+	});
+
 	hudOverlayWindow = win;
 
 	// Reset the user's saved HUD position when displays change so the bar


### PR DESCRIPTION
## Summary

Fixes Linux startup issue where the app only appears in the system tray with no visible window.

## Root Cause

Two problems:

1. **No Linux GPU configuration** — `configureGpuAccelerationSwitches()` had branches for macOS (Metal) and Windows (D3D11) but fell through with no config for Linux. Many distros ship broken VAAPI drivers causing `vaInitialize failed` errors that prevent the Chromium renderer from loading.

2. **HUD window relies solely on `did-finish-load`** — the window is created with `show: false` and only shown inside `did-finish-load`. If the renderer fails to load (GPU error), this event never fires, so the window stays invisible. Combined with `skipTaskbar: true`, there's no way for the user to see or interact with the app.

## Changes

### Linux GPU config (`electron/main.ts`)
- Use EGL instead of GLX (better Wayland compatibility)
- Disable VAAPI video decoder/encoder to avoid broken driver crashes

### HUD window fallback (`electron/windows.ts`)
- Add `ready-to-show` handler as safety net: if window is not visible after 500ms, force-show it
- Guarded so it does not double-show on working systems

Ref #261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized GPU acceleration on Linux/Unix by enabling EGL rendering and adjusting hardware video codec behavior to improve rendering stability and performance.
  * Improved HUD overlay reliability on Linux/Unix with a fallback display path ensuring overlay windows reliably appear during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->