### PR TITLE
fix: allow toggling mic during recording

### DIFF
--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -162,6 +162,7 @@ export function LaunchWindow() {
 		pauseRecording,
 		resumeRecording,
 		cancelRecording,
+		toggleMicrophoneDuringRecording,
 		microphoneEnabled,
 		setMicrophoneEnabled,
 		microphoneDeviceId,
@@ -1046,6 +1047,7 @@ export function LaunchWindow() {
 			<Separator />
 
 			<IconButton
+				onClick={toggleMicrophoneDuringRecording}
 				title={
 					microphoneEnabled
 						? t("recording.disableMicrophone")

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -51,6 +51,7 @@ type UseScreenRecorderReturn = {
 	pauseRecording: () => void;
 	resumeRecording: () => void;
 	cancelRecording: () => void;
+	toggleMicrophoneDuringRecording: () => void;
 	preparePermissions: (options?: { startup?: boolean }) => Promise<boolean>;
 	isMacOS: boolean;
 	microphoneEnabled: boolean;
@@ -738,6 +739,15 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		void window.electronAPI.setRecordingPreferences({ microphoneEnabled: enabled });
 	}, []);
 
+	const toggleMicrophoneDuringRecording = useCallback(() => {
+		const nextEnabled = !microphoneEnabled;
+		const micTrack = microphoneStream.current?.getAudioTracks()[0] ?? null;
+		if (micTrack) {
+			micTrack.enabled = nextEnabled;
+		}
+		persistMicrophoneEnabled(nextEnabled);
+	}, [microphoneEnabled, persistMicrophoneEnabled]);
+
 	const persistMicrophoneDeviceId = useCallback((deviceId: string | undefined) => {
 		setMicrophoneDeviceId(deviceId);
 		void window.electronAPI.setRecordingPreferences({ microphoneDeviceId: deviceId });
@@ -1403,6 +1413,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		pauseRecording,
 		resumeRecording,
 		cancelRecording,
+		toggleMicrophoneDuringRecording,
 		preparePermissions,
 		isMacOS,
 		microphoneEnabled,


### PR DESCRIPTION
## Summary
- make the HUD mic button respond during an active recording
- toggle the live microphone track on and off instead of leaving the control inactive
- keep the persisted microphone-enabled preference in sync with the recording-time toggle

## Testing
- ran 
> recordly@1.1.23 dev
> vite

vite v5.4.21 building for development...

watching for file changes...
vite v5.4.21 building for development...

watching for file changes...

build started...

build started...

  VITE v5.4.21  ready in 136 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
transforming...
✓ 1 modules transformed.
transforming...
rendering chunks...
computing gzip size...
dist-electron/preload.mjs  18.52 kB │ gzip: 3.43 kB
built in 158ms.
✓ 428 modules transformed.
rendering chunks...
computing gzip size...
dist-electron/main.js  804.63 kB │ gzip: 168.19 kB
built in 1066ms.
RECORDINGS_DIR: /home/uri/.config/Recordly-dev/recordings
User Data Path: /home/uri/.config/Recordly-dev
[media-server] Listening at http://127.0.0.1:45727
- verified the app builds and the mic button is clickable during recording


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microphone toggle control is now available during active screen recording sessions. Users can enable or disable their microphone directly from the recording interface without interrupting the recording process. Microphone preferences are automatically saved and restored across sessions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->