### PR TITLE
fix(linux): allow full-screen capture by position if IDs do not match

### DIFF
--- a/electron/ipc/register/sources.ts
+++ b/electron/ipc/register/sources.ts
@@ -101,10 +101,19 @@ export function registerSourceHandlers({
 				.filter((source) => source.id.startsWith("screen:"))
 				.map((source) => [String(source.display_id ?? ""), source] as const),
 		);
+		// On Linux, desktopCapturer display_id values may not match screen.getAllDisplays() IDs.
+		// Keep an ordered list so we can fall back to position-based matching.
+		const electronScreenSourcesByIndex = electronSources.filter((source) =>
+			source.id.startsWith("screen:"),
+		);
 
 		const screenSources = displays.map((display, index) => {
 			const displayId = String(display.id);
-			const matchedSource = electronScreenSourcesByDisplayId.get(displayId);
+			const matchedSource =
+				electronScreenSourcesByDisplayId.get(displayId) ??
+				(electronScreenSourcesByIndex.length === displays.length
+					? electronScreenSourcesByIndex[index]
+					: undefined);
 			const displayName =
 				displayId === primaryDisplayId
 					? `Screen ${index + 1} (Primary)`


### PR DESCRIPTION
## Summary

Fixes Linux full-screen capture failing with 'Selected display is not available for browser capture on this system'.

### Root cause
On Linux/X11, Electron's desktopCapturer returns screen sources whose display_id values do not match those from screen.getAllDisplays(). This caused all displays to be assigned fallback IDs, which are rejected by the recording logic.

### Fix
If the number of Electron screen sources matches the number of displays, pair them by position as a fallback. This allows full-screen capture to work on Linux/X11 even when IDs do not match.

Closes #265


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved screen source matching logic on Linux systems for more accurate display detection and screen capture functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->