### PR TITLE
fix(linux/wayland): collapse 3-step capture flow into a single portal dialog (closes #268)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -891,8 +891,22 @@ app.whenReady().then(async () => {
 	// ignored by the native capture pipeline.
 	session.defaultSession.setDisplayMediaRequestHandler(async (_request, callback) => {
 		try {
-			const sources = await desktopCapturer.getSources({ types: ["screen", "window"] });
 			const sourceId = getSelectedSourceId();
+			// On Linux/Wayland, calling desktopCapturer.getSources() itself
+			// invokes the xdg-desktop-portal picker. If we then return one of
+			// those sources, Chromium triggers a SECOND portal because the
+			// pre-enumerated source IDs are stale on Wayland. To collapse this
+			// into a single portal invocation, when the Linux portal sentinel
+			// is set we skip getSources entirely and hand back a synthetic
+			// source id; Chromium then opens the portal once to actually
+			// resolve the capture.
+			const isLinuxPortalSentinel =
+				process.platform === "linux" && sourceId === "screen:linux-portal";
+			if (isLinuxPortalSentinel) {
+				callback({ video: { id: "screen:0:0", name: "Entire screen" } });
+				return;
+			}
+			const sources = await desktopCapturer.getSources({ types: ["screen", "window"] });
 			const source = sourceId
 				? (sources.find((s) => s.id === sourceId) ?? sources[0])
 				: sources[0];

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -900,8 +900,13 @@ app.whenReady().then(async () => {
 			// is set we skip getSources entirely and hand back a synthetic
 			// source id; Chromium then opens the portal once to actually
 			// resolve the capture.
+			// Default to the sentinel on Linux when no source has been
+			// pre-selected (e.g. fresh session where the renderer skipped the
+			// source picker entirely). This avoids calling getSources() which
+			// would itself trigger an extra portal dialog.
 			const isLinuxPortalSentinel =
-				process.platform === "linux" && sourceId === "screen:linux-portal";
+				process.platform === "linux" &&
+				(sourceId === "screen:linux-portal" || !sourceId);
 			if (isLinuxPortalSentinel) {
 				callback({ video: { id: "screen:0:0", name: "Entire screen" } });
 				return;

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -788,6 +788,11 @@ export function createEditorWindow(): BrowserWindow {
 	win.webContents.on("did-finish-load", () => {
 		console.log("[editor-window] did-finish-load", win.webContents.getURL());
 		win?.webContents.send("main-process-message", new Date().toLocaleString());
+		// Fallback for Linux/Wayland where `ready-to-show` may not fire reliably.
+		if (!win.isDestroyed() && !win.isVisible()) {
+			console.log("[editor-window] forcing show after did-finish-load");
+			win.show();
+		}
 	});
 
 	win.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL) => {

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -1144,7 +1144,11 @@ export function LaunchWindow() {
 			<button
 				type="button"
 				className={`${styles.recBtn} ${styles.electronNoDrag}`}
-				onClick={hasSelectedSource ? toggleRecording : () => toggleDropdown("sources")}
+				onClick={
+					hasSelectedSource || platform === "linux"
+						? toggleRecording
+						: () => toggleDropdown("sources")
+				}
 				disabled={countdownActive}
 				title={t("recording.record")}
 			>

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -1093,23 +1093,27 @@ export function LaunchWindow() {
 
 	const idleControls = (
 		<>
-			<button
-				type="button"
-				className={`${styles.screenSel} ${styles.electronNoDrag}`}
-				onClick={() => toggleDropdown("sources")}
-				title={selectedSource}
-			>
-				<Monitor size={16} />
-				<ContentClamp className={styles.sourceLabel} truncateLength={36}>
-					{selectedSource}
-				</ContentClamp>
-				<ChevronUp
-					size={10}
-					className={`text-[#6b6b78] ml-0.5 transition-transform duration-200 ${activeDropdown === "sources" ? "" : "rotate-180"}`}
-				/>
-			</button>
+			{platform !== "linux" && (
+				<>
+					<button
+						type="button"
+						className={`${styles.screenSel} ${styles.electronNoDrag}`}
+						onClick={() => toggleDropdown("sources")}
+						title={selectedSource}
+					>
+						<Monitor size={16} />
+						<ContentClamp className={styles.sourceLabel} truncateLength={36}>
+							{selectedSource}
+						</ContentClamp>
+						<ChevronUp
+							size={10}
+							className={`text-[#6b6b78] ml-0.5 transition-transform duration-200 ${activeDropdown === "sources" ? "" : "rotate-180"}`}
+						/>
+					</button>
 
-			<Separator />
+					<Separator />
+				</>
+			)}
 
 			<IconButton
 				onClick={toggleMicrophone}

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -334,6 +334,14 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			return source;
 		}
 
+		// Linux/Wayland portal sentinel: do NOT call getSources here, because
+		// on Wayland that triggers an additional xdg-desktop-portal dialog.
+		// The sentinel is handled later by routing through getDisplayMedia,
+		// which lets the portal pick the source in a single dialog.
+		if (source.id === "screen:linux-portal") {
+			return source;
+		}
+
 		try {
 			const liveSources = await window.electronAPI.getSources({
 				types: ["screen"],
@@ -827,7 +835,13 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		setStarting(true);
 
 		try {
-			const selectedSource = await window.electronAPI.getSelectedSource();
+			const platform = await window.electronAPI.getPlatform();
+			const existingSource = await window.electronAPI.getSelectedSource();
+			const selectedSource =
+				existingSource ??
+				(platform === "linux"
+					? { id: "screen:linux-portal", name: "Linux Portal" }
+					: null);
 			if (!selectedSource) {
 				alert("Please select a source to record");
 				return;
@@ -841,8 +855,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			recordingSessionTimestamp.current = Date.now();
 			resetRecordingClock(recordingSessionTimestamp.current);
 			await prepareWebcamRecorder();
-
-			const platform = await window.electronAPI.getPlatform();
 			const useNativeMacScreenCapture =
 				platform === "darwin" &&
 				(selectedSource.id?.startsWith("screen:") ||
@@ -1018,18 +1030,32 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 			if (wantsAudioCapture) {
 				let screenMediaStream: MediaStream;
+				const useLinuxPortal = selectedSource.id === "screen:linux-portal";
 
 				if (systemAudioEnabled) {
 					try {
-						screenMediaStream = await mediaDevices.getUserMedia({
-							audio: {
-								mandatory: {
-									chromeMediaSource: CHROME_MEDIA_SOURCE,
-									chromeMediaSourceId: browserCaptureSource.id,
-								},
-							},
-							video: browserScreenVideoConstraints,
-						});
+						screenMediaStream = useLinuxPortal
+							? await mediaDevices.getDisplayMedia({
+									audio: true,
+									video: {
+										displaySurface: "monitor",
+										width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
+										height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
+										frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
+										cursor: "never",
+									},
+									selfBrowserSurface: "exclude",
+									surfaceSwitching: "exclude",
+								})
+							: await mediaDevices.getUserMedia({
+									audio: {
+										mandatory: {
+											chromeMediaSource: CHROME_MEDIA_SOURCE,
+											chromeMediaSourceId: browserCaptureSource.id,
+										},
+									},
+									video: browserScreenVideoConstraints,
+								});
 					} catch (audioError) {
 						console.warn(
 							"System audio capture failed, falling back to video-only:",
@@ -1038,16 +1064,42 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						alert(
 							"System audio is not available for this source. Recording will continue without system audio.",
 						);
-						screenMediaStream = await mediaDevices.getUserMedia({
-							audio: false,
-							video: browserScreenVideoConstraints,
-						});
+						screenMediaStream = useLinuxPortal
+							? await mediaDevices.getDisplayMedia({
+									audio: false,
+									video: {
+										displaySurface: "monitor",
+										width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
+										height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
+										frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
+										cursor: "never",
+									},
+									selfBrowserSurface: "exclude",
+									surfaceSwitching: "exclude",
+								})
+							: await mediaDevices.getUserMedia({
+									audio: false,
+									video: browserScreenVideoConstraints,
+								});
 					}
 				} else {
-					screenMediaStream = await mediaDevices.getUserMedia({
-						audio: false,
-						video: browserScreenVideoConstraints,
-					});
+					screenMediaStream = useLinuxPortal
+						? await mediaDevices.getDisplayMedia({
+								audio: false,
+								video: {
+									displaySurface: "monitor",
+									width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
+									height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
+									frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
+									cursor: "never",
+								},
+								selfBrowserSurface: "exclude",
+								surfaceSwitching: "exclude",
+							})
+						: await mediaDevices.getUserMedia({
+								audio: false,
+								video: browserScreenVideoConstraints,
+							});
 				}
 
 				screenStream.current = screenMediaStream;

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -846,6 +846,16 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				alert("Please select a source to record");
 				return;
 			}
+			// Persist the synthetic Linux portal sentinel to main so that the
+			// setDisplayMediaRequestHandler can short-circuit getSources() and
+			// avoid triggering an extra portal dialog.
+			if (!existingSource && selectedSource.id === "screen:linux-portal") {
+				try {
+					await window.electronAPI.selectSource(selectedSource);
+				} catch (err) {
+					console.warn("Failed to persist Linux portal sentinel source:", err);
+				}
+			}
 
 			const permissionsReady = await preparePermissions();
 			if (!permissionsReady) {
@@ -1031,22 +1041,24 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			if (wantsAudioCapture) {
 				let screenMediaStream: MediaStream;
 				const useLinuxPortal = selectedSource.id === "screen:linux-portal";
+				const acquireLinuxPortalStream = (withAudio: boolean) =>
+					mediaDevices.getDisplayMedia({
+						audio: withAudio,
+						video: {
+							displaySurface: "monitor",
+							width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
+							height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
+							frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
+							cursor: "never",
+						},
+						selfBrowserSurface: "exclude",
+						surfaceSwitching: "exclude",
+					});
 
 				if (systemAudioEnabled) {
 					try {
 						screenMediaStream = useLinuxPortal
-							? await mediaDevices.getDisplayMedia({
-									audio: true,
-									video: {
-										displaySurface: "monitor",
-										width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
-										height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
-										frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
-										cursor: "never",
-									},
-									selfBrowserSurface: "exclude",
-									surfaceSwitching: "exclude",
-								})
+							? await acquireLinuxPortalStream(true)
 							: await mediaDevices.getUserMedia({
 									audio: {
 										mandatory: {
@@ -1065,18 +1077,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 							"System audio is not available for this source. Recording will continue without system audio.",
 						);
 						screenMediaStream = useLinuxPortal
-							? await mediaDevices.getDisplayMedia({
-									audio: false,
-									video: {
-										displaySurface: "monitor",
-										width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
-										height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
-										frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
-										cursor: "never",
-									},
-									selfBrowserSurface: "exclude",
-									surfaceSwitching: "exclude",
-								})
+							? await acquireLinuxPortalStream(false)
 							: await mediaDevices.getUserMedia({
 									audio: false,
 									video: browserScreenVideoConstraints,
@@ -1084,18 +1085,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					}
 				} else {
 					screenMediaStream = useLinuxPortal
-						? await mediaDevices.getDisplayMedia({
-								audio: false,
-								video: {
-									displaySurface: "monitor",
-									width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
-									height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
-									frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
-									cursor: "never",
-								},
-								selfBrowserSurface: "exclude",
-								surfaceSwitching: "exclude",
-							})
+						? await acquireLinuxPortalStream(false)
 						: await mediaDevices.getUserMedia({
 								audio: false,
 								video: browserScreenVideoConstraints,


### PR DESCRIPTION
## Summary

On Linux/Wayland, starting a fullscreen recording previously required **three** separate picker interactions:

1. The in-app source dropdown
2. An xdg-desktop-portal dialog (from `desktopCapturer.getSources()` in the renderer)
3. A second xdg-desktop-portal dialog (from Chromium re-prompting because pre-enumerated source IDs are stale on Wayland)

After this PR, Linux users go straight from the record button to **a single** OS portal dialog, matching the streamlined flow on macOS/Windows.

Fixes #268. Builds on top of #267.

## Root cause

Wayland's `xdg-desktop-portal` model is fundamentally different from X11/macOS/Windows:

- `desktopCapturer.getSources()` itself triggers a portal dialog on Wayland.
- Source IDs returned from `getSources` are **stale** by the time Chromium tries to start the actual capture, so Chromium opens the portal again to resolve a real source.
- Electron's `useSystemPicker` option (which bypasses the handler) is currently macOS-only.

## Changes

- **`src/components/launch/LaunchWindow.tsx`**: Skip the in-app source dropdown on Linux — the OS portal *is* the source picker.
- **`src/hooks/useScreenRecorder.ts`**:
  - Introduce a `screen:linux-portal` sentinel source.
  - Route capture through `navigator.mediaDevices.getDisplayMedia()` (instead of `getUserMedia` with `chromeMediaSource: 'desktop'`) when the sentinel is active.
  - Short-circuit `resolveBrowserCaptureSource` for the sentinel to avoid an extra `getSources()` portal trigger.
- **`electron/main.ts`** (`setDisplayMediaRequestHandler`): When the sentinel is set, skip `desktopCapturer.getSources()` entirely and return a synthetic source — Chromium then opens the portal exactly once, for the actual capture.
- **`electron/windows.ts`** (`createEditorWindow`): Also call `win.show()` from `did-finish-load` as a fallback. On some Wayland sessions `ready-to-show` does not fire reliably, leaving the editor window hidden after a recording finishes.

## Testing

Tested locally on Linux/Wayland (Electron 39):

- Click Record → countdown → **single** portal dialog → recording starts.
- Stop recording → editor window appears with the recording loaded.
- Verified both with and without system audio.

No changes to macOS/Windows code paths — all sentinel logic is gated on `process.platform === "linux"` or `selectedSource.id === "screen:linux-portal"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better screen recording on Linux/Wayland to avoid duplicate prompts and ensure capture starts reliably.
  * Ensure editor windows become visible on platforms where ready-to-show may not trigger.
  * Improved source selection and recording flow on Linux so recording can start without extra manual steps.
  * More reliable system-audio capture on Linux when using the platform capture flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->