### PR TITLE
fix: clip coordinate model with sourceStartMs, remove trim/speed UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
             release/*.dmg
             release/*.zip
             release/*.blockmap
-            release/latest-mac.yml
+            release/*-mac.yml
           if-no-files-found: error
 
   build-macos-arm64:
@@ -229,7 +229,7 @@ jobs:
             release/*.dmg
             release/*.zip
             release/*.blockmap
-            release/latest-mac.yml
+            release/*-mac.yml
           if-no-files-found: error
 
   merge-macos-update-metadata:
@@ -260,17 +260,25 @@ jobs:
       - name: Install PyYAML
         run: python -m pip install pyyaml
 
-      - name: Merge latest-mac.yml
+      - name: Merge mac update metadata
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p release-assets/merged
           python <<'PY'
           from pathlib import Path
+          import glob
           import yaml
 
-          x64_info = yaml.safe_load(Path('release-assets/macos-x64/latest-mac.yml').read_text())
-          arm64_info = yaml.safe_load(Path('release-assets/macos-arm64/latest-mac.yml').read_text())
+          x64_files = glob.glob('release-assets/macos-x64/*-mac.yml')
+          arm64_files = glob.glob('release-assets/macos-arm64/*-mac.yml')
+          if not x64_files or not arm64_files:
+            raise SystemExit('Could not find macOS update metadata files.')
+          # Use the filename from x64 (e.g. latest-mac.yml or beta-mac.yml)
+          channel_filename = Path(x64_files[0]).name
+
+          x64_info = yaml.safe_load(Path(x64_files[0]).read_text())
+          arm64_info = yaml.safe_load(Path(arm64_files[0]).read_text())
 
           merged_files = []
           seen_urls = set()
@@ -292,7 +300,7 @@ jobs:
           if not merged.get('releaseDate') and arm64_info.get('releaseDate'):
             merged['releaseDate'] = arm64_info['releaseDate']
 
-          Path('release-assets/merged/latest-mac.yml').write_text(
+          Path(f'release-assets/merged/{channel_filename}').write_text(
             yaml.safe_dump(merged, sort_keys=False)
           )
           PY
@@ -372,7 +380,7 @@ jobs:
           path: |
             release/*.exe
             release/*.blockmap
-            release/latest*.yml
+            release/*.yml
           if-no-files-found: error
 
   build-linux-x64:
@@ -427,7 +435,7 @@ jobs:
           path: |
             release/*.AppImage
             release/*.blockmap
-            release/latest-linux.yml
+            release/*-linux.yml
           if-no-files-found: error
 
   publish-release-assets:
@@ -484,13 +492,13 @@ jobs:
             release-assets/macos-arm64/*.dmg
             release-assets/macos-arm64/*.zip
             release-assets/macos-arm64/*.blockmap
-            release-assets/macos-merged/latest-mac.yml
+            release-assets/macos-merged/*.yml
             release-assets/windows-x64/*.exe
             release-assets/windows-x64/*.blockmap
-            release-assets/windows-x64/latest*.yml
+            release-assets/windows-x64/*.yml
             release-assets/linux-x64/*.AppImage
             release-assets/linux-x64/*.blockmap
-            release-assets/linux-x64/latest-linux.yml
+            release-assets/linux-x64/*.yml
           )
 
           if [ ${#assets[@]} -eq 0 ]; then

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/webadderall/Recordly/issues"
 	},
 	"private": true,
-	"version": "1.1.23",
+	"version": "1.2.0-beta.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { useTheme } from "@/contexts/ThemeContext";
 import { getAssetPath, getRenderableAssetUrl, getWallpaperThumbnailUrl } from "@/lib/assetPath";
 import type { ExtensionSettingField } from "@/lib/extensions";
 import { extensionHost, type FrameInstance } from "@/lib/extensions";
@@ -28,7 +29,6 @@ import tahoeCursorUrl from "../../assets/cursors/Cursor=Default.svg";
 import { useI18n, useScopedT } from "../../contexts/I18nContext";
 import type { AppLocale } from "../../i18n/config";
 import { SUPPORTED_LOCALES } from "../../i18n/config";
-import { useTheme } from "@/contexts/ThemeContext";
 import { AnnotationSettingsPanel } from "./AnnotationSettingsPanel";
 import { loadEditorPreferences, saveEditorPreferences } from "./editorPreferences";
 import { SliderControl } from "./SliderControl";
@@ -43,7 +43,6 @@ import type {
 	CursorStyle,
 	EditorEffectSection,
 	FigureData,
-	PlaybackSpeed,
 	WebcamOverlaySettings,
 	WebcamPositionPreset,
 	ZoomDepth,
@@ -69,7 +68,6 @@ import {
 	DEFAULT_WEBCAM_SHADOW,
 	DEFAULT_WEBCAM_SIZE,
 	DEFAULT_ZOOM_MOTION_BLUR,
-	SPEED_OPTIONS,
 } from "./types";
 import { fromCursorSwaySliderValue, toCursorSwaySliderValue } from "./videoPlayback/cursorSway";
 import {
@@ -332,8 +330,6 @@ interface SettingsPanelProps {
 	selectedZoomMode?: ZoomMode | null;
 	onZoomModeChange?: (mode: ZoomMode) => void;
 	onZoomDelete?: (id: string) => void;
-	selectedTrimId?: string | null;
-	onTrimDelete?: (id: string) => void;
 	selectedClipId?: string | null;
 	selectedClipSpeed?: number | null;
 	selectedClipMuted?: boolean | null;
@@ -425,10 +421,6 @@ interface SettingsPanelProps {
 	onClearAutoCaptions?: () => void;
 	onDownloadWhisperSmallModel?: () => void;
 	onDeleteWhisperSmallModel?: () => void;
-	selectedSpeedId?: string | null;
-	selectedSpeedValue?: PlaybackSpeed | null;
-	onSpeedChange?: (speed: PlaybackSpeed) => void;
-	onSpeedDelete?: (id: string) => void;
 }
 
 const ZOOM_DEPTH_OPTIONS: Array<{ depth: ZoomDepth; label: string }> = [
@@ -687,8 +679,6 @@ export function SettingsPanel({
 	selectedZoomMode,
 	onZoomModeChange,
 	onZoomDelete,
-	selectedTrimId,
-	onTrimDelete,
 	selectedClipId,
 	selectedClipSpeed,
 	selectedClipMuted,
@@ -762,10 +752,6 @@ export function SettingsPanel({
 	onClearAutoCaptions,
 	onDownloadWhisperSmallModel,
 	onDeleteWhisperSmallModel,
-	selectedSpeedId,
-	selectedSpeedValue,
-	onSpeedChange,
-	onSpeedDelete,
 }: SettingsPanelProps) {
 	const tSettings = useScopedT("settings");
 	const { locale, setLocale, t } = useI18n();
@@ -1215,12 +1201,6 @@ export function SettingsPanel({
 			{props?.children}
 		</div>
 	);
-
-	const handleTrimDeleteClick = () => {
-		if (selectedTrimId && onTrimDelete) {
-			onTrimDelete(selectedTrimId);
-		}
-	};
 
 	const crop = cropRegion ?? {
 		x: 0,
@@ -2890,74 +2870,6 @@ export function SettingsPanel({
 						{effectSectionContent}
 					</motion.div>
 				</AnimatePresence>
-			</div>
-
-			<div
-				className={cn(
-					"flex-shrink-0 border-t border-foreground/10 bg-editor-header p-4 pt-3",
-					!selectedTrimId && !selectedSpeedId && "hidden",
-				)}
-			>
-				{selectedTrimId && (
-					<div className="mb-4">
-						<Button
-							onClick={handleTrimDeleteClick}
-							variant="destructive"
-							size="sm"
-							className="mt-2 h-8 w-full gap-2 border border-red-500/20 bg-red-500/10 text-xs text-red-400 transition-all hover:border-red-500/30 hover:bg-red-500/20"
-						>
-							<Trash2 className="h-3 w-3" />
-							{tSettings("trim.deleteRegion")}
-						</Button>
-					</div>
-				)}
-
-				{selectedSpeedId && (
-					<div>
-						<div className="mb-3 flex items-center justify-between">
-							<span className="text-sm font-medium text-foreground">
-								{tSettings("speed.playbackSpeed")}
-							</span>
-							{selectedSpeedValue && (
-								<span className="rounded-full bg-[#d97706]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[#d97706]">
-									{SPEED_OPTIONS.find((o) => o.speed === selectedSpeedValue)
-										?.label ?? `${selectedSpeedValue}×`}
-								</span>
-							)}
-						</div>
-						<div className="grid grid-cols-7 gap-1.5">
-							{SPEED_OPTIONS.map((option) => {
-								const isActive = selectedSpeedValue === option.speed;
-								return (
-									<Button
-										key={option.speed}
-										type="button"
-										onClick={() => onSpeedChange?.(option.speed)}
-										className={cn(
-											"h-auto w-full rounded-lg border px-1 py-2 text-center shadow-sm transition-all duration-200 ease-out cursor-pointer",
-											isActive
-												? "border-[#d97706] bg-[#d97706] text-white"
-												: "border-foreground/5 bg-foreground/5 text-muted-foreground hover:bg-foreground/10 hover:border-foreground/10 hover:text-foreground",
-										)}
-									>
-										<span className="text-xs font-semibold">
-											{option.label}
-										</span>
-									</Button>
-								);
-							})}
-						</div>
-						<Button
-							onClick={() => selectedSpeedId && onSpeedDelete?.(selectedSpeedId)}
-							variant="destructive"
-							size="sm"
-							className="mt-2 h-8 w-full gap-2 border border-red-500/20 bg-red-500/10 text-xs text-red-400 transition-all hover:border-red-500/30 hover:bg-red-500/20"
-						>
-							<Trash2 className="h-3 w-3" />
-							{tSettings("speed.deleteRegion")}
-						</Button>
-					</div>
-				)}
 			</div>
 		</div>
 	);

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -745,8 +745,7 @@ export default function VideoEditor() {
 		}
 		context.imageSmoothingEnabled = true;
 		context.imageSmoothingQuality = "high";
-		const editorBgHsl = getComputedStyle(document.documentElement).getPropertyValue("--editor-bg").trim();
-		context.fillStyle = editorBgHsl ? `hsl(${editorBgHsl})` : "#111113";
+		context.fillStyle = "#111113";
 		context.fillRect(0, 0, targetWidth, targetHeight);
 
 		const previewWidth = previewHandle?.containerRef.current?.clientWidth || 1920;
@@ -781,7 +780,7 @@ export default function VideoEditor() {
 					padding,
 					cropRegion,
 					webcam,
-					webcamUrl: resolvedWebcamVideoUrl ?? (webcam.sourcePath ? toFileUrl(webcam.sourcePath) : null),
+					webcamUrl: webcam.sourcePath ? toFileUrl(webcam.sourcePath) : null,
 					videoWidth: previewVideo.videoWidth,
 					videoHeight: previewVideo.videoHeight,
 					annotationRegions,
@@ -1807,6 +1806,7 @@ export default function VideoEditor() {
 			setResolvedWebcamVideoUrl(null);
 			return;
 		}
+		setResolvedWebcamVideoUrl(null);
 		void resolveVideoUrl(webcam.sourcePath).then((url) => {
 			if (!cancelled) setResolvedWebcamVideoUrl(url);
 		});
@@ -2808,12 +2808,22 @@ export default function VideoEditor() {
 
 	const handleClipDelete = useCallback(
 		(id: string) => {
+			const deletedClip = clipRegions.find((c) => c.id === id);
 			setClipRegions((prev) => prev.filter((clip) => clip.id !== id));
+			if (deletedClip) {
+				const { startMs, endMs } = deletedClip;
+				// Cascade: remove all timeline items fully within the deleted clip's span
+				setZoomRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
+				setAnnotationRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
+				setTrimRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
+				setSpeedRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
+				setAudioRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
+			}
 			if (selectedClipId === id) {
 				setSelectedClipId(null);
 			}
 		},
-		[selectedClipId],
+		[clipRegions, selectedClipId],
 	);
 
 	const handleSelectSpeed = useCallback((id: string | null) => {
@@ -3539,7 +3549,7 @@ export default function VideoEditor() {
 						videoPadding: padding,
 						cropRegion,
 						webcam,
-						webcamUrl: resolvedWebcamVideoUrl ?? (webcam.sourcePath ? toFileUrl(webcam.sourcePath) : null),
+						webcamUrl: webcam.sourcePath ? toFileUrl(webcam.sourcePath) : null,
 						annotationRegions,
 						autoCaptions,
 						autoCaptionSettings,
@@ -3708,7 +3718,7 @@ export default function VideoEditor() {
 						padding,
 						cropRegion,
 						webcam,
-						webcamUrl: resolvedWebcamVideoUrl ?? (webcam.sourcePath ? toFileUrl(webcam.sourcePath) : null),
+						webcamUrl: webcam.sourcePath ? toFileUrl(webcam.sourcePath) : null,
 						annotationRegions,
 						autoCaptions,
 						autoCaptionSettings,
@@ -4177,8 +4187,8 @@ export default function VideoEditor() {
 		? Math.min(
 				typeof exportProgress?.renderProgress === "number"
 					? exportProgress.renderProgress
-					: (exportProgress?.percentage ?? 100),
-				100,
+					: (exportProgress?.percentage ?? 99),
+				99,
 			)
 		: null;
 	const isLightningExportInProgress =
@@ -4234,7 +4244,7 @@ export default function VideoEditor() {
 					})
 				: isExportFinalizing
 					? t("editor.exportStatus.finalizingPercent", "Finalizing {{percent}}%", {
-							percent: Math.round(exportFinalizingProgress ?? 100),
+							percent: Math.round(exportFinalizingProgress ?? 99),
 						})
 					: t("editor.exportStatus.completePercent", "{{percent}}% complete", {
 							percent: Math.round(exportProgress.percentage),
@@ -4258,7 +4268,7 @@ export default function VideoEditor() {
 			<div className="flex h-screen items-center justify-center bg-background">
 				<div className="text-foreground">Loading video...</div>
 				{projectBrowser}
-				<Toaster className="pointer-events-auto" />
+				<Toaster theme="dark" className="pointer-events-auto" />
 			</div>
 		);
 	}
@@ -4271,21 +4281,21 @@ export default function VideoEditor() {
 						ref={projectBrowserFallbackTriggerRef}
 						type="button"
 						onClick={handleOpenProjectBrowser}
-						className="rounded-[5px] bg-neutral-800 px-3 py-1.5 text-sm font-semibold text-white shadow-[0_14px_32px_rgba(0,0,0,0.18)] transition-colors hover:bg-neutral-700 dark:bg-white dark:text-black dark:hover:bg-white/90"
+						className="rounded-[5px] bg-white px-3 py-1.5 text-sm font-semibold text-black shadow-[0_14px_32px_rgba(0,0,0,0.18)] transition-colors hover:bg-white/92"
 					>
 						Open Projects
 					</button>
 				</div>
 				{projectBrowser}
-				<Toaster className="pointer-events-auto" />
+				<Toaster theme="dark" className="pointer-events-auto" />
 			</div>
 		);
 	}
 
 	return (
-		<div className="flex flex-col h-screen bg-editor-bg text-foreground overflow-hidden selection:bg-[#2563EB]/30">
+		<div className="flex flex-col h-screen bg-[#111113] text-slate-200 overflow-hidden selection:bg-[#2563EB]/30">
 			<div
-				className="relative flex h-11 flex-shrink-0 items-center justify-between bg-editor-header/88 px-5 backdrop-blur-md border-b border-foreground/10 z-50"
+				className="relative flex h-11 flex-shrink-0 items-center justify-between bg-[#151518]/88 px-5 backdrop-blur-md border-b border-white/10 z-50"
 				style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
 			>
 				<div
@@ -4305,13 +4315,13 @@ export default function VideoEditor() {
 					</Button>
 					<DiscordLinkButton />
 					<FeedbackDialog />
-					<div className="ml-1 h-5 w-px bg-foreground/10" />
+					<div className="ml-1 h-5 w-px bg-white/10" />
 					<Button
 						type="button"
 						variant="ghost"
 						onClick={handleUndo}
 						disabled={!canUndo}
-						className="inline-flex h-8 w-8 items-center justify-center rounded-[5px] border border-foreground/10 bg-foreground/5 p-0 text-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+						className="inline-flex h-8 w-8 items-center justify-center rounded-[5px] border border-white/10 bg-white/5 p-0 text-slate-200 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
 						title={t("common.actions.undo", "Undo")}
 						aria-label={t("common.actions.undo", "Undo")}
 					>
@@ -4322,7 +4332,7 @@ export default function VideoEditor() {
 						variant="ghost"
 						onClick={handleRedo}
 						disabled={!canRedo}
-						className="inline-flex h-8 w-8 items-center justify-center rounded-[5px] border border-foreground/10 bg-foreground/5 p-0 text-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+						className="inline-flex h-8 w-8 items-center justify-center rounded-[5px] border border-white/10 bg-white/5 p-0 text-slate-200 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
 						title={t("common.actions.redo", "Redo")}
 						aria-label={t("common.actions.redo", "Redo")}
 					>
@@ -4333,10 +4343,10 @@ export default function VideoEditor() {
 					className="pointer-events-none absolute left-1/2 flex min-w-0 -translate-x-1/2 items-baseline justify-center gap-0"
 					style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
 				>
-					<span className="text-sm font-semibold tracking-tight text-foreground/90">
+					<span className="text-sm font-semibold tracking-tight text-white/90">
 						{projectDisplayName}
 					</span>
-					<span className="text-xs font-medium tracking-tight text-muted-foreground/70">
+					<span className="text-xs font-medium tracking-tight text-slate-500">
 						.recordly
 					</span>
 				</div>
@@ -4348,7 +4358,7 @@ export default function VideoEditor() {
 						ref={projectBrowserTriggerRef}
 						type="button"
 						onClick={handleOpenProjectBrowser}
-						className="inline-flex h-8 min-w-[96px] items-center justify-center gap-1.5 rounded-[5px] bg-neutral-800 px-4 text-white shadow-[0_14px_32px_rgba(0,0,0,0.18)] transition-colors hover:bg-neutral-700 dark:bg-white dark:text-black dark:hover:bg-white/90"
+						className="inline-flex h-8 min-w-[96px] items-center justify-center gap-1.5 rounded-[5px] bg-white px-4 text-black shadow-[0_14px_32px_rgba(0,0,0,0.18)] transition-colors hover:bg-white/92"
 					>
 						<FolderOpen className="h-4 w-4" />
 						<span className="text-sm font-semibold tracking-tight">
@@ -4358,7 +4368,7 @@ export default function VideoEditor() {
 					<Button
 						type="button"
 						onClick={handleSaveProject}
-						className="inline-flex h-8 min-w-[96px] items-center justify-center gap-1.5 rounded-[5px] bg-neutral-800 px-4 text-white transition-colors hover:bg-neutral-700 dark:bg-white dark:text-black dark:hover:bg-white/90"
+						className="inline-flex h-8 min-w-[96px] items-center justify-center gap-1.5 rounded-[5px] bg-white px-4 text-black transition-colors hover:bg-white/92"
 					>
 						<span
 							className={`${hasUnsavedChanges ? "flex" : "hidden"} size-2 relative`}
@@ -4371,7 +4381,7 @@ export default function VideoEditor() {
 							{t("common.actions.save")}
 						</span>
 					</Button>
-					<div className="mx-1 h-5 w-px bg-foreground/10" />
+					<div className="mx-1 h-5 w-px bg-white/10" />
 					<DropdownMenu
 						open={showExportDropdown}
 						onOpenChange={setShowExportDropdown}
@@ -4395,25 +4405,25 @@ export default function VideoEditor() {
 							className="w-[360px] border-none bg-transparent p-0 shadow-none"
 						>
 							{isExporting ? (
-								<div className="rounded-2xl border border-foreground/10 bg-editor-surface p-4 text-foreground shadow-2xl">
+								<div className="rounded-2xl border border-white/10 bg-[#17171a] p-4 text-slate-200 shadow-2xl">
 									<div className="mb-3 flex items-center justify-between gap-3">
 										<div>
-											<p className="text-sm font-semibold text-foreground">
+											<p className="text-sm font-semibold text-white">
 												{t("editor.exportStatus.exporting", "Exporting")}
 											</p>
-											<p className="text-xs text-muted-foreground">
+											<p className="text-xs text-slate-400">
 												{t(
 													"editor.exportStatus.renderingFile",
 													"Rendering your file.",
 												)}
 											</p>
 											{isLightningExportInProgress ? (
-												<p className="mt-1 flex items-center gap-1 text-[11px] text-muted-foreground/70">
+												<p className="mt-1 flex items-center gap-1 text-[11px] text-slate-500">
 													PLEASE
 													<button
 														type="button"
 														onClick={() => void openLightningIssues()}
-														className="underline decoration-slate-500/70 underline-offset-2 transition-colors hover:text-foreground"
+														className="underline decoration-slate-500/70 underline-offset-2 transition-colors hover:text-slate-200"
 													>
 														report bugs
 													</button>
@@ -4422,7 +4432,7 @@ export default function VideoEditor() {
 												</p>
 											) : null}
 											{isLegacyExportInProgress ? (
-												<p className="mt-1 text-[11px] text-muted-foreground/70">
+												<p className="mt-1 text-[11px] text-slate-500">
 													Export too slow? Cancel and try Lightning
 													export!
 												</p>
@@ -4437,7 +4447,7 @@ export default function VideoEditor() {
 											{t("common.actions.cancel")}
 										</Button>
 									</div>
-									<div className="h-2 overflow-hidden rounded-full border border-foreground/5 bg-foreground/5">
+									<div className="h-2 overflow-hidden rounded-full border border-white/5 bg-white/5">
 										{isExportSaving ? (
 											<div className="indeterminate-progress h-full rounded-full bg-transparent" />
 										) : (
@@ -4449,35 +4459,36 @@ export default function VideoEditor() {
 											/>
 										)}
 									</div>
-									<p className="mt-2 text-xs text-muted-foreground">
+									<p className="mt-2 text-xs text-slate-400">
 										{exportPercentLabel}
 									</p>
 									{isRenderingAudio ? (
-										<p className="mt-1 text-[11px] text-muted-foreground/70">
-											{t("editor.export.processingAudioEdits", "Processing audio with speed/overlay edits")}
+										<p className="mt-1 text-[11px] text-slate-500">
+											Audio requires real-time playback for speed/overlay
+											edits
 										</p>
 									) : exportRenderSpeedLabel ? (
-										<p className="mt-1 text-[11px] text-muted-foreground/70">
+										<p className="mt-1 text-[11px] text-slate-500">
 											{exportRenderSpeedLabel}
 										</p>
 									) : null}
 									{exportRuntimeLabel ? (
-										<p className="mt-1 text-[11px] text-muted-foreground/70">
+										<p className="mt-1 text-[11px] text-slate-500">
 											Path: {exportRuntimeLabel}
 										</p>
 									) : null}
 								</div>
 							) : exportError ? (
-								<div className="rounded-2xl border border-foreground/10 bg-editor-surface p-4 text-foreground shadow-2xl">
-									<p className="text-sm font-semibold text-foreground">
+								<div className="rounded-2xl border border-white/10 bg-[#17171a] p-4 text-slate-200 shadow-2xl">
+									<p className="text-sm font-semibold text-white">
 										{t("editor.exportStatus.issue", "Export issue")}
 									</p>
 									{exportRuntimeLabel ? (
-										<p className="mt-1 text-[11px] text-muted-foreground/70">
+										<p className="mt-1 text-[11px] text-slate-500">
 											Path: {exportRuntimeLabel}
 										</p>
 									) : null}
-									<p className="mt-1 whitespace-pre-line text-xs leading-relaxed text-muted-foreground">
+									<p className="mt-1 whitespace-pre-line text-xs leading-relaxed text-slate-400">
 										{exportError}
 									</p>
 									<div className="mt-4 flex gap-2">
@@ -4494,29 +4505,29 @@ export default function VideoEditor() {
 											type="button"
 											variant="outline"
 											onClick={handleExportDropdownClose}
-											className="h-8 flex-1 border-foreground/10 bg-foreground/5 text-xs text-muted-foreground hover:bg-foreground/10"
+											className="h-8 flex-1 border-white/10 bg-white/5 text-xs text-slate-300 hover:bg-white/10"
 										>
 											{t("common.actions.close", "Close")}
 										</Button>
 									</div>
 								</div>
 							) : exportedFilePath ? (
-								<div className="rounded-2xl border border-foreground/10 bg-editor-surface p-4 text-foreground shadow-2xl">
-									<p className="text-sm font-semibold text-foreground">
+								<div className="rounded-2xl border border-white/10 bg-[#17171a] p-4 text-slate-200 shadow-2xl">
+									<p className="text-sm font-semibold text-white">
 										{t("editor.exportStatus.complete", "Export complete")}
 									</p>
-									<p className="mt-1 text-xs text-muted-foreground">
+									<p className="mt-1 text-xs text-slate-400">
 										{t(
 											"editor.exportStatus.savedSuccessfully",
 											"Your file was saved successfully.",
 										)}
 									</p>
 									{exportRuntimeLabel ? (
-										<p className="mt-1 text-[11px] text-muted-foreground/70">
+										<p className="mt-1 text-[11px] text-slate-500">
 											Path: {exportRuntimeLabel}
 										</p>
 									) : null}
-									<p className="mt-3 truncate text-xs text-muted-foreground/70">
+									<p className="mt-3 truncate text-xs text-slate-500">
 										{exportedFilePath.split("/").pop()}
 									</p>
 									<div className="mt-4 flex gap-2">
@@ -4531,7 +4542,7 @@ export default function VideoEditor() {
 											type="button"
 											variant="outline"
 											onClick={handleExportDropdownClose}
-											className="h-8 flex-1 border-foreground/10 bg-foreground/5 text-xs text-muted-foreground hover:bg-foreground/10"
+											className="h-8 flex-1 border-white/10 bg-white/5 text-xs text-slate-300 hover:bg-white/10"
 										>
 											Done
 										</Button>
@@ -4567,7 +4578,7 @@ export default function VideoEditor() {
 			</div>
 
 			<div className="relative flex min-h-0 flex-1 flex-col gap-3 p-4">
-				<div className="flex min-h-0 flex-1 gap-3 relative z-10">
+				<div className="flex min-h-0 flex-1 gap-3">
 					{/* Settings sidebar */}
 					<div className="flex flex-shrink-0 gap-1.5">
 						{/* Icon rail */}
@@ -4587,7 +4598,7 @@ export default function VideoEditor() {
 											{isActive && (
 												<motion.span
 													layoutId="rail-active-bg"
-													className="absolute inset-0 rounded-lg bg-foreground/[0.08]"
+													className="absolute inset-0 rounded-lg bg-white/[0.08]"
 													transition={{
 														type: "spring",
 														stiffness: 450,
@@ -4600,7 +4611,7 @@ export default function VideoEditor() {
 												animate={{
 													color: isActive
 														? "#2563EB"
-														: "hsl(var(--foreground))",
+														: "rgba(255,255,255,1)",
 												}}
 												transition={{ duration: 0.14 }}
 											>
@@ -4636,16 +4647,16 @@ export default function VideoEditor() {
 									</div>
 								);
 							})}
-							<div className="mt-auto flex flex-col items-center gap-0.5 pt-3">
+							<div className="mt-auto pt-3">
 								<motion.button
 									type="button"
 									onClick={() => toast.info("Account coming soon")}
 									title="Account"
-									className="group relative flex h-9 w-9 items-center justify-center rounded-lg text-foreground/55 outline-none transition hover:text-foreground focus:outline-none focus-visible:outline-none"
+									className="group relative flex h-9 w-9 items-center justify-center rounded-lg text-white/55 outline-none transition hover:text-white focus:outline-none focus-visible:outline-none"
 									whileHover={{ opacity: 1 }}
 									initial={{ opacity: 0.55 }}
 								>
-									<motion.span className="absolute inset-0 rounded-lg bg-foreground/[0.04] opacity-0 transition group-hover:opacity-100" />
+									<motion.span className="absolute inset-0 rounded-lg bg-white/[0.04] opacity-0 transition group-hover:opacity-100" />
 									<User className="relative z-10 h-[22px] w-[22px]" />
 								</motion.button>
 							</div>
@@ -4813,7 +4824,7 @@ export default function VideoEditor() {
 											<Button
 												variant="ghost"
 												size="sm"
-												className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground hover:bg-foreground/10 transition-all gap-1"
+												className="h-7 px-2 text-xs text-white hover:text-white hover:bg-white/10 transition-all gap-1"
 											>
 												<span className="font-medium">
 													{getAspectRatioLabel(aspectRatio)}
@@ -4823,13 +4834,13 @@ export default function VideoEditor() {
 										</DropdownMenuTrigger>
 										<DropdownMenuContent
 											align="center"
-											className="bg-editor-surface-alt border-foreground/10"
+											className="bg-[#1a1a1c] border-white/10"
 										>
 											{ASPECT_RATIOS.map((ratio) => (
 												<DropdownMenuItem
 													key={ratio}
 													onClick={() => setAspectRatio(ratio)}
-													className="text-muted-foreground hover:text-foreground hover:bg-foreground/10 cursor-pointer flex items-center justify-between gap-3"
+													className="text-slate-300 hover:text-white hover:bg-white/10 cursor-pointer flex items-center justify-between gap-3"
 												>
 													<span>{getAspectRatioLabel(ratio)}</span>
 													{aspectRatio === ratio && (
@@ -4839,12 +4850,12 @@ export default function VideoEditor() {
 											))}
 										</DropdownMenuContent>
 									</DropdownMenu>
-									<div className="w-[1px] h-4 bg-foreground/20" />
+									<div className="w-[1px] h-4 bg-white/20" />
 									<Button
 										variant="ghost"
 										size="sm"
 										onClick={handleOpenCropEditor}
-										className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground hover:bg-foreground/10 transition-all gap-1.5"
+										className="h-7 px-2 text-xs text-white hover:text-white hover:bg-white/10 transition-all gap-1.5"
 									>
 										<Crop className="w-3.5 h-3.5" />
 										<span className="font-medium">
@@ -4968,7 +4979,7 @@ export default function VideoEditor() {
 										<Button
 											variant="ghost"
 											size="sm"
-											className="h-7 gap-1 rounded-full border border-foreground/[0.08] bg-foreground/[0.04] px-2.5 text-[11px] text-foreground/65 shadow-[inset_0_1px_0_hsl(var(--foreground)/0.06)] transition-all hover:bg-foreground/[0.08] hover:text-foreground"
+											className="h-7 gap-1 rounded-full border border-white/[0.08] bg-white/[0.04] px-2.5 text-[11px] text-white/65 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] transition-all hover:bg-white/[0.08] hover:text-white"
 										>
 											<Plus className="w-3.5 h-3.5" />
 											<span className="font-medium">
@@ -4979,7 +4990,7 @@ export default function VideoEditor() {
 									</DropdownMenuTrigger>
 									<DropdownMenuContent
 										align="start"
-										className="bg-editor-surface-alt border-foreground/10"
+										className="bg-[#1a1a1c] border-white/10"
 									>
 										<DropdownMenuItem
 											onClick={() => {
@@ -4993,24 +5004,24 @@ export default function VideoEditor() {
 														: 0;
 												timelineRef.current?.addAnnotation(nextTrackIndex);
 											}}
-											className="text-muted-foreground hover:text-foreground hover:bg-foreground/10 cursor-pointer"
+											className="text-slate-300 hover:text-white hover:bg-white/10 cursor-pointer"
 										>
 											{t("timeline.annotation.label")}
 										</DropdownMenuItem>
 										<DropdownMenuItem
 											onClick={() => timelineRef.current?.addAudio()}
-											className="text-muted-foreground hover:text-foreground hover:bg-foreground/10 cursor-pointer"
+											className="text-slate-300 hover:text-white hover:bg-white/10 cursor-pointer"
 										>
 											{t("timeline.audio.label")}
 										</DropdownMenuItem>
 									</DropdownMenuContent>
 								</DropdownMenu>
-								<div className="w-[1px] h-4 bg-foreground/10 mx-1" />
+								<div className="w-[1px] h-4 bg-white/10 mx-1" />
 								<Button
 									onClick={() => timelineRef.current?.addZoom()}
 									variant="ghost"
 									size="icon"
-									className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-[#2563EB]/10 hover:text-[#2563EB]"
+									className="h-7 w-7 rounded-full text-slate-400 transition-all hover:bg-[#2563EB]/10 hover:text-[#2563EB]"
 									title={t("timeline.zoom.addZoom")}
 								>
 									<ZoomIn className="w-4 h-4" />
@@ -5019,7 +5030,7 @@ export default function VideoEditor() {
 									onClick={() => timelineRef.current?.suggestZooms()}
 									variant="ghost"
 									size="icon"
-									className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-[#2563EB]/10 hover:text-[#2563EB]"
+									className="h-7 w-7 rounded-full text-slate-400 transition-all hover:bg-[#2563EB]/10 hover:text-[#2563EB]"
 									title={t("timeline.zoom.suggestZooms")}
 								>
 									<WandSparkles className="w-4 h-4" />
@@ -5028,7 +5039,7 @@ export default function VideoEditor() {
 									onClick={() => timelineRef.current?.splitClip()}
 									variant="ghost"
 									size="icon"
-									className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground"
+									className="h-7 w-7 rounded-full text-slate-400 transition-all hover:bg-white/10 hover:text-white"
 									title={t("editor.toolbar.splitClip")}
 								>
 									<Scissors className="w-4 h-4" />
@@ -5037,13 +5048,13 @@ export default function VideoEditor() {
 							{/* Playback controls - centered */}
 							<div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
 								<div className="flex items-center gap-1.5 pointer-events-auto">
-									<span className="mr-1 text-[10px] font-medium tabular-nums text-muted-foreground">
+									<span className="mr-1 text-[10px] font-medium tabular-nums text-slate-400">
 										{formatTime(timelinePlayheadTime)}
 									</span>
 									<Button
 										variant="ghost"
 										size="icon"
-										className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground"
+										className="h-7 w-7 rounded-full text-slate-400 transition-all hover:bg-white/10 hover:text-white"
 										title={t("editor.playback.skipBack")}
 										onClick={() => {
 											const currentMs = timelinePlayheadTime * 1000;
@@ -5063,7 +5074,7 @@ export default function VideoEditor() {
 									<Button
 										variant="ghost"
 										size="icon"
-										className={`h-7 w-7 rounded-full border border-foreground/10 transition-all shadow-[0_8px_18px_rgba(0,0,0,0.18)] ${isPlaying ? "bg-foreground/10 text-foreground hover:bg-foreground/20" : "bg-neutral-800 text-white hover:bg-neutral-700 dark:bg-white dark:text-black dark:hover:bg-white/90"}`}
+										className={`h-7 w-7 rounded-full border border-white/10 transition-all shadow-[0_8px_18px_rgba(0,0,0,0.18)] ${isPlaying ? "bg-white/10 text-white hover:bg-white/20" : "bg-white text-black hover:bg-white/90"}`}
 										onClick={togglePlayPause}
 										title={isPlaying ? "Pause" : "Play"}
 									>
@@ -5076,7 +5087,7 @@ export default function VideoEditor() {
 									<Button
 										variant="ghost"
 										size="icon"
-										className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground"
+										className="h-7 w-7 rounded-full text-slate-400 transition-all hover:bg-white/10 hover:text-white"
 										title={t("editor.playback.skipForward")}
 										onClick={() => {
 											const currentMs = timelinePlayheadTime * 1000;
@@ -5091,7 +5102,7 @@ export default function VideoEditor() {
 									>
 										<SkipForward className="w-3.5 h-3.5" weight="fill" />
 									</Button>
-									<span className="text-[10px] font-medium text-muted-foreground/70 tabular-nums ml-1">
+									<span className="text-[10px] font-medium text-slate-500 tabular-nums ml-1">
 										{formatTime(duration)}
 									</span>
 								</div>
@@ -5106,7 +5117,7 @@ export default function VideoEditor() {
 											? t("editor.timeline.expand")
 											: t("editor.timeline.collapse")
 									}
-									className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground"
+									className="h-7 w-7 rounded-full text-slate-400 transition-all hover:bg-white/10 hover:text-white"
 									onClick={() => {
 										setTimelineCollapsed((p) => !p);
 									}}
@@ -5120,7 +5131,7 @@ export default function VideoEditor() {
 								<div className="flex items-center gap-1.5">
 									<button
 										type="button"
-										className="text-muted-foreground hover:text-foreground transition-colors"
+										className="text-slate-400 hover:text-white transition-colors"
 										title={t("editor.playback.muteUnmute")}
 										onClick={() =>
 											setPreviewVolume(previewVolume <= 0.001 ? 1 : 0)
@@ -5134,9 +5145,9 @@ export default function VideoEditor() {
 											<Volume2 className="w-3.5 h-3.5" />
 										)}
 									</button>
-									<div className="relative flex h-7 w-24 select-none items-center overflow-hidden rounded-full border border-foreground/[0.06] bg-editor-bg/80 shadow-[inset_0_1px_0_hsl(var(--foreground)/0.06)]">
+									<div className="relative flex h-7 w-24 select-none items-center overflow-hidden rounded-full border border-white/[0.06] bg-black/55 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
 										<div
-											className="absolute inset-y-[3px] left-[3px] right-auto rounded-[10px] bg-foreground/[0.08]"
+											className="absolute inset-y-[3px] left-[3px] right-auto rounded-[10px] bg-white/[0.08]"
 											style={{
 												width:
 													previewVolume > 0
@@ -5145,10 +5156,10 @@ export default function VideoEditor() {
 											}}
 										/>
 										<div
-											className="pointer-events-none absolute bottom-[18%] top-[18%] z-10 w-[2px] rounded-full bg-foreground/95 shadow-[0_0_10px_rgba(37,99,235,0.28)]"
+											className="pointer-events-none absolute bottom-[18%] top-[18%] z-10 w-[2px] rounded-full bg-white/95 shadow-[0_0_10px_rgba(37,99,235,0.28)]"
 											style={{ left: `calc(${previewVolume * 100}% - 8px)` }}
 										/>
-										<span className="pointer-events-none relative z-10 pl-2 text-[10px] font-medium text-muted-foreground">
+										<span className="pointer-events-none relative z-10 pl-2 text-[10px] font-medium text-slate-400">
 											{Math.round(previewVolume * 100)}%
 										</span>
 										<input
@@ -5233,13 +5244,13 @@ export default function VideoEditor() {
 						className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm animate-in fade-in duration-200"
 						onClick={handleCancelCropEditor}
 					/>
-					<div className="fixed left-1/2 top-1/2 z-[60] max-h-[90vh] w-[90vw] max-w-5xl -translate-x-1/2 -translate-y-1/2 overflow-auto rounded-2xl border border-foreground/10 bg-editor-dialog p-8 shadow-2xl animate-in zoom-in-95 duration-200">
+					<div className="fixed left-1/2 top-1/2 z-[60] max-h-[90vh] w-[90vw] max-w-5xl -translate-x-1/2 -translate-y-1/2 overflow-auto rounded-2xl border border-white/10 bg-[#09090b] p-8 shadow-2xl animate-in zoom-in-95 duration-200">
 						<div className="mb-6 flex items-center justify-between">
 							<div>
-								<span className="text-xl font-bold text-foreground">
+								<span className="text-xl font-bold text-slate-200">
 									{t("settings.crop.title")}
 								</span>
-								<p className="mt-2 text-sm text-muted-foreground">
+								<p className="mt-2 text-sm text-slate-400">
 									{t("settings.crop.instruction")}
 								</p>
 							</div>
@@ -5247,7 +5258,7 @@ export default function VideoEditor() {
 								variant="ghost"
 								size="icon"
 								onClick={handleCancelCropEditor}
-								className="text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+								className="text-slate-400 hover:bg-white/10 hover:text-white"
 							>
 								<X className="h-5 w-5" />
 							</Button>
@@ -5273,7 +5284,7 @@ export default function VideoEditor() {
 
 			{projectBrowser}
 
-			<Toaster className="pointer-events-auto" />
+			<Toaster theme="dark" className="pointer-events-auto" />
 		</div>
 	);
 }

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -146,7 +146,6 @@ import {
 	DEFAULT_CROP_REGION,
 	DEFAULT_CURSOR_STYLE,
 	DEFAULT_FIGURE_DATA,
-	DEFAULT_PLAYBACK_SPEED,
 	DEFAULT_WEBCAM_OVERLAY,
 	DEFAULT_ZOOM_DEPTH,
 	DEFAULT_ZOOM_IN_DURATION_MS,
@@ -157,7 +156,7 @@ import {
 	type EditorEffectSection,
 	type FigureData,
 	getClipSourceEndMs,
-	type PlaybackSpeed,
+	getClipSourceStartMs,
 	type SpeedRegion,
 	type TrimRegion,
 	type WebcamOverlaySettings,
@@ -176,14 +175,11 @@ import {
 type EditorHistorySnapshot = {
 	zoomRegions: ZoomRegion[];
 	clipRegions: ClipRegion[];
-	speedRegions: SpeedRegion[];
 	annotationRegions: AnnotationRegion[];
 	audioRegions: AudioRegion[];
 	autoCaptions: CaptionCue[];
 	selectedZoomId: string | null;
-	selectedTrimId: string | null;
 	selectedClipId: string | null;
-	selectedSpeedId: string | null;
 	selectedAnnotationId: string | null;
 	selectedAudioId: string | null;
 };
@@ -556,16 +552,35 @@ export default function VideoEditor() {
 	const [zoomRegions, setZoomRegions] = useState<ZoomRegion[]>([]);
 	const [cursorTelemetry, setCursorTelemetry] = useState<CursorTelemetryPoint[]>([]);
 	const [selectedZoomId, setSelectedZoomId] = useState<string | null>(null);
-	const [trimRegions, setTrimRegions] = useState<TrimRegion[]>([]);
-	const [selectedTrimId, setSelectedTrimId] = useState<string | null>(null);
 	const [clipRegions, setClipRegions] = useState<ClipRegion[]>([]);
 	const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
-	const [speedRegions, setSpeedRegions] = useState<SpeedRegion[]>([]);
-	const [selectedSpeedId, setSelectedSpeedId] = useState<string | null>(null);
 	const [annotationRegions, setAnnotationRegions] = useState<AnnotationRegion[]>([]);
 	const [selectedAnnotationId, setSelectedAnnotationId] = useState<string | null>(null);
 	const [audioRegions, setAudioRegions] = useState<AudioRegion[]>([]);
 	const [selectedAudioId, setSelectedAudioId] = useState<string | null>(null);
+
+	// Trim regions derived from clips (gaps = sections to skip in export)
+	const trimRegions = useMemo<TrimRegion[]>(() => {
+		const totalMs = Math.round(duration * 1000);
+		if (totalMs <= 0 || clipRegions.length === 0) return [];
+		return clipsToTrims(clipRegions, totalMs);
+	}, [clipRegions, duration]);
+
+	// Speed regions derived purely from clip speeds (no standalone speed regions)
+	const effectiveSpeedRegions = useMemo<SpeedRegion[]>(
+		() =>
+			clipRegions
+				.filter((clip) => clip.speed !== 1)
+				.map((clip) => ({
+					id: `clip-speed-${clip.id}`,
+					startMs: getClipSourceStartMs(clip),
+					endMs: getClipSourceEndMs(clip),
+					speed: clip.speed as SpeedRegion["speed"],
+				})),
+		[clipRegions],
+	);
+	const speedRegions = effectiveSpeedRegions;
+
 	const [autoCaptions, setAutoCaptions] = useState<CaptionCue[]>([]);
 	const [autoCaptionSettings, setAutoCaptionSettings] = useState<AutoCaptionSettings>(
 		DEFAULT_AUTO_CAPTION_SETTINGS,
@@ -632,9 +647,7 @@ export default function VideoEditor() {
 	const projectBrowserTriggerRef = useRef<HTMLButtonElement | null>(null);
 	const projectBrowserFallbackTriggerRef = useRef<HTMLButtonElement | null>(null);
 	const nextZoomIdRef = useRef(1);
-	const nextTrimIdRef = useRef(1);
 	const nextClipIdRef = useRef(1);
-	const nextSpeedIdRef = useRef(1);
 	const nextAudioIdRef = useRef(1);
 
 	const { shortcuts, isMac } = useShortcuts();
@@ -786,27 +799,14 @@ export default function VideoEditor() {
 					annotationRegions,
 					autoCaptions,
 					autoCaptionSettings,
-					speedRegions: (() => {
-						const clipDerived: SpeedRegion[] = clipRegions
-							.filter((clip) => clip.speed !== 1)
-							.map((clip) => ({
-								id: `clip-speed-${clip.id}`,
-								startMs: clip.startMs,
-								endMs: getClipSourceEndMs(clip),
-								speed: clip.speed as SpeedRegion["speed"],
-							}));
-						if (clipDerived.length === 0) return speedRegions;
-						const result = [...speedRegions];
-						for (const cs of clipDerived) {
-							const overlaps = speedRegions.some(
-								(sr) => sr.endMs > cs.startMs && sr.startMs < cs.endMs,
-							);
-							if (!overlaps) {
-								result.push(cs);
-							}
-						}
-						return result;
-					})(),
+					speedRegions: clipRegions
+						.filter((clip) => clip.speed !== 1)
+						.map((clip) => ({
+							id: `clip-speed-${clip.id}`,
+							startMs: getClipSourceStartMs(clip),
+							endMs: getClipSourceEndMs(clip),
+							speed: clip.speed as SpeedRegion["speed"],
+						})),
 					previewWidth,
 					previewHeight,
 					cursorTelemetry,
@@ -897,7 +897,6 @@ export default function VideoEditor() {
 		padding,
 		shadowIntensity,
 		showCursor,
-		speedRegions,
 		wallpaper,
 		webcam,
 		zoomInDurationMs,
@@ -1344,28 +1343,22 @@ export default function VideoEditor() {
 		return {
 			zoomRegions,
 			clipRegions,
-			speedRegions,
 			annotationRegions,
 			audioRegions,
 			autoCaptions,
 			selectedZoomId,
-			selectedTrimId,
 			selectedClipId,
-			selectedSpeedId,
 			selectedAnnotationId,
 			selectedAudioId,
 		};
 	}, [
 		zoomRegions,
 		clipRegions,
-		speedRegions,
 		annotationRegions,
 		audioRegions,
 		autoCaptions,
 		selectedZoomId,
-		selectedTrimId,
 		selectedClipId,
-		selectedSpeedId,
 		selectedAnnotationId,
 		selectedAudioId,
 	]);
@@ -1376,14 +1369,11 @@ export default function VideoEditor() {
 			const cloned = cloneSnapshot(snapshot);
 			setZoomRegions(cloned.zoomRegions);
 			setClipRegions(cloned.clipRegions);
-			setSpeedRegions(cloned.speedRegions);
 			setAnnotationRegions(cloned.annotationRegions);
 			setAudioRegions(cloned.audioRegions);
 			setAutoCaptions(cloned.autoCaptions);
 			setSelectedZoomId(cloned.selectedZoomId);
-			setSelectedTrimId(cloned.selectedTrimId);
 			setSelectedClipId(cloned.selectedClipId);
-			setSelectedSpeedId(cloned.selectedSpeedId);
 			setSelectedAnnotationId(cloned.selectedAnnotationId);
 			setSelectedAudioId(cloned.selectedAudioId);
 
@@ -1394,10 +1384,6 @@ export default function VideoEditor() {
 			nextClipIdRef.current = deriveNextId(
 				"clip",
 				cloned.clipRegions.map((region) => region.id),
-			);
-			nextSpeedIdRef.current = deriveNextId(
-				"speed",
-				cloned.speedRegions.map((region) => region.id),
 			);
 			nextAnnotationIdRef.current = deriveNextId(
 				"annotation",
@@ -1503,10 +1489,8 @@ export default function VideoEditor() {
 			setCropRegion(DEFAULT_CROP_REGION);
 			setWebcam(normalizedEditor.webcam);
 			setZoomRegions(normalizedEditor.zoomRegions);
-			setTrimRegions(normalizedEditor.trimRegions);
 			setClipRegions(normalizedEditor.clipRegions);
 			clipInitializedRef.current = normalizedEditor.clipRegions.length > 0;
-			setSpeedRegions(normalizedEditor.speedRegions);
 			setAnnotationRegions(normalizedEditor.annotationRegions);
 			setAudioRegions(normalizedEditor.audioRegions);
 			setAutoCaptions(normalizedEditor.autoCaptions);
@@ -1523,9 +1507,7 @@ export default function VideoEditor() {
 			setGifSizePreset(normalizedEditor.gifSizePreset);
 
 			setSelectedZoomId(null);
-			setSelectedTrimId(null);
 			setSelectedClipId(null);
-			setSelectedSpeedId(null);
 			setSelectedAnnotationId(null);
 			setSelectedAudioId(null);
 
@@ -1533,17 +1515,9 @@ export default function VideoEditor() {
 				"zoom",
 				normalizedEditor.zoomRegions.map((region) => region.id),
 			);
-			nextTrimIdRef.current = deriveNextId(
-				"trim",
-				normalizedEditor.trimRegions.map((region) => region.id),
-			);
 			nextClipIdRef.current = deriveNextId(
 				"clip",
 				normalizedEditor.clipRegions.map((region: ClipRegion) => region.id),
-			);
-			nextSpeedIdRef.current = deriveNextId(
-				"speed",
-				normalizedEditor.speedRegions.map((region) => region.id),
 			);
 			nextAudioIdRef.current = deriveNextId(
 				"audio",
@@ -2346,19 +2320,13 @@ export default function VideoEditor() {
 		clipInitializedRef.current = true;
 	}, [duration, clipRegions.length]);
 
-	// Derive trimRegions from clipRegions so export/playback pipelines stay unchanged
-	useEffect(() => {
-		const totalMs = Math.round(duration * 1000);
-		if (totalMs <= 0 || clipRegions.length === 0) return;
-		setTrimRegions(clipsToTrims(clipRegions, totalMs));
-	}, [clipRegions, duration]);
-
 	const mapTimelineTimeToSourceTime = useCallback(
 		(timeMs: number) => {
 			for (const clip of clipRegions) {
 				if (timeMs < clip.startMs || timeMs > clip.endMs) continue;
+				const sourceStart = getClipSourceStartMs(clip);
 				const speed = Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
-				return Math.round(clip.startMs + (timeMs - clip.startMs) * speed);
+				return Math.round(sourceStart + (timeMs - clip.startMs) * speed);
 			}
 			return Math.round(timeMs);
 		},
@@ -2368,10 +2336,11 @@ export default function VideoEditor() {
 	const mapSourceTimeToTimelineTime = useCallback(
 		(timeMs: number) => {
 			for (const clip of clipRegions) {
+				const sourceStart = getClipSourceStartMs(clip);
 				const sourceEndMs = getClipSourceEndMs(clip);
-				if (timeMs < clip.startMs || timeMs > sourceEndMs) continue;
+				if (timeMs < sourceStart || timeMs > sourceEndMs) continue;
 				const speed = Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
-				return Math.round(clip.startMs + (timeMs - clip.startMs) / speed);
+				return Math.round(clip.startMs + (timeMs - sourceStart) / speed);
 			}
 			return Math.round(timeMs);
 		},
@@ -2392,29 +2361,6 @@ export default function VideoEditor() {
 		() => mapSourceTimeToTimelineTime(currentTime * 1000) / 1000,
 		[currentTime, mapSourceTimeToTimelineTime],
 	);
-
-	// Merge clip speeds into speed regions so playback + export respect per-clip speed
-	const effectiveSpeedRegions = useMemo<SpeedRegion[]>(() => {
-		const clipDerived: SpeedRegion[] = clipRegions
-			.filter((clip) => clip.speed !== 1)
-			.map((clip) => ({
-				id: `clip-speed-${clip.id}`,
-				startMs: clip.startMs,
-				endMs: getClipSourceEndMs(clip),
-				speed: clip.speed as SpeedRegion["speed"],
-			}));
-		if (clipDerived.length === 0) return speedRegions;
-		const result = [...speedRegions];
-		for (const cs of clipDerived) {
-			const overlaps = speedRegions.some(
-				(sr) => sr.endMs > cs.startMs && sr.startMs < cs.endMs,
-			);
-			if (!overlaps) {
-				result.push(cs);
-			}
-		}
-		return result;
-	}, [clipRegions, speedRegions]);
 
 	function togglePlayPause() {
 		const playback = videoPlaybackRef.current;
@@ -2442,7 +2388,6 @@ export default function VideoEditor() {
 		setSelectedZoomId(id);
 		if (id) {
 			setActiveEffectSection("zoom");
-			setSelectedTrimId(null);
 			setSelectedAnnotationId(null);
 			setSelectedAudioId(null);
 		} else {
@@ -2450,20 +2395,10 @@ export default function VideoEditor() {
 		}
 	}, []);
 
-	const handleSelectTrim = useCallback((id: string | null) => {
-		setSelectedTrimId(id);
-		if (id) {
-			setSelectedZoomId(null);
-			setSelectedAnnotationId(null);
-			setSelectedAudioId(null);
-		}
-	}, []);
-
 	const handleSelectAnnotation = useCallback((id: string | null) => {
 		setSelectedAnnotationId(id);
 		if (id) {
 			setSelectedZoomId(null);
-			setSelectedTrimId(null);
 			setSelectedAudioId(null);
 		}
 	}, []);
@@ -2485,7 +2420,6 @@ export default function VideoEditor() {
 			}
 			setZoomRegions((prev) => [...prev, newRegion]);
 			setSelectedZoomId(id);
-			setSelectedTrimId(null);
 			setSelectedAnnotationId(null);
 			extensionHost.emitEvent({
 				type: "timeline:region-added",
@@ -2579,35 +2513,8 @@ export default function VideoEditor() {
 		zoomRegions,
 	]);
 
-	const handleTrimAdded = useCallback((span: Span) => {
-		const id = `trim-${nextTrimIdRef.current++}`;
-		const newRegion: TrimRegion = {
-			id,
-			startMs: Math.round(span.start),
-			endMs: Math.round(span.end),
-		};
-		setTrimRegions((prev) => [...prev, newRegion]);
-		setSelectedTrimId(id);
-		setSelectedZoomId(null);
-		setSelectedAnnotationId(null);
-	}, []);
-
 	const handleZoomSpanChange = useCallback((id: string, span: Span) => {
 		setZoomRegions((prev) =>
-			prev.map((region) =>
-				region.id === id
-					? {
-							...region,
-							startMs: Math.round(span.start),
-							endMs: Math.round(span.end),
-						}
-					: region,
-			),
-		);
-	}, []);
-
-	const handleTrimSpanChange = useCallback((id: string, span: Span) => {
-		setTrimRegions((prev) =>
 			prev.map((region) =>
 				region.id === id
 					? {
@@ -2672,16 +2579,6 @@ export default function VideoEditor() {
 		[selectedZoomId],
 	);
 
-	const handleTrimDelete = useCallback(
-		(id: string) => {
-			setTrimRegions((prev) => prev.filter((region) => region.id !== id));
-			if (selectedTrimId === id) {
-				setSelectedTrimId(null);
-			}
-		},
-		[selectedTrimId],
-	);
-
 	const handleSelectClip = useCallback((id: string | null) => {
 		setSelectedClipId(id);
 		if (id) {
@@ -2701,12 +2598,17 @@ export default function VideoEditor() {
 				if (!target) return prev;
 				const leftId = `clip-${nextClipIdRef.current++}`;
 				const rightId = `clip-${nextClipIdRef.current++}`;
+				const speed = Number.isFinite(target.speed) && target.speed > 0 ? target.speed : 1;
+				const targetSourceStart = target.sourceStartMs ?? target.startMs;
+				const splitOffset = Math.round(splitMs) - target.startMs;
+				const rightSourceStart = Math.round(targetSourceStart + splitOffset * speed);
 				const left: ClipRegion = {
 					id: leftId,
 					startMs: target.startMs,
 					endMs: Math.round(splitMs),
 					speed: target.speed,
 					muted: target.muted,
+					sourceStartMs: target.sourceStartMs,
 				};
 				const right: ClipRegion = {
 					id: rightId,
@@ -2714,6 +2616,7 @@ export default function VideoEditor() {
 					endMs: target.endMs,
 					speed: target.speed,
 					muted: target.muted,
+					sourceStartMs: rightSourceStart,
 				};
 				if (selectedClipId === target.id) {
 					setSelectedClipId(leftId);
@@ -2737,20 +2640,17 @@ export default function VideoEditor() {
 
 				if (isMove) {
 					const delta = startDelta;
-					setZoomRegions((prev) =>
-						prev.map((zoom) => {
-							const overlaps =
-								zoom.startMs < oldClip.endMs && zoom.endMs > oldClip.startMs;
-							if (overlaps) {
-								return {
-									...zoom,
-									startMs: zoom.startMs + delta,
-									endMs: zoom.endMs + delta,
-								};
-							}
-							return zoom;
-						}),
-					);
+					const moveContained = <T extends { startMs: number; endMs: number }>(
+						regions: T[],
+					): T[] =>
+						regions.map((r) =>
+							r.startMs >= oldClip.startMs && r.endMs <= oldClip.endMs
+								? { ...r, startMs: r.startMs + delta, endMs: r.endMs + delta }
+								: r,
+						);
+					setZoomRegions((prev) => moveContained(prev));
+					setAnnotationRegions((prev) => moveContained(prev));
+					setAudioRegions((prev) => moveContained(prev));
 				}
 			}
 
@@ -2779,19 +2679,21 @@ export default function VideoEditor() {
 			setClipRegions((prev) =>
 				prev.map((c) => (c.id === selectedClipId ? { ...c, speed, endMs: newEndMs } : c)),
 			);
-			// Scale zoom regions that lie within this clip proportionally
-			setZoomRegions((prev) =>
-				prev.map((zoom) => {
-					if (zoom.startMs < clip.startMs || zoom.startMs >= clip.endMs) return zoom;
+			// Scale all child regions within this clip proportionally
+			const scaleInClip = <T extends { startMs: number; endMs: number }>(regions: T[]): T[] =>
+				regions.map((r) => {
+					if (r.startMs < clip.startMs || r.startMs >= clip.endMs) return r;
 					return {
-						...zoom,
+						...r,
 						startMs: Math.round(
-							clip.startMs + (zoom.startMs - clip.startMs) * scaleFactor,
+							clip.startMs + (r.startMs - clip.startMs) * scaleFactor,
 						),
-						endMs: Math.round(clip.startMs + (zoom.endMs - clip.startMs) * scaleFactor),
+						endMs: Math.round(clip.startMs + (r.endMs - clip.startMs) * scaleFactor),
 					};
-				}),
-			);
+				});
+			setZoomRegions((prev) => scaleInClip(prev));
+			setAnnotationRegions((prev) => scaleInClip(prev));
+			setAudioRegions((prev) => scaleInClip(prev));
 		},
 		[selectedClipId, clipRegions],
 	);
@@ -2813,11 +2715,15 @@ export default function VideoEditor() {
 			if (deletedClip) {
 				const { startMs, endMs } = deletedClip;
 				// Cascade: remove all timeline items fully within the deleted clip's span
-				setZoomRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
-				setAnnotationRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
-				setTrimRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
-				setSpeedRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
-				setAudioRegions((prev) => prev.filter((r) => r.startMs < startMs || r.endMs > endMs));
+				setZoomRegions((prev) =>
+					prev.filter((r) => r.startMs < startMs || r.endMs > endMs),
+				);
+				setAnnotationRegions((prev) =>
+					prev.filter((r) => r.startMs < startMs || r.endMs > endMs),
+				);
+				setAudioRegions((prev) =>
+					prev.filter((r) => r.startMs < startMs || r.endMs > endMs),
+				);
 			}
 			if (selectedClipId === id) {
 				setSelectedClipId(null);
@@ -2826,62 +2732,11 @@ export default function VideoEditor() {
 		[clipRegions, selectedClipId],
 	);
 
-	const handleSelectSpeed = useCallback((id: string | null) => {
-		setSelectedSpeedId(id);
-		if (id) {
-			setSelectedZoomId(null);
-			setSelectedTrimId(null);
-			setSelectedAnnotationId(null);
-			setSelectedAudioId(null);
-		}
-	}, []);
-
-	const handleSpeedAdded = useCallback((span: Span) => {
-		const id = `speed-${nextSpeedIdRef.current++}`;
-		const newRegion: SpeedRegion = {
-			id,
-			startMs: Math.round(span.start),
-			endMs: Math.round(span.end),
-			speed: DEFAULT_PLAYBACK_SPEED,
-		};
-		setSpeedRegions((prev) => [...prev, newRegion]);
-		setSelectedSpeedId(id);
-		setSelectedZoomId(null);
-		setSelectedTrimId(null);
-		setSelectedAnnotationId(null);
-	}, []);
-
-	const handleSpeedSpanChange = useCallback((id: string, span: Span) => {
-		setSpeedRegions((prev) =>
-			prev.map((region) =>
-				region.id === id
-					? {
-							...region,
-							startMs: Math.round(span.start),
-							endMs: Math.round(span.end),
-						}
-					: region,
-			),
-		);
-	}, []);
-
-	const handleSpeedDelete = useCallback(
-		(id: string) => {
-			setSpeedRegions((prev) => prev.filter((region) => region.id !== id));
-			if (selectedSpeedId === id) {
-				setSelectedSpeedId(null);
-			}
-		},
-		[selectedSpeedId],
-	);
-
 	const handleSelectAudio = useCallback((id: string | null) => {
 		setSelectedAudioId(id);
 		if (id) {
 			setSelectedZoomId(null);
-			setSelectedTrimId(null);
 			setSelectedAnnotationId(null);
-			setSelectedSpeedId(null);
 		}
 	}, []);
 
@@ -2898,9 +2753,7 @@ export default function VideoEditor() {
 		setAudioRegions((prev) => [...prev, newRegion]);
 		setSelectedAudioId(id);
 		setSelectedZoomId(null);
-		setSelectedTrimId(null);
 		setSelectedAnnotationId(null);
-		setSelectedSpeedId(null);
 	}, []);
 
 	const handleAudioSpanChange = useCallback((id: string, span: Span) => {
@@ -2927,18 +2780,6 @@ export default function VideoEditor() {
 		[selectedAudioId],
 	);
 
-	const handleSpeedChange = useCallback(
-		(speed: PlaybackSpeed) => {
-			if (!selectedSpeedId) return;
-			setSpeedRegions((prev) =>
-				prev.map((region) =>
-					region.id === selectedSpeedId ? { ...region, speed } : region,
-				),
-			);
-		},
-		[selectedSpeedId],
-	);
-
 	const handleAnnotationAdded = useCallback((span: Span, trackIndex = 0) => {
 		const id = `annotation-${nextAnnotationIdRef.current++}`;
 		const zIndex = nextAnnotationZIndexRef.current++; // Assign z-index based on creation order
@@ -2957,7 +2798,6 @@ export default function VideoEditor() {
 		setAnnotationRegions((prev) => [...prev, newRegion]);
 		setSelectedAnnotationId(id);
 		setSelectedZoomId(null);
-		setSelectedTrimId(null);
 	}, []);
 
 	const handleAnnotationSpanChange = useCallback((id: string, span: Span) => {
@@ -3148,12 +2988,6 @@ export default function VideoEditor() {
 	}, [selectedZoomId, zoomRegions]);
 
 	useEffect(() => {
-		if (selectedTrimId && !trimRegions.some((region) => region.id === selectedTrimId)) {
-			setSelectedTrimId(null);
-		}
-	}, [selectedTrimId, trimRegions]);
-
-	useEffect(() => {
 		if (
 			selectedAnnotationId &&
 			!annotationRegions.some((region) => region.id === selectedAnnotationId)
@@ -3161,12 +2995,6 @@ export default function VideoEditor() {
 			setSelectedAnnotationId(null);
 		}
 	}, [selectedAnnotationId, annotationRegions]);
-
-	useEffect(() => {
-		if (selectedSpeedId && !speedRegions.some((region) => region.id === selectedSpeedId)) {
-			setSelectedSpeedId(null);
-		}
-	}, [selectedSpeedId, speedRegions]);
 
 	useEffect(() => {
 		if (selectedAudioId && !audioRegions.some((region) => region.id === selectedAudioId)) {
@@ -3330,8 +3158,10 @@ export default function VideoEditor() {
 	}, []);
 
 	// Sync audio playback with video currentTime and isPlaying state
+	// currentTime is SOURCE time (from video element); audioRegions use TIMELINE coordinates
 	useEffect(() => {
 		const currentTimeMs = currentTime * 1000;
+		const timelineMs = mapSourceTimeToTimelineTime(currentTimeMs);
 		const activeSpeedRegion = speedRegions.find(
 			(region) => currentTimeMs >= region.startMs && currentTimeMs < region.endMs,
 		);
@@ -3341,10 +3171,10 @@ export default function VideoEditor() {
 			const audio = audioElementsRef.current.get(region.id);
 			if (!audio) continue;
 
-			const isInRegion = currentTimeMs >= region.startMs && currentTimeMs < region.endMs;
+			const isInRegion = timelineMs >= region.startMs && timelineMs < region.endMs;
 
 			if (isPlaying && isInRegion) {
-				const audioOffset = (currentTimeMs - region.startMs) / 1000;
+				const audioOffset = (timelineMs - region.startMs) / 1000;
 				// Only seek if significantly out of sync (> 200ms)
 				if (Math.abs(audio.currentTime - audioOffset) > 0.2) {
 					audio.currentTime = audioOffset;
@@ -3366,7 +3196,7 @@ export default function VideoEditor() {
 				}
 			}
 		}
-	}, [isPlaying, currentTime, audioRegions, speedRegions]);
+	}, [isPlaying, currentTime, audioRegions, speedRegions, mapSourceTimeToTimelineTime]);
 
 	useEffect(() => {
 		if (sourceAudioFallbackPaths.length === 0) {
@@ -4689,8 +4519,6 @@ export default function VideoEditor() {
 									selectedZoomId && handleZoomModeChange(mode)
 								}
 								onZoomDelete={handleZoomDelete}
-								selectedTrimId={selectedTrimId}
-								onTrimDelete={handleTrimDelete}
 								selectedClipId={selectedClipId}
 								selectedClipSpeed={
 									selectedClipId
@@ -4800,15 +4628,6 @@ export default function VideoEditor() {
 								}
 								onAnnotationBlurColorChange={handleAnnotationBlurColorChange}
 								onAnnotationDelete={handleAnnotationDelete}
-								selectedSpeedId={selectedSpeedId}
-								selectedSpeedValue={
-									selectedSpeedId
-										? (speedRegions.find((r) => r.id === selectedSpeedId)
-												?.speed ?? null)
-										: null
-								}
-								onSpeedChange={handleSpeedChange}
-								onSpeedDelete={handleSpeedDelete}
 							/>
 						)}
 					</div>
@@ -5205,22 +5024,11 @@ export default function VideoEditor() {
 						selectedZoomId={selectedZoomId}
 						onSelectZoom={handleSelectZoom}
 						trimRegions={trimRegions}
-						onTrimAdded={handleTrimAdded}
-						onTrimSpanChange={handleTrimSpanChange}
-						onTrimDelete={handleTrimDelete}
-						selectedTrimId={selectedTrimId}
-						onSelectTrim={handleSelectTrim}
 						clipRegions={clipRegions}
 						onClipSplit={handleClipSplit}
 						onClipSpanChange={handleClipSpanChange}
 						selectedClipId={selectedClipId}
 						onSelectClip={handleSelectClip}
-						speedRegions={speedRegions}
-						onSpeedAdded={handleSpeedAdded}
-						onSpeedSpanChange={handleSpeedSpanChange}
-						onSpeedDelete={handleSpeedDelete}
-						selectedSpeedId={selectedSpeedId}
-						onSelectSpeed={handleSelectSpeed}
 						audioRegions={audioRegions}
 						onAudioAdded={handleAudioAdded}
 						onAudioSpanChange={handleAudioSpanChange}

--- a/src/components/video-editor/hooks/useEditorRegions.ts
+++ b/src/components/video-editor/hooks/useEditorRegions.ts
@@ -1,0 +1,684 @@
+/**
+ * useEditorRegions – owns all timeline region state (zoom, clip,
+ * annotation, audio) together with every handler that mutates them.
+ *
+ * Trim regions are derived automatically from clips (gaps between clips).
+ * Speed regions are derived automatically from clip speeds.
+ * Neither trims nor speeds are user-editable as standalone entities.
+ */
+
+import type { Span } from "dnd-timeline";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { extensionHost } from "@/lib/extensions";
+import { deriveNextId } from "../projectPersistence";
+import {
+	type AnnotationRegion,
+	type AudioRegion,
+	type ClipRegion,
+	clampFocusToDepth,
+	clipsToTrims,
+	DEFAULT_ANNOTATION_POSITION,
+	DEFAULT_ANNOTATION_SIZE,
+	DEFAULT_ANNOTATION_STYLE,
+	DEFAULT_FIGURE_DATA,
+	type EditorEffectSection,
+	type FigureData,
+	getClipSourceEndMs,
+	getClipSourceStartMs,
+	type SpeedRegion,
+	type TrimRegion,
+	type ZoomDepth,
+	type ZoomFocus,
+	type ZoomMode,
+	type ZoomRegion,
+} from "../types";
+
+interface UseEditorRegionsParams {
+	duration: number;
+	currentTime: number;
+	videoPath: string | null;
+	setActiveEffectSection: (
+		section: EditorEffectSection | ((prev: EditorEffectSection) => EditorEffectSection),
+	) => void;
+}
+
+export function useEditorRegions({
+	duration,
+	currentTime,
+	videoPath,
+	setActiveEffectSection,
+}: UseEditorRegionsParams) {
+	// ─── Region state ───────────────────────────────────────────────────────
+	const [zoomRegions, setZoomRegions] = useState<ZoomRegion[]>([]);
+	const [clipRegions, setClipRegions] = useState<ClipRegion[]>([]);
+	const [annotationRegions, setAnnotationRegions] = useState<AnnotationRegion[]>([]);
+	const [audioRegions, setAudioRegions] = useState<AudioRegion[]>([]);
+
+	// ─── Selection state ────────────────────────────────────────────────────
+	const [selectedZoomId, setSelectedZoomId] = useState<string | null>(null);
+	const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
+	const [selectedAnnotationId, setSelectedAnnotationId] = useState<string | null>(null);
+	const [selectedAudioId, setSelectedAudioId] = useState<string | null>(null);
+
+	// ─── ID counters ────────────────────────────────────────────────────────
+	const nextZoomIdRef = useRef(1);
+	const nextClipIdRef = useRef(1);
+	const nextAnnotationIdRef = useRef(1);
+	const nextAnnotationZIndexRef = useRef(1);
+	const nextAudioIdRef = useRef(1);
+	const clipInitializedRef = useRef(false);
+	const autoSuggestedVideoPathRef = useRef<string | null>(null);
+	const pendingFreshRecordingAutoZoomPathRef = useRef<string | null>(null);
+
+	// ─── Derived ────────────────────────────────────────────────────────────
+	const totalMs = useMemo(() => Math.round(duration * 1000), [duration]);
+
+	// Initialise a single full-track clip when duration first becomes known
+	useEffect(() => {
+		if (totalMs <= 0 || clipInitializedRef.current) return;
+		if (clipRegions.length === 0) {
+			const id = `clip-${nextClipIdRef.current++}`;
+			setClipRegions([{ id, startMs: 0, endMs: totalMs, speed: 1 }]);
+		}
+		clipInitializedRef.current = true;
+	}, [totalMs, clipRegions.length]);
+
+	// Trim regions are derived from clips (gaps = sections to remove in export)
+	const trimRegions = useMemo<TrimRegion[]>(() => {
+		if (totalMs <= 0 || clipRegions.length === 0) return [];
+		return clipsToTrims(clipRegions, totalMs);
+	}, [clipRegions, totalMs]);
+
+	// Clear stale selection IDs when regions are removed externally
+	useEffect(() => {
+		if (selectedZoomId && !zoomRegions.some((r) => r.id === selectedZoomId))
+			setSelectedZoomId(null);
+	}, [selectedZoomId, zoomRegions]);
+	useEffect(() => {
+		if (selectedAnnotationId && !annotationRegions.some((r) => r.id === selectedAnnotationId))
+			setSelectedAnnotationId(null);
+	}, [selectedAnnotationId, annotationRegions]);
+	useEffect(() => {
+		if (selectedAudioId && !audioRegions.some((r) => r.id === selectedAudioId))
+			setSelectedAudioId(null);
+	}, [selectedAudioId, audioRegions]);
+
+	// ─── Time mapping ───────────────────────────────────────────────────────
+	const mapTimelineTimeToSourceTime = useCallback(
+		(timeMs: number) => {
+			for (const clip of clipRegions) {
+				if (timeMs < clip.startMs || timeMs > clip.endMs) continue;
+				const sourceStart = getClipSourceStartMs(clip);
+				const speed = Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
+				return Math.round(sourceStart + (timeMs - clip.startMs) * speed);
+			}
+			return Math.round(timeMs);
+		},
+		[clipRegions],
+	);
+
+	const mapSourceTimeToTimelineTime = useCallback(
+		(timeMs: number) => {
+			for (const clip of clipRegions) {
+				const sourceStart = getClipSourceStartMs(clip);
+				const sourceEndMs = getClipSourceEndMs(clip);
+				if (timeMs < sourceStart || timeMs > sourceEndMs) continue;
+				const speed = Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
+				return Math.round(clip.startMs + (timeMs - sourceStart) / speed);
+			}
+			return Math.round(timeMs);
+		},
+		[clipRegions],
+	);
+
+	// ─── Effective regions ──────────────────────────────────────────────────
+	const effectiveZoomRegions = useMemo<ZoomRegion[]>(
+		() =>
+			zoomRegions.map((r) => ({
+				...r,
+				startMs: mapTimelineTimeToSourceTime(r.startMs),
+				endMs: mapTimelineTimeToSourceTime(r.endMs),
+			})),
+		[zoomRegions, mapTimelineTimeToSourceTime],
+	);
+
+	// Speed regions derived purely from clip speeds (no standalone speed regions)
+	const effectiveSpeedRegions = useMemo<SpeedRegion[]>(
+		() =>
+			clipRegions
+				.filter((c) => c.speed !== 1)
+				.map((c) => ({
+					id: `clip-speed-${c.id}`,
+					startMs: getClipSourceStartMs(c),
+					endMs: getClipSourceEndMs(c),
+					speed: c.speed as SpeedRegion["speed"],
+				})),
+		[clipRegions],
+	);
+
+	const timelinePlayheadTime = useMemo(
+		() => mapSourceTimeToTimelineTime(currentTime * 1000) / 1000,
+		[currentTime, mapSourceTimeToTimelineTime],
+	);
+
+	// ─── Zoom handlers ──────────────────────────────────────────────────────
+	const handleZoomAdded = useCallback(
+		(span: Span) => {
+			const id = `zoom-${nextZoomIdRef.current++}`;
+			const newRegion: ZoomRegion = {
+				id,
+				startMs: Math.round(span.start),
+				endMs: Math.round(span.end),
+				depth: 3,
+				focus: { cx: 0.5, cy: 0.5 },
+				mode: "manual",
+			};
+			if (videoPath && pendingFreshRecordingAutoZoomPathRef.current === videoPath) {
+				autoSuggestedVideoPathRef.current = videoPath;
+				pendingFreshRecordingAutoZoomPathRef.current = null;
+			}
+			setZoomRegions((prev) => [...prev, newRegion]);
+			setSelectedZoomId(id);
+
+			setSelectedAnnotationId(null);
+			extensionHost.emitEvent({
+				type: "timeline:region-added",
+				data: { id, startMs: newRegion.startMs, endMs: newRegion.endMs },
+			});
+		},
+		[videoPath],
+	);
+
+	const handleZoomSuggested = useCallback(
+		(span: Span, focus: ZoomFocus) => {
+			const id = `zoom-${nextZoomIdRef.current++}`;
+			const newRegion: ZoomRegion = {
+				id,
+				startMs: Math.round(span.start),
+				endMs: Math.round(span.end),
+				depth: 2,
+				focus: clampFocusToDepth(focus, 2),
+				mode: "auto",
+			};
+			if (videoPath && pendingFreshRecordingAutoZoomPathRef.current === videoPath) {
+				autoSuggestedVideoPathRef.current = videoPath;
+				pendingFreshRecordingAutoZoomPathRef.current = null;
+			}
+			setZoomRegions((prev) => [...prev, newRegion]);
+			extensionHost.emitEvent({
+				type: "timeline:region-added",
+				data: { id, startMs: newRegion.startMs, endMs: newRegion.endMs },
+			});
+		},
+		[videoPath],
+	);
+
+	const handleZoomSpanChange = useCallback((id: string, span: Span) => {
+		setZoomRegions((prev) =>
+			prev.map((r) =>
+				r.id === id
+					? { ...r, startMs: Math.round(span.start), endMs: Math.round(span.end) }
+					: r,
+			),
+		);
+	}, []);
+
+	const handleZoomDelete = useCallback((id: string) => {
+		setZoomRegions((prev) => prev.filter((r) => r.id !== id));
+		setSelectedZoomId((cur) => (cur === id ? null : cur));
+		extensionHost.emitEvent({ type: "timeline:region-removed", data: { id } });
+	}, []);
+
+	const handleZoomFocusChange = useCallback((id: string, focus: ZoomFocus) => {
+		setZoomRegions((prev) =>
+			prev.map((r) => (r.id === id ? { ...r, focus: clampFocusToDepth(focus, r.depth) } : r)),
+		);
+	}, []);
+
+	const handleZoomDepthChange = useCallback(
+		(depth: ZoomDepth) => {
+			setZoomRegions((prev) =>
+				prev.map((r) =>
+					r.id === selectedZoomId
+						? { ...r, depth, focus: clampFocusToDepth(r.focus, depth) }
+						: r,
+				),
+			);
+		},
+		[selectedZoomId],
+	);
+
+	const handleZoomModeChange = useCallback(
+		(mode: ZoomMode) => {
+			setZoomRegions((prev) =>
+				prev.map((r) => (r.id === selectedZoomId ? { ...r, mode } : r)),
+			);
+		},
+		[selectedZoomId],
+	);
+
+	const handleSelectZoom = useCallback(
+		(id: string | null) => {
+			setSelectedZoomId(id);
+			if (id) {
+				setActiveEffectSection("zoom");
+				setSelectedAnnotationId(null);
+				setSelectedAudioId(null);
+			} else {
+				setActiveEffectSection((s) => (s === "zoom" ? "scene" : s));
+			}
+		},
+		[setActiveEffectSection],
+	);
+
+	// ─── Clip handlers ──────────────────────────────────────────────────────
+	const handleSelectClip = useCallback(
+		(id: string | null) => {
+			setSelectedClipId(id);
+			if (id) {
+				setActiveEffectSection("clip");
+				setSelectedZoomId(null);
+				setSelectedAnnotationId(null);
+				setSelectedAudioId(null);
+			} else {
+				setActiveEffectSection((s) => (s === "clip" ? "scene" : s));
+			}
+		},
+		[setActiveEffectSection],
+	);
+
+	const handleClipSplit = useCallback(
+		(splitMs: number) => {
+			setClipRegions((prev) => {
+				const target = prev.find((c) => splitMs > c.startMs && splitMs < c.endMs);
+				if (!target) return prev;
+				const leftId = `clip-${nextClipIdRef.current++}`;
+				const rightId = `clip-${nextClipIdRef.current++}`;
+				const speed = Number.isFinite(target.speed) && target.speed > 0 ? target.speed : 1;
+				const targetSourceStart = target.sourceStartMs ?? target.startMs;
+				const splitOffset = Math.round(splitMs) - target.startMs;
+				const rightSourceStart = Math.round(targetSourceStart + splitOffset * speed);
+				const left: ClipRegion = {
+					id: leftId,
+					startMs: target.startMs,
+					endMs: Math.round(splitMs),
+					speed: target.speed,
+					muted: target.muted,
+					sourceStartMs: target.sourceStartMs,
+				};
+				const right: ClipRegion = {
+					id: rightId,
+					startMs: Math.round(splitMs),
+					endMs: target.endMs,
+					speed: target.speed,
+					muted: target.muted,
+					sourceStartMs: rightSourceStart,
+				};
+				if (selectedClipId === target.id) setSelectedClipId(leftId);
+				return prev.flatMap((c) => (c.id === target.id ? [left, right] : [c]));
+			});
+		},
+		[selectedClipId],
+	);
+
+	const handleClipSpanChange = useCallback(
+		(id: string, span: Span) => {
+			const oldClip = clipRegions.find((c) => c.id === id);
+			const newStart = Math.round(span.start);
+			const newEnd = Math.round(span.end);
+			if (oldClip) {
+				const startDelta = newStart - oldClip.startMs;
+				const endDelta = newEnd - oldClip.endMs;
+				const isMove = Math.abs(startDelta - endDelta) < 1 && Math.abs(startDelta) > 0;
+				if (isMove) {
+					const delta = startDelta;
+					const moveOverlapping = <T extends { startMs: number; endMs: number }>(
+						regions: T[],
+					): T[] =>
+						regions.map((r) =>
+							r.startMs >= oldClip.startMs && r.endMs <= oldClip.endMs
+								? { ...r, startMs: r.startMs + delta, endMs: r.endMs + delta }
+								: r,
+						);
+					setZoomRegions((prev) => moveOverlapping(prev));
+					setAnnotationRegions((prev) => moveOverlapping(prev));
+					setAudioRegions((prev) => moveOverlapping(prev));
+				}
+			}
+			setClipRegions((prev) =>
+				prev.map((c) => (c.id === id ? { ...c, startMs: newStart, endMs: newEnd } : c)),
+			);
+		},
+		[clipRegions],
+	);
+
+	const handleClipSpeedChange = useCallback(
+		(speed: number) => {
+			if (!selectedClipId || !Number.isFinite(speed) || speed <= 0) return;
+			const clip = clipRegions.find((c) => c.id === selectedClipId);
+			if (!clip) return;
+			const oldSpeed = Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
+			const sourceDurationMs = (clip.endMs - clip.startMs) * oldSpeed;
+			const newEndMs = Math.round(clip.startMs + sourceDurationMs / speed);
+			const scaleFactor = oldSpeed / speed;
+			setClipRegions((prev) =>
+				prev.map((c) => (c.id === selectedClipId ? { ...c, speed, endMs: newEndMs } : c)),
+			);
+			// Scale all child regions within this clip proportionally
+			const scaleInClip = <T extends { startMs: number; endMs: number }>(regions: T[]): T[] =>
+				regions.map((r) => {
+					if (r.startMs < clip.startMs || r.startMs >= clip.endMs) return r;
+					return {
+						...r,
+						startMs: Math.round(
+							clip.startMs + (r.startMs - clip.startMs) * scaleFactor,
+						),
+						endMs: Math.round(clip.startMs + (r.endMs - clip.startMs) * scaleFactor),
+					};
+				});
+			setZoomRegions((prev) => scaleInClip(prev));
+			setAnnotationRegions((prev) => scaleInClip(prev));
+			setAudioRegions((prev) => scaleInClip(prev));
+		},
+		[selectedClipId, clipRegions],
+	);
+
+	const handleClipMutedChange = useCallback(
+		(muted: boolean) => {
+			if (!selectedClipId) return;
+			setClipRegions((prev) =>
+				prev.map((c) => (c.id === selectedClipId ? { ...c, muted } : c)),
+			);
+		},
+		[selectedClipId],
+	);
+
+	const handleClipDelete = useCallback(
+		(id: string) => {
+			const deletedClip = clipRegions.find((c) => c.id === id);
+			setClipRegions((prev) => prev.filter((c) => c.id !== id));
+			if (deletedClip) {
+				const { startMs, endMs } = deletedClip;
+				// Cascade: remove all timeline items fully within the deleted clip's span
+				setZoomRegions((prev) =>
+					prev.filter((r) => r.startMs < startMs || r.endMs > endMs),
+				);
+				setAnnotationRegions((prev) =>
+					prev.filter((r) => r.startMs < startMs || r.endMs > endMs),
+				);
+				setAudioRegions((prev) =>
+					prev.filter((r) => r.startMs < startMs || r.endMs > endMs),
+				);
+			}
+			setSelectedClipId((cur) => (cur === id ? null : cur));
+		},
+		[clipRegions],
+	);
+
+	// ─── Annotation handlers ─────────────────────────────────────────────────
+	const handleSelectAnnotation = useCallback((id: string | null) => {
+		setSelectedAnnotationId(id);
+		if (id) {
+			setSelectedZoomId(null);
+			setSelectedAudioId(null);
+		}
+	}, []);
+
+	const handleAnnotationAdded = useCallback((span: Span, trackIndex = 0) => {
+		const id = `annotation-${nextAnnotationIdRef.current++}`;
+		const zIndex = nextAnnotationZIndexRef.current++;
+		const newRegion: AnnotationRegion = {
+			id,
+			startMs: Math.round(span.start),
+			endMs: Math.round(span.end),
+			type: "text",
+			content: "Enter text...",
+			position: { ...DEFAULT_ANNOTATION_POSITION },
+			size: { ...DEFAULT_ANNOTATION_SIZE },
+			style: { ...DEFAULT_ANNOTATION_STYLE },
+			zIndex,
+			trackIndex,
+		};
+		setAnnotationRegions((prev) => [...prev, newRegion]);
+		setSelectedAnnotationId(id);
+		setSelectedZoomId(null);
+	}, []);
+
+	const handleAnnotationSpanChange = useCallback((id: string, span: Span) => {
+		setAnnotationRegions((prev) =>
+			prev.map((r) =>
+				r.id === id
+					? { ...r, startMs: Math.round(span.start), endMs: Math.round(span.end) }
+					: r,
+			),
+		);
+	}, []);
+
+	const handleAnnotationDelete = useCallback((id: string) => {
+		setAnnotationRegions((prev) => prev.filter((r) => r.id !== id));
+		setSelectedAnnotationId((cur) => (cur === id ? null : cur));
+	}, []);
+
+	const handleAnnotationContentChange = useCallback((id: string, content: string) => {
+		setAnnotationRegions((prev) =>
+			prev.map((r) => {
+				if (r.id !== id) return r;
+				if (r.type === "text") return { ...r, content, textContent: content };
+				if (r.type === "image") return { ...r, content, imageContent: content };
+				return { ...r, content };
+			}),
+		);
+	}, []);
+
+	const handleAnnotationTypeChange = useCallback((id: string, type: AnnotationRegion["type"]) => {
+		setAnnotationRegions((prev) =>
+			prev.map((r) => {
+				if (r.id !== id) return r;
+				const updated = { ...r, type };
+				if (type === "text") updated.content = r.textContent || "Enter text...";
+				else if (type === "image") updated.content = r.imageContent || "";
+				else if (type === "figure") {
+					updated.content = "";
+					if (!r.figureData)
+						(updated as AnnotationRegion).figureData = { ...DEFAULT_FIGURE_DATA };
+				} else if (type === "blur") {
+					updated.content = "";
+					if (r.blurIntensity === undefined)
+						(updated as AnnotationRegion).blurIntensity = 20;
+				}
+				return updated;
+			}),
+		);
+	}, []);
+
+	const handleAnnotationStyleChange = useCallback(
+		(id: string, style: Partial<AnnotationRegion["style"]>) => {
+			setAnnotationRegions((prev) =>
+				prev.map((r) => (r.id === id ? { ...r, style: { ...r.style, ...style } } : r)),
+			);
+		},
+		[],
+	);
+
+	const handleAnnotationFigureDataChange = useCallback((id: string, figureData: FigureData) => {
+		setAnnotationRegions((prev) => prev.map((r) => (r.id === id ? { ...r, figureData } : r)));
+	}, []);
+
+	const handleAnnotationBlurIntensityChange = useCallback((id: string, blurIntensity: number) => {
+		setAnnotationRegions((prev) =>
+			prev.map((r) => (r.id === id ? { ...r, blurIntensity } : r)),
+		);
+	}, []);
+
+	const handleAnnotationBlurColorChange = useCallback((id: string, blurColor: string) => {
+		setAnnotationRegions((prev) => prev.map((r) => (r.id === id ? { ...r, blurColor } : r)));
+	}, []);
+
+	const handleAnnotationPositionChange = useCallback(
+		(id: string, position: { x: number; y: number }) => {
+			setAnnotationRegions((prev) => prev.map((r) => (r.id === id ? { ...r, position } : r)));
+		},
+		[],
+	);
+
+	const handleAnnotationSizeChange = useCallback(
+		(id: string, size: { width: number; height: number }) => {
+			setAnnotationRegions((prev) => prev.map((r) => (r.id === id ? { ...r, size } : r)));
+		},
+		[],
+	);
+
+	// ─── Audio handlers ──────────────────────────────────────────────────────
+	const handleSelectAudio = useCallback((id: string | null) => {
+		setSelectedAudioId(id);
+		if (id) {
+			setSelectedZoomId(null);
+			setSelectedAnnotationId(null);
+		}
+	}, []);
+
+	const handleAudioAdded = useCallback((span: Span, audioPath: string, trackIndex?: number) => {
+		const id = `audio-${nextAudioIdRef.current++}`;
+		setAudioRegions((prev) => [
+			...prev,
+			{
+				id,
+				startMs: Math.round(span.start),
+				endMs: Math.round(span.end),
+				audioPath,
+				volume: 1,
+				trackIndex,
+			},
+		]);
+		setSelectedAudioId(id);
+		setSelectedZoomId(null);
+		setSelectedAnnotationId(null);
+	}, []);
+
+	const handleAudioSpanChange = useCallback((id: string, span: Span) => {
+		setAudioRegions((prev) =>
+			prev.map((r) =>
+				r.id === id
+					? { ...r, startMs: Math.round(span.start), endMs: Math.round(span.end) }
+					: r,
+			),
+		);
+	}, []);
+
+	const handleAudioDelete = useCallback((id: string) => {
+		setAudioRegions((prev) => prev.filter((r) => r.id !== id));
+		setSelectedAudioId((cur) => (cur === id ? null : cur));
+	}, []);
+
+	/** Reset ALL region state from a freshly loaded project. */
+	const resetForProject = useCallback(
+		(editor: {
+			zoomRegions: ZoomRegion[];
+			clipRegions: ClipRegion[];
+			annotationRegions: AnnotationRegion[];
+			audioRegions: AudioRegion[];
+		}) => {
+			setZoomRegions(editor.zoomRegions);
+			setClipRegions(editor.clipRegions);
+			clipInitializedRef.current = editor.clipRegions.length > 0;
+			setAnnotationRegions(editor.annotationRegions);
+			setAudioRegions(editor.audioRegions);
+			setSelectedZoomId(null);
+			setSelectedClipId(null);
+			setSelectedAnnotationId(null);
+			setSelectedAudioId(null);
+			nextZoomIdRef.current = deriveNextId(
+				"zoom",
+				editor.zoomRegions.map((r) => r.id),
+			);
+			nextClipIdRef.current = deriveNextId(
+				"clip",
+				editor.clipRegions.map((r) => r.id),
+			);
+			nextAnnotationIdRef.current = deriveNextId(
+				"annotation",
+				editor.annotationRegions.map((r) => r.id),
+			);
+			nextAudioIdRef.current = deriveNextId(
+				"audio",
+				editor.audioRegions.map((r) => r.id),
+			);
+			nextAnnotationZIndexRef.current =
+				editor.annotationRegions.reduce((max, r) => Math.max(max, r.zIndex), 0) + 1;
+		},
+		[],
+	);
+
+	return {
+		// State
+		zoomRegions,
+		setZoomRegions,
+		trimRegions,
+		clipRegions,
+		setClipRegions,
+		annotationRegions,
+		setAnnotationRegions,
+		audioRegions,
+		setAudioRegions,
+		// Selections
+		selectedZoomId,
+		setSelectedZoomId,
+		selectedClipId,
+		setSelectedClipId,
+		selectedAnnotationId,
+		setSelectedAnnotationId,
+		selectedAudioId,
+		setSelectedAudioId,
+		// Refs
+		nextZoomIdRef,
+		nextClipIdRef,
+		nextAnnotationIdRef,
+		nextAnnotationZIndexRef,
+		nextAudioIdRef,
+		clipInitializedRef,
+		autoSuggestedVideoPathRef,
+		pendingFreshRecordingAutoZoomPathRef,
+		// Derived
+		effectiveZoomRegions,
+		effectiveSpeedRegions,
+		mapTimelineTimeToSourceTime,
+		mapSourceTimeToTimelineTime,
+		timelinePlayheadTime,
+		// Zoom
+		handleZoomAdded,
+		handleZoomSuggested,
+		handleZoomSpanChange,
+		handleZoomDelete,
+		handleZoomFocusChange,
+		handleZoomDepthChange,
+		handleZoomModeChange,
+		handleSelectZoom,
+		// Clip
+		handleSelectClip,
+		handleClipSplit,
+		handleClipSpanChange,
+		handleClipSpeedChange,
+		handleClipMutedChange,
+		handleClipDelete,
+		// Annotation
+		handleSelectAnnotation,
+		handleAnnotationAdded,
+		handleAnnotationSpanChange,
+		handleAnnotationDelete,
+		handleAnnotationContentChange,
+		handleAnnotationTypeChange,
+		handleAnnotationStyleChange,
+		handleAnnotationFigureDataChange,
+		handleAnnotationBlurIntensityChange,
+		handleAnnotationBlurColorChange,
+		handleAnnotationPositionChange,
+		handleAnnotationSizeChange,
+		// Audio
+		handleSelectAudio,
+		handleAudioAdded,
+		handleAudioSpanChange,
+		handleAudioDelete,
+		// Project reset
+		resetForProject,
+	};
+}

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -405,6 +405,9 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 						endMs,
 						speed: isFiniteNumber(region.speed) ? region.speed : 1,
 						muted: typeof region.muted === "boolean" ? region.muted : false,
+						...(isFiniteNumber(region.sourceStartMs)
+							? { sourceStartMs: Math.round(region.sourceStartMs) }
+							: {}),
 					};
 				})
 		: [];

--- a/src/components/video-editor/timeline/AudioWaveform.tsx
+++ b/src/components/video-editor/timeline/AudioWaveform.tsx
@@ -83,7 +83,7 @@ export default function AudioWaveform({ peaks }: AudioWaveformProps) {
 		<canvas
 			ref={setCanvasRef}
 			className="absolute inset-0 w-full h-full pointer-events-none"
-			style={{ zIndex: 0 }}
+			style={{ display: "block" }}
 		/>
 	);
 }

--- a/src/components/video-editor/timeline/Row.tsx
+++ b/src/components/video-editor/timeline/Row.tsx
@@ -30,7 +30,7 @@ export default function Row({ id, children, label, hint, isEmpty, labelColor = "
 					<span className="text-[11px] text-foreground/15 font-medium">{hint}</span>
 				</div>
 			)}
-			<div ref={setNodeRef} className="relative h-full min-h-0" style={rowStyle}>
+			<div ref={setNodeRef} className="relative h-full min-h-0 overflow-hidden" style={rowStyle}>
 				{children}
 			</div>
 		</div>

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -1,5 +1,3 @@
-import type { Range, Span } from "dnd-timeline";
-import { useTimelineContext } from "dnd-timeline";
 import {
 	Check,
 	CaretDown as ChevronDown,
@@ -11,6 +9,8 @@ import {
 	MagicWand as WandSparkles,
 	MagnifyingGlassPlus as ZoomIn,
 } from "@phosphor-icons/react";
+import type { Range, Span } from "dnd-timeline";
+import { useTimelineContext } from "dnd-timeline";
 import {
 	forwardRef,
 	type KeyboardEvent as ReactKeyboardEvent,

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -49,7 +49,6 @@ import type {
 	AudioRegion,
 	ClipRegion,
 	CursorTelemetryPoint,
-	SpeedRegion,
 	TrimRegion,
 	ZoomFocus,
 	ZoomMode,
@@ -123,11 +122,6 @@ interface TimelineEditorProps {
 	selectedZoomId: string | null;
 	onSelectZoom: (id: string | null) => void;
 	trimRegions?: TrimRegion[];
-	onTrimAdded?: (span: Span) => void;
-	onTrimSpanChange?: (id: string, span: Span) => void;
-	onTrimDelete?: (id: string) => void;
-	selectedTrimId?: string | null;
-	onSelectTrim?: (id: string | null) => void;
 	clipRegions?: ClipRegion[];
 	onClipSplit?: (splitMs: number) => void;
 	onClipSpanChange?: (id: string, span: Span) => void;
@@ -140,12 +134,6 @@ interface TimelineEditorProps {
 	onAnnotationDelete?: (id: string) => void;
 	selectedAnnotationId?: string | null;
 	onSelectAnnotation?: (id: string | null) => void;
-	speedRegions?: SpeedRegion[];
-	onSpeedAdded?: (span: Span) => void;
-	onSpeedSpanChange?: (id: string, span: Span) => void;
-	onSpeedDelete?: (id: string) => void;
-	selectedSpeedId?: string | null;
-	onSelectSpeed?: (id: string | null) => void;
 	audioRegions?: AudioRegion[];
 	onAudioAdded?: (span: Span, audioPath: string, trackIndex?: number) => void;
 	onAudioSpanChange?: (id: string, span: Span) => void;
@@ -585,16 +573,12 @@ function Timeline({
 	currentTimeMs,
 	onSeek,
 	onSelectZoom,
-	onSelectTrim,
 	onSelectClip,
 	onSelectAnnotation,
-	onSelectSpeed,
 	onSelectAudio,
 	selectedZoomId,
-	selectedTrimId: _selectedTrimId,
 	selectedClipId,
 	selectedAnnotationId,
-	selectedSpeedId: _selectedSpeedId,
 	selectedAudioId,
 	selectAllBlocksActive = false,
 	onClearBlockSelection,
@@ -606,16 +590,12 @@ function Timeline({
 	currentTimeMs: number;
 	onSeek?: (time: number) => void;
 	onSelectZoom?: (id: string | null) => void;
-	onSelectTrim?: (id: string | null) => void;
 	onSelectClip?: (id: string | null) => void;
 	onSelectAnnotation?: (id: string | null) => void;
-	onSelectSpeed?: (id: string | null) => void;
 	onSelectAudio?: (id: string | null) => void;
 	selectedZoomId: string | null;
-	selectedTrimId?: string | null;
 	selectedClipId?: string | null;
 	selectedAnnotationId?: string | null;
-	selectedSpeedId?: string | null;
 	selectedAudioId?: string | null;
 	selectAllBlocksActive?: boolean;
 	onClearBlockSelection?: () => void;
@@ -640,10 +620,8 @@ function Timeline({
 			// Only clear selection if clicking on empty space (not on items)
 			// This is handled by event propagation - items stop propagation
 			onSelectZoom?.(null);
-			onSelectTrim?.(null);
 			onSelectClip?.(null);
 			onSelectAnnotation?.(null);
-			onSelectSpeed?.(null);
 			onSelectAudio?.(null);
 			onClearBlockSelection?.();
 
@@ -661,10 +639,8 @@ function Timeline({
 		[
 			onSeek,
 			onSelectZoom,
-			onSelectTrim,
 			onSelectClip,
 			onSelectAnnotation,
-			onSelectSpeed,
 			onSelectAudio,
 			onClearBlockSelection,
 			videoDurationMs,
@@ -839,11 +815,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			selectedZoomId,
 			onSelectZoom,
 			trimRegions = [],
-			onTrimAdded,
-			onTrimSpanChange,
-			onTrimDelete,
-			selectedTrimId,
-			onSelectTrim,
 			clipRegions = [],
 			onClipSplit,
 			onClipSpanChange,
@@ -856,12 +827,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			onAnnotationDelete,
 			selectedAnnotationId,
 			onSelectAnnotation,
-			speedRegions = [],
-			onSpeedAdded,
-			onSpeedSpanChange,
-			onSpeedDelete,
-			selectedSpeedId,
-			onSelectSpeed,
 			audioRegions = [],
 			onAudioAdded,
 			onAudioSpanChange,
@@ -1003,13 +968,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			onSelectZoom(null);
 		}, [selectedZoomId, onZoomDelete, onSelectZoom]);
 
-		// Delete selected trim item
-		const deleteSelectedTrim = useCallback(() => {
-			if (!selectedTrimId || !onTrimDelete || !onSelectTrim) return;
-			onTrimDelete(selectedTrimId);
-			onSelectTrim(null);
-		}, [selectedTrimId, onTrimDelete, onSelectTrim]);
-
 		const deleteSelectedClip = useCallback(() => {
 			if (!selectedClipId || !onClipDelete || !onSelectClip) return;
 			onClipDelete(selectedClipId);
@@ -1022,12 +980,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			onSelectAnnotation(null);
 		}, [selectedAnnotationId, onAnnotationDelete, onSelectAnnotation]);
 
-		const deleteSelectedSpeed = useCallback(() => {
-			if (!selectedSpeedId || !onSpeedDelete || !onSelectSpeed) return;
-			onSpeedDelete(selectedSpeedId);
-			onSelectSpeed(null);
-		}, [selectedSpeedId, onSpeedDelete, onSelectSpeed]);
-
 		const deleteSelectedAudio = useCallback(() => {
 			if (!selectedAudioId || !onAudioDelete || !onSelectAudio) return;
 			onAudioDelete(selectedAudioId);
@@ -1036,42 +988,28 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 
 		const clearSelectedBlocks = useCallback(() => {
 			onSelectZoom(null);
-			onSelectTrim?.(null);
 			onSelectClip?.(null);
 			onSelectAnnotation?.(null);
-			onSelectSpeed?.(null);
 			onSelectAudio?.(null);
 			setSelectAllBlocksActive(false);
-		}, [
-			onSelectAnnotation,
-			onSelectAudio,
-			onSelectClip,
-			onSelectSpeed,
-			onSelectTrim,
-			onSelectZoom,
-		]);
+		}, [onSelectAnnotation, onSelectAudio, onSelectClip, onSelectZoom]);
 
 		const hasAnyTimelineBlocks =
 			zoomRegions.length > 0 ||
 			trimRegions.length > 0 ||
 			clipRegions.length > 0 ||
 			annotationRegions.length > 0 ||
-			speedRegions.length > 0 ||
 			audioRegions.length > 0;
 
 		const deleteAllBlocks = useCallback(() => {
 			const zoomIds = zoomRegions.map((region) => region.id);
-			const trimIds = trimRegions.map((region) => region.id);
 			const clipIds = clipRegions.map((region) => region.id);
 			const annotationIds = annotationRegions.map((region) => region.id);
-			const speedIds = speedRegions.map((region) => region.id);
 			const audioIds = audioRegions.map((region) => region.id);
 
 			zoomIds.forEach((id) => onZoomDelete(id));
-			trimIds.forEach((id) => onTrimDelete?.(id));
 			clipIds.forEach((id) => onClipDelete?.(id));
 			annotationIds.forEach((id) => onAnnotationDelete?.(id));
-			speedIds.forEach((id) => onSpeedDelete?.(id));
 			audioIds.forEach((id) => onAudioDelete?.(id));
 
 			clearSelectedBlocks();
@@ -1084,11 +1022,7 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			onAnnotationDelete,
 			onAudioDelete,
 			onClipDelete,
-			onSpeedDelete,
-			onTrimDelete,
 			onZoomDelete,
-			speedRegions,
-			trimRegions,
 			zoomRegions,
 		]);
 
@@ -1098,14 +1032,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				onSelectZoom(id);
 			},
 			[onSelectZoom],
-		);
-
-		const handleSelectTrim = useCallback(
-			(id: string | null) => {
-				setSelectAllBlocksActive(false);
-				onSelectTrim?.(id);
-			},
-			[onSelectTrim],
 		);
 
 		const handleSelectClip = useCallback(
@@ -1122,14 +1048,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				onSelectAnnotation?.(id);
 			},
 			[onSelectAnnotation],
-		);
-
-		const handleSelectSpeed = useCallback(
-			(id: string | null) => {
-				setSelectAllBlocksActive(false);
-				onSelectSpeed?.(id);
-			},
-			[onSelectSpeed],
 		);
 
 		const handleSelectAudio = useCallback(
@@ -1149,11 +1067,9 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 		// this effect on every drag/resize and races with dnd-timeline's internal state.
 		const zoomRegionsRef = useRef(zoomRegions);
 		const trimRegionsRef = useRef(trimRegions);
-		const speedRegionsRef = useRef(speedRegions);
 		const audioRegionsRef = useRef(audioRegions);
 		zoomRegionsRef.current = zoomRegions;
 		trimRegionsRef.current = trimRegions;
-		speedRegionsRef.current = speedRegions;
 		audioRegionsRef.current = audioRegions;
 
 		useEffect(() => {
@@ -1176,36 +1092,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				}
 			});
 
-			trimRegionsRef.current.forEach((region) => {
-				const clampedStart = Math.max(0, Math.min(region.startMs, totalMs));
-				const minEnd = clampedStart + safeMinDurationMs;
-				const clampedEnd = Math.min(totalMs, Math.max(minEnd, region.endMs));
-				const normalizedStart = Math.max(
-					0,
-					Math.min(clampedStart, totalMs - safeMinDurationMs),
-				);
-				const normalizedEnd = Math.max(minEnd, Math.min(clampedEnd, totalMs));
-
-				if (normalizedStart !== region.startMs || normalizedEnd !== region.endMs) {
-					onTrimSpanChange?.(region.id, { start: normalizedStart, end: normalizedEnd });
-				}
-			});
-
-			speedRegionsRef.current.forEach((region) => {
-				const clampedStart = Math.max(0, Math.min(region.startMs, totalMs));
-				const minEnd = clampedStart + safeMinDurationMs;
-				const clampedEnd = Math.min(totalMs, Math.max(minEnd, region.endMs));
-				const normalizedStart = Math.max(
-					0,
-					Math.min(clampedStart, totalMs - safeMinDurationMs),
-				);
-				const normalizedEnd = Math.max(minEnd, Math.min(clampedEnd, totalMs));
-
-				if (normalizedStart !== region.startMs || normalizedEnd !== region.endMs) {
-					onSpeedSpanChange?.(region.id, { start: normalizedStart, end: normalizedEnd });
-				}
-			});
-
 			audioRegionsRef.current.forEach((region) => {
 				const clampedStart = Math.max(0, Math.min(region.startMs, totalMs));
 				const minEnd = clampedStart + safeMinDurationMs;
@@ -1221,23 +1107,14 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				}
 			});
 			// Only re-run when the timeline scale changes, not on every region edit
-		}, [
-			totalMs,
-			safeMinDurationMs,
-			onZoomSpanChange,
-			onTrimSpanChange,
-			onSpeedSpanChange,
-			onAudioSpanChange,
-		]);
+		}, [totalMs, safeMinDurationMs, onZoomSpanChange, onAudioSpanChange]);
 
 		const hasOverlap = useCallback(
 			(newSpan: Span, excludeId?: string): boolean => {
 				// Determine which row the item belongs to
 				const isZoomItem = zoomRegions.some((r) => r.id === excludeId);
-				const isTrimItem = trimRegions.some((r) => r.id === excludeId);
 				const isClipItem = clipRegions.some((r) => r.id === excludeId);
 				const isAnnotationItem = annotationRegions.some((r) => r.id === excludeId);
-				const isSpeedItem = speedRegions.some((r) => r.id === excludeId);
 				const isAudioItem = audioRegions.some((r) => r.id === excludeId);
 
 				if (isAnnotationItem) {
@@ -1246,7 +1123,7 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 
 				// Helper to check overlap against a specific set of regions
 				const checkOverlap = (
-					regions: (ZoomRegion | TrimRegion | ClipRegion | SpeedRegion | AudioRegion)[],
+					regions: (ZoomRegion | TrimRegion | ClipRegion | AudioRegion)[],
 				) => {
 					return regions.some((region) => {
 						if (region.id === excludeId) return false;
@@ -1259,16 +1136,8 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 					return checkOverlap(zoomRegions);
 				}
 
-				if (isTrimItem) {
-					return checkOverlap(trimRegions);
-				}
-
 				if (isClipItem) {
 					return checkOverlap(clipRegions);
-				}
-
-				if (isSpeedItem) {
-					return checkOverlap(speedRegions);
 				}
 
 				if (isAudioItem) {
@@ -1277,7 +1146,7 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 
 				return false;
 			},
-			[zoomRegions, trimRegions, clipRegions, annotationRegions, speedRegions, audioRegions],
+			[zoomRegions, clipRegions, annotationRegions, audioRegions],
 		);
 
 		// Keep newly added timeline regions at the original short default instead of
@@ -1408,92 +1277,12 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			handleSuggestZooms();
 		}, [autoSuggestZoomsTrigger, handleSuggestZooms, onAutoSuggestZoomsConsumed]);
 
-		const handleAddTrim = useCallback(() => {
-			if (!videoDuration || videoDuration === 0 || totalMs === 0 || !onTrimAdded) {
-				return;
-			}
-
-			const defaultDuration = Math.min(defaultRegionDurationMs, totalMs);
-			if (defaultDuration <= 0) {
-				return;
-			}
-
-			// Always place trim at playhead
-			const startPos = Math.max(0, Math.min(currentTimeMs, totalMs));
-			// Find the next trim region after the playhead
-			const sorted = [...trimRegions].sort((a, b) => a.startMs - b.startMs);
-			const nextRegion = sorted.find((region) => region.startMs > startPos);
-			const gapToNext = nextRegion ? nextRegion.startMs - startPos : totalMs - startPos;
-
-			// Check if playhead is inside any trim region
-			const isOverlapping = sorted.some(
-				(region) => startPos >= region.startMs && startPos < region.endMs,
-			);
-			if (isOverlapping || gapToNext <= 0) {
-				toast.error("Cannot place trim here", {
-					description:
-						"Trim already exists at this location or not enough space available.",
-				});
-				return;
-			}
-
-			const actualDuration = Math.min(defaultRegionDurationMs, gapToNext);
-			onTrimAdded({ start: startPos, end: startPos + actualDuration });
-		}, [
-			videoDuration,
-			totalMs,
-			currentTimeMs,
-			trimRegions,
-			onTrimAdded,
-			defaultRegionDurationMs,
-		]);
-
 		const handleSplitClip = useCallback(() => {
 			if (!videoDuration || videoDuration === 0 || totalMs === 0 || !onClipSplit) {
 				return;
 			}
 			onClipSplit(currentTimeMs);
 		}, [videoDuration, totalMs, currentTimeMs, onClipSplit]);
-
-		const handleAddSpeed = useCallback(() => {
-			if (!videoDuration || videoDuration === 0 || totalMs === 0 || !onSpeedAdded) {
-				return;
-			}
-
-			const defaultDuration = Math.min(defaultRegionDurationMs, totalMs);
-			if (defaultDuration <= 0) {
-				return;
-			}
-
-			// Always place speed region at playhead
-			const startPos = Math.max(0, Math.min(currentTimeMs, totalMs));
-			// Find the next speed region after the playhead
-			const sorted = [...speedRegions].sort((a, b) => a.startMs - b.startMs);
-			const nextRegion = sorted.find((region) => region.startMs > startPos);
-			const gapToNext = nextRegion ? nextRegion.startMs - startPos : totalMs - startPos;
-
-			// Check if playhead is inside any speed region
-			const isOverlapping = sorted.some(
-				(region) => startPos >= region.startMs && startPos < region.endMs,
-			);
-			if (isOverlapping || gapToNext <= 0) {
-				toast.error("Cannot place speed here", {
-					description:
-						"Speed region already exists at this location or not enough space available.",
-				});
-				return;
-			}
-
-			const actualDuration = Math.min(defaultRegionDurationMs, gapToNext);
-			onSpeedAdded({ start: startPos, end: startPos + actualDuration });
-		}, [
-			videoDuration,
-			totalMs,
-			currentTimeMs,
-			speedRegions,
-			onSpeedAdded,
-			defaultRegionDurationMs,
-		]);
 
 		const handleAddAudio = useCallback(async () => {
 			if (!videoDuration || videoDuration === 0 || totalMs === 0 || !onAudioAdded) {
@@ -1592,17 +1381,11 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				if (matchesShortcut(e, keyShortcuts.addZoom, isMac)) {
 					handleAddZoom();
 				}
-				if (matchesShortcut(e, keyShortcuts.addTrim, isMac)) {
-					handleAddTrim();
-				}
 				if (matchesShortcut(e, keyShortcuts.splitClip, isMac)) {
 					handleSplitClip();
 				}
 				if (matchesShortcut(e, keyShortcuts.addAnnotation, isMac)) {
 					handleAddAnnotation();
-				}
-				if (matchesShortcut(e, keyShortcuts.addSpeed, isMac)) {
-					handleAddSpeed();
 				}
 
 				// Tab: Cycle through overlapping annotations at current time
@@ -1644,14 +1427,10 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 						deleteSelectedKeyframe();
 					} else if (selectedZoomId) {
 						deleteSelectedZoom();
-					} else if (selectedTrimId) {
-						deleteSelectedTrim();
 					} else if (selectedClipId) {
 						deleteSelectedClip();
 					} else if (selectedAnnotationId) {
 						deleteSelectedAnnotation();
-					} else if (selectedSpeedId) {
-						deleteSelectedSpeed();
 					} else if (selectedAudioId) {
 						deleteSelectedAudio();
 					}
@@ -1662,24 +1441,18 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 		}, [
 			addKeyframe,
 			handleAddZoom,
-			handleAddTrim,
 			handleSplitClip,
 			handleAddAnnotation,
-			handleAddSpeed,
 			deleteAllBlocks,
 			deleteSelectedKeyframe,
 			deleteSelectedZoom,
-			deleteSelectedTrim,
 			deleteSelectedClip,
 			deleteSelectedAnnotation,
-			deleteSelectedSpeed,
 			deleteSelectedAudio,
 			selectedKeyframeId,
 			selectedZoomId,
-			selectedTrimId,
 			selectedClipId,
 			selectedAnnotationId,
-			selectedSpeedId,
 			selectedAudioId,
 			annotationRegions,
 			currentTimeMs,
@@ -1805,33 +1578,25 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 
 		const handleItemSpanChange = useCallback(
 			(id: string, span: Span) => {
-				// Check if it's a zoom, trim, clip, speed, or annotation item
+				// Check if it's a zoom, clip, annotation, or audio item
 				if (zoomRegions.some((r) => r.id === id)) {
 					onZoomSpanChange(id, span);
-				} else if (trimRegions.some((r) => r.id === id)) {
-					onTrimSpanChange?.(id, span);
 				} else if (clipRegions.some((r) => r.id === id)) {
 					onClipSpanChange?.(id, span);
 				} else if (annotationRegions.some((r) => r.id === id)) {
 					onAnnotationSpanChange?.(id, span);
-				} else if (speedRegions.some((r) => r.id === id)) {
-					onSpeedSpanChange?.(id, span);
 				} else if (audioRegions.some((r) => r.id === id)) {
 					onAudioSpanChange?.(id, span);
 				}
 			},
 			[
 				zoomRegions,
-				trimRegions,
 				clipRegions,
 				annotationRegions,
-				speedRegions,
 				audioRegions,
 				onZoomSpanChange,
-				onTrimSpanChange,
 				onClipSpanChange,
 				onAnnotationSpanChange,
-				onSpeedSpanChange,
 				onAudioSpanChange,
 			],
 		);
@@ -2115,16 +1880,12 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 							currentTimeMs={currentTimeMs}
 							onSeek={onSeek}
 							onSelectZoom={handleSelectZoom}
-							onSelectTrim={handleSelectTrim}
 							onSelectClip={handleSelectClip}
 							onSelectAnnotation={handleSelectAnnotation}
-							onSelectSpeed={handleSelectSpeed}
 							onSelectAudio={handleSelectAudio}
 							selectedZoomId={selectedZoomId}
-							selectedTrimId={selectedTrimId}
 							selectedClipId={selectedClipId}
 							selectedAnnotationId={selectedAnnotationId}
-							selectedSpeedId={selectedSpeedId}
 							selectedAudioId={selectedAudioId}
 							selectAllBlocksActive={selectAllBlocksActive}
 							onClearBlockSelection={clearSelectedBlocks}

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -147,24 +147,33 @@ export interface ClipRegion {
 	endMs: number;
 	speed: number;
 	muted?: boolean;
+	/** Source video start position. Defaults to startMs when omitted (speed=1 clips). */
+	sourceStartMs?: number;
+}
+
+/** Get the source-coordinate start position of a clip. */
+export function getClipSourceStartMs(clip: ClipRegion): number {
+	return clip.sourceStartMs ?? clip.startMs;
 }
 
 export function getClipSourceEndMs(clip: ClipRegion): number {
+	const sourceStart = clip.sourceStartMs ?? clip.startMs;
 	const displayDurationMs = Math.max(0, clip.endMs - clip.startMs);
 	const speed = Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
-	return Math.round(clip.startMs + displayDurationMs * speed);
+	return Math.round(sourceStart + displayDurationMs * speed);
 }
 
 /** Convert clip regions (kept segments) to trim regions (gaps to remove). */
 export function clipsToTrims(clips: ClipRegion[], totalDurationMs: number): TrimRegion[] {
 	if (clips.length === 0) return [];
-	const sorted = [...clips].sort((a, b) => a.startMs - b.startMs);
+	const sorted = [...clips].sort((a, b) => getClipSourceStartMs(a) - getClipSourceStartMs(b));
 	const trims: TrimRegion[] = [];
 	let cursor = 0;
 	let trimId = 1;
 	for (const clip of sorted) {
-		if (clip.startMs > cursor) {
-			trims.push({ id: `trim-gap-${trimId++}`, startMs: cursor, endMs: clip.startMs });
+		const sourceStart = getClipSourceStartMs(clip);
+		if (sourceStart > cursor) {
+			trims.push({ id: `trim-gap-${trimId++}`, startMs: cursor, endMs: sourceStart });
 		}
 		cursor = getClipSourceEndMs(clip);
 	}

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,8 +1,6 @@
 export const SHORTCUT_ACTIONS = [
 	"addZoom",
-	"addTrim",
 	"splitClip",
-	"addSpeed",
 	"addAnnotation",
 	"addKeyframe",
 	"deleteSelected",
@@ -76,9 +74,7 @@ export function findConflict(
 
 export const DEFAULT_SHORTCUTS: ShortcutsConfig = {
 	addZoom: { key: "z" },
-	addTrim: { key: "t" },
 	splitClip: { key: "c" },
-	addSpeed: { key: "s" },
 	addAnnotation: { key: "a" },
 	addKeyframe: { key: "f" },
 	deleteSelected: { key: "d", ctrl: true },
@@ -87,9 +83,7 @@ export const DEFAULT_SHORTCUTS: ShortcutsConfig = {
 
 export const SHORTCUT_LABELS: Record<ShortcutAction, string> = {
 	addZoom: "Add Zoom",
-	addTrim: "Add Trim",
 	splitClip: "Split Clip",
-	addSpeed: "Add Speed",
 	addAnnotation: "Add Annotation",
 	addKeyframe: "Add Keyframe",
 	deleteSelected: "Delete Selected",


### PR DESCRIPTION
## Summary

Fixes critical coordinate-space bugs in the clip editing system and removes trim/speed as standalone user-editable concepts (clips are now the only editing primitive).

## Coordinate Model Fix: `sourceStartMs`

**The bug:** When splitting a clip with speed ≠ 1, the right half pointed to the wrong source footage. `clip.startMs` was serving double duty as both timeline position and source video position — these diverge as soon as speed changes or clips are rearranged.

**The fix:** Added `sourceStartMs` to `ClipRegion` to explicitly track where in the source video each clip starts (defaults to `startMs` for backward compat). All coordinate conversion now uses `getClipSourceStartMs()`:

- `mapTimelineTimeToSourceTime` / `mapSourceTimeToTimelineTime` — use `sourceStartMs` for source range checks and mapping
- `effectiveSpeedRegions` — `startMs` field uses source coordinates
- `handleClipSplit` — computes `rightSourceStart` so the right half maps to correct source footage
- Project persistence preserves `sourceStartMs` on save/load

## Audio Region Sync Fix

`currentTime` (from `video.currentTime`) is in **source coordinates**, but `audioRegion.startMs/endMs` are **timeline coordinates**. The sync effect was comparing them directly. Now converts source time → timeline time via `mapSourceTimeToTimelineTime` before the comparison.

## Cascade Fix

Clip move (`handleClipSpanChange`) and clip speed change (`handleClipSpeedChange`) now cascade position/scale changes to **annotations and audio regions**, not just zoom regions.

## Trim/Speed Removal

Removed trim and speed as standalone user-editable region types:
- Removed from `SettingsPanel`, `TimelineEditor`, and keyboard shortcuts
- `trimRegions` and `speedRegions` are now derived from clips via `useMemo` (for export pipeline consumption)
- Export pipeline unchanged — still consumes TrimRegion/SpeedRegion as before

## Verification

- Zero TypeScript errors (`npx tsc --noEmit`)
- Zero Biome errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 1.2.0-beta.1 for beta release.

* **Bug Fixes**
  * Removed trim deletion UI from the Settings Panel.
  * Removed speed region editing controls from the Settings Panel.
  * Removed trim and speed editing actions from Timeline Editor.

* **Style**
  * Updated canvas element display styling in audio waveform.
  * Added overflow clipping to timeline row containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->