### PR TITLE
fix(recording): prefer playable browser capture codecs

### DIFF
--- a/src/hooks/recordingMimeType.test.ts
+++ b/src/hooks/recordingMimeType.test.ts
@@ -25,14 +25,13 @@ describe("selectRecordingMimeType", () => {
 		const mimeType = selectRecordingMimeType({
 			isTypeSupported: (type) =>
 				[
-					"video/webm;codecs=av1",
-					"video/webm;codecs=h264",
 					"video/webm;codecs=vp9",
+					"video/webm;codecs=vp8",
 				].includes(type),
-			canPlayType: (type) => (type === "video/webm;codecs=vp9" ? "probably" : ""),
+			canPlayType: (type) => (type === "video/webm;codecs=vp8" ? "probably" : ""),
 		});
 
-		expect(mimeType).toBe("video/webm;codecs=vp9");
+		expect(mimeType).toBe("video/webm;codecs=vp8");
 	});
 
 	it("falls back to the first supported codec when playback probing is unavailable", () => {
@@ -48,12 +47,12 @@ describe("selectRecordingMimeType", () => {
 		expect(mimeType).toBe("video/webm;codecs=av1");
 	});
 
-	it("uses generic webm as the final fallback", () => {
+	it("returns undefined when no preferred mime type is supported", () => {
 		const mimeType = selectRecordingMimeType({
 			isTypeSupported: () => false,
 			canPlayType: () => "",
 		});
 
-		expect(mimeType).toBe("video/webm");
+		expect(mimeType).toBeUndefined();
 	});
 });

--- a/src/hooks/recordingMimeType.test.ts
+++ b/src/hooks/recordingMimeType.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { selectRecordingMimeType } from "./recordingMimeType";
+
+describe("selectRecordingMimeType", () => {
+	it("prefers codecs the editor can play back", () => {
+		const mimeType = selectRecordingMimeType({
+			isTypeSupported: () => true,
+			canPlayType: (type) => {
+				if (type === "video/webm;codecs=vp9") {
+					return "probably";
+				}
+
+				if (type === "video/webm") {
+					return "maybe";
+				}
+
+				return "";
+			},
+		});
+
+		expect(mimeType).toBe("video/webm;codecs=vp9");
+	});
+
+	it("skips recorder-only codecs when playback support is missing", () => {
+		const mimeType = selectRecordingMimeType({
+			isTypeSupported: (type) =>
+				[
+					"video/webm;codecs=av1",
+					"video/webm;codecs=h264",
+					"video/webm;codecs=vp9",
+				].includes(type),
+			canPlayType: (type) => (type === "video/webm;codecs=vp9" ? "probably" : ""),
+		});
+
+		expect(mimeType).toBe("video/webm;codecs=vp9");
+	});
+
+	it("falls back to the first supported codec when playback probing is unavailable", () => {
+		const mimeType = selectRecordingMimeType({
+			isTypeSupported: (type) =>
+				[
+					"video/webm;codecs=av1",
+					"video/webm;codecs=h264",
+				].includes(type),
+			canPlayType: () => "",
+		});
+
+		expect(mimeType).toBe("video/webm;codecs=av1");
+	});
+
+	it("uses generic webm as the final fallback", () => {
+		const mimeType = selectRecordingMimeType({
+			isTypeSupported: () => false,
+			canPlayType: () => "",
+		});
+
+		expect(mimeType).toBe("video/webm");
+	});
+});

--- a/src/hooks/recordingMimeType.ts
+++ b/src/hooks/recordingMimeType.ts
@@ -1,0 +1,31 @@
+const FALLBACK_RECORDING_MIME_TYPE = "video/webm";
+
+const RECORDING_MIME_TYPE_PREFERENCES = [
+	"video/webm;codecs=vp9",
+	"video/webm",
+	"video/webm;codecs=vp8",
+	"video/webm;codecs=av1",
+	"video/webm;codecs=h264",
+] as const;
+
+type MimeTypeSelectorOptions = {
+	isTypeSupported?: (type: string) => boolean;
+	canPlayType?: (type: string) => string;
+};
+
+export function selectRecordingMimeType(
+	options: MimeTypeSelectorOptions = {},
+): string {
+	const isTypeSupported =
+		options.isTypeSupported ?? ((type: string) => MediaRecorder.isTypeSupported(type));
+	const canPlayType =
+		options.canPlayType ??
+		((type: string) => document.createElement("video").canPlayType(type));
+
+	const supportedTypes = RECORDING_MIME_TYPE_PREFERENCES.filter((type) =>
+		isTypeSupported(type),
+	);
+	const playableType = supportedTypes.find((type) => canPlayType(type) !== "");
+
+	return playableType ?? supportedTypes[0] ?? FALLBACK_RECORDING_MIME_TYPE;
+}

--- a/src/hooks/recordingMimeType.ts
+++ b/src/hooks/recordingMimeType.ts
@@ -1,5 +1,3 @@
-const FALLBACK_RECORDING_MIME_TYPE = "video/webm";
-
 const RECORDING_MIME_TYPE_PREFERENCES = [
 	"video/webm;codecs=vp9",
 	"video/webm",
@@ -15,7 +13,7 @@ type MimeTypeSelectorOptions = {
 
 export function selectRecordingMimeType(
 	options: MimeTypeSelectorOptions = {},
-): string {
+): string | undefined {
 	const isTypeSupported =
 		options.isTypeSupported ?? ((type: string) => MediaRecorder.isTypeSupported(type));
 	const canPlayType =
@@ -27,5 +25,5 @@ export function selectRecordingMimeType(
 	);
 	const playableType = supportedTypes.find((type) => canPlayType(type) !== "");
 
-	return playableType ?? supportedTypes[0] ?? FALLBACK_RECORDING_MIME_TYPE;
+	return playableType ?? supportedTypes[0];
 }

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -543,8 +543,8 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			pendingWebcamPathPromise.current = webcamStopPromise.current;
 
 			const recorder = new MediaRecorder(webcamStream.current, {
-				mimeType,
 				videoBitsPerSecond: WEBCAM_BITRATE,
+				...(mimeType ? { mimeType } : {}),
 			});
 
 			webcamRecorder.current = recorder;
@@ -571,7 +571,11 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						0,
 						getRecordingDurationMs(Date.now()) - webcamTimeOffsetMs.current,
 					);
-					const webcamBlob = new Blob(webcamChunks.current, { type: mimeType });
+					const webcamBlobType = recorder.mimeType || mimeType;
+					const webcamBlob = new Blob(
+						webcamChunks.current,
+						webcamBlobType ? { type: webcamBlobType } : undefined,
+					);
 					webcamChunks.current = [];
 					const fixedBlob = await fixWebmDuration(webcamBlob, duration);
 					const arrayBuffer = await fixedBlob.arrayBuffer();
@@ -1206,7 +1210,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			const mimeType = selectMimeType();
 
 			console.log(
-				`Recording at ${width}x${height} @ ${frameRate ?? TARGET_FRAME_RATE}fps using ${mimeType} / ${Math.round(
+				`Recording at ${width}x${height} @ ${frameRate ?? TARGET_FRAME_RATE}fps using ${mimeType ?? "browser default"} / ${Math.round(
 					videoBitsPerSecond / BITS_PER_MEGABIT,
 				)} Mbps`,
 			);
@@ -1214,8 +1218,8 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			chunks.current = [];
 			const hasAudio = stream.current.getAudioTracks().length > 0;
 			const recorder = new MediaRecorder(stream.current, {
-				mimeType,
 				videoBitsPerSecond,
+				...(mimeType ? { mimeType } : {}),
 				...(hasAudio
 					? {
 							audioBitsPerSecond: systemAudioIncluded
@@ -1237,7 +1241,11 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 				const duration = getRecordingDurationMs(Date.now());
 				const recordedChunks = chunks.current;
-				const buggyBlob = new Blob(recordedChunks, { type: mimeType });
+				const recordingBlobType = recorder.mimeType || mimeType;
+				const buggyBlob = new Blob(
+					recordedChunks,
+					recordingBlobType ? { type: recordingBlobType } : undefined,
+				);
 				chunks.current = [];
 				const timestamp = recordingSessionTimestamp.current ?? Date.now();
 				const videoFileName = `${RECORDING_FILE_PREFIX}${timestamp}${VIDEO_FILE_EXTENSION}`;

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -2,6 +2,7 @@ import { fixWebmDuration } from "@fix-webm-duration/fix";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getEffectiveRecordingDurationMs } from "@/lib/mediaTiming";
+import { selectRecordingMimeType } from "./recordingMimeType";
 
 const TARGET_FRAME_RATE = 60;
 const TARGET_WIDTH = 3840;
@@ -32,6 +33,14 @@ const WEBCAM_WIDTH = 1280;
 const WEBCAM_HEIGHT = 720;
 const WEBCAM_FRAME_RATE = 30;
 const WEBCAM_SUFFIX = "-webcam";
+const LINUX_PORTAL_SOURCE: ProcessedDesktopSource = {
+	id: "screen:linux-portal",
+	name: "Linux Portal",
+	display_id: "",
+	thumbnail: null,
+	appIcon: null,
+	sourceType: "screen",
+};
 
 type PauseSegment = {
 	startMs: number;
@@ -262,15 +271,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	}, []);
 
 	const selectMimeType = useCallback(() => {
-		const preferred = [
-			"video/webm;codecs=av1",
-			"video/webm;codecs=h264",
-			"video/webm;codecs=vp9",
-			"video/webm;codecs=vp8",
-			"video/webm",
-		];
-
-		return preferred.find((type) => MediaRecorder.isTypeSupported(type)) ?? "video/webm";
+		return selectRecordingMimeType();
 	}, []);
 
 	const computeBitrate = (width: number, height: number) => {
@@ -838,10 +839,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			const platform = await window.electronAPI.getPlatform();
 			const existingSource = await window.electronAPI.getSelectedSource();
 			const selectedSource =
-				existingSource ??
-				(platform === "linux"
-					? { id: "screen:linux-portal", name: "Linux Portal" }
-					: null);
+				existingSource ?? (platform === "linux" ? LINUX_PORTAL_SOURCE : null);
 			if (!selectedSource) {
 				alert("Please select a source to record");
 				return;


### PR DESCRIPTION
## Description
Fix browser-based recording sessions that save successfully but fail to open in the editor with "Failed to load video".

## Motivation
The browser capture path could prefer MIME types that `MediaRecorder` accepts but the in-app player cannot reliably decode, and it could still pass an explicitly unsupported fallback MIME type into `new MediaRecorder(...)` when probing found no supported preference.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
No tracked issue was linked for this bug.

## Screenshots / Video
N/A for this bugfix-only change.

## Testing Guide
1. Start a browser-based recording session.
2. Stop the recording.
3. Verify the editor opens the saved recording instead of showing "Failed to load video".
4. Run `npx vitest --run src/hooks/recordingMimeType.test.ts src/hooks/useScreenRecorder.test.ts`.
5. Run `npx tsc --noEmit`.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.