### PR TITLE
fix(windows): normalize WGC sample timestamps

### DIFF
--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -19,6 +19,7 @@ static std::atomic<bool> g_stopRequested{false};
 static std::atomic<bool> g_pauseRequested{false};
 static std::atomic<bool> g_resumePending{false};
 static std::atomic<int64_t> g_lastFrameTimestampHns{0};
+static std::atomic<int64_t> g_firstFrameTimestampHns{-1};
 static std::atomic<int64_t> g_pauseStartTimestampHns{0};
 static std::atomic<int64_t> g_accumulatedPausedHns{0};
 static std::mutex g_stopMutex;
@@ -257,6 +258,16 @@ int main(int argc, char* argv[]) {
 
         if (g_pauseRequested) return;
 
+        int64_t firstFrameTimestampHns = g_firstFrameTimestampHns.load();
+        if (firstFrameTimestampHns < 0) {
+            int64_t expected = -1;
+            if (g_firstFrameTimestampHns.compare_exchange_strong(expected, timestampHns)) {
+                firstFrameTimestampHns = timestampHns;
+            } else {
+                firstFrameTimestampHns = g_firstFrameTimestampHns.load();
+            }
+        }
+
         int64_t adjustedTimestampHns = timestampHns;
         if (g_resumePending.exchange(false)) {
             const int64_t pauseStart = g_pauseStartTimestampHns.load();
@@ -265,6 +276,7 @@ int main(int argc, char* argv[]) {
             }
         }
 
+        adjustedTimestampHns -= firstFrameTimestampHns;
         adjustedTimestampHns -= g_accumulatedPausedHns.load();
         if (adjustedTimestampHns < 0) {
             adjustedTimestampHns = 0;


### PR DESCRIPTION
## Description
Fix Windows native WGC recordings that stop successfully but produce an MP4 the editor cannot load.

## Motivation
The native helper wrote sample timestamps using absolute capture times instead of normalizing them to the start of the recording session, which could produce effectively unusable MP4 output.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
No tracked issue was linked for this bug.

## Screenshots / Video
N/A for this native timestamp fix.

## Testing Guide
1. Start a Windows native screen recording session.
2. Stop the recording.
3. Verify the saved MP4 opens in the editor instead of failing to load.
4. Manual verification on Windows was used for this change.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.