### PR TITLE
Revert "fix(windows): normalize WGC sample timestamps"

### DIFF
--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -19,7 +19,6 @@ static std::atomic<bool> g_stopRequested{false};
 static std::atomic<bool> g_pauseRequested{false};
 static std::atomic<bool> g_resumePending{false};
 static std::atomic<int64_t> g_lastFrameTimestampHns{0};
-static std::atomic<int64_t> g_firstFrameTimestampHns{-1};
 static std::atomic<int64_t> g_pauseStartTimestampHns{0};
 static std::atomic<int64_t> g_accumulatedPausedHns{0};
 static std::mutex g_stopMutex;
@@ -258,16 +257,6 @@ int main(int argc, char* argv[]) {
 
         if (g_pauseRequested) return;
 
-        int64_t firstFrameTimestampHns = g_firstFrameTimestampHns.load();
-        if (firstFrameTimestampHns < 0) {
-            int64_t expected = -1;
-            if (g_firstFrameTimestampHns.compare_exchange_strong(expected, timestampHns)) {
-                firstFrameTimestampHns = timestampHns;
-            } else {
-                firstFrameTimestampHns = g_firstFrameTimestampHns.load();
-            }
-        }
-
         int64_t adjustedTimestampHns = timestampHns;
         if (g_resumePending.exchange(false)) {
             const int64_t pauseStart = g_pauseStartTimestampHns.load();
@@ -276,7 +265,6 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        adjustedTimestampHns -= firstFrameTimestampHns;
         adjustedTimestampHns -= g_accumulatedPausedHns.load();
         if (adjustedTimestampHns < 0) {
             adjustedTimestampHns = 0;


### PR DESCRIPTION
Reverts webadderall/Recordly#276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame timestamp handling during video capture to ensure accurate timing after pause/resume operations. Timestamps now correctly account for paused duration without unnecessary adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->