### PR TITLE
fix(export): reopen saved videos and default to source quality

### DIFF
--- a/electron/ipc/project/manager.test.ts
+++ b/electron/ipc/project/manager.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("local media path policy", () => {
+	let tempRoot: string;
+	let appDataPath: string;
+	let userDataPath: string;
+	let tempPath: string;
+	let appPath: string;
+
+	beforeEach(async () => {
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "recordly-media-policy-"));
+		appDataPath = path.join(tempRoot, "AppData");
+		userDataPath = path.join(tempRoot, "UserData");
+		tempPath = path.join(tempRoot, "Temp");
+		appPath = path.join(tempRoot, "App");
+
+		await Promise.all(
+			[appDataPath, userDataPath, tempPath, appPath].map((dirPath) =>
+				fs.mkdir(dirPath, { recursive: true }),
+			),
+		);
+
+		vi.resetModules();
+		vi.doMock("electron", () => ({
+			app: {
+				isPackaged: false,
+				getAppPath: () => appPath,
+				getPath: (name: string) => {
+					if (name === "appData") return appDataPath;
+					if (name === "userData") return userDataPath;
+					if (name === "temp") return tempPath;
+					return tempRoot;
+				},
+				setPath: () => undefined,
+			},
+		}));
+	});
+
+	afterEach(async () => {
+		vi.resetModules();
+		vi.doUnmock("electron");
+		if (tempRoot) {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("allows existing exported media files outside the session directories", async () => {
+		const downloadsPath = path.join(tempRoot, "Downloads");
+		const exportPath = path.join(downloadsPath, "export-test.mp4");
+		await fs.mkdir(downloadsPath, { recursive: true });
+		await fs.writeFile(exportPath, "test-video");
+
+		const { isAllowedLocalMediaPath } = await import("./manager");
+
+		await expect(isAllowedLocalMediaPath(exportPath)).resolves.toBe(true);
+	});
+
+	it("rejects missing media files outside the allowed directories", async () => {
+		const missingPath = path.join(tempRoot, "Downloads", "missing.mp4");
+		const { isAllowedLocalMediaPath } = await import("./manager");
+
+		await expect(isAllowedLocalMediaPath(missingPath)).resolves.toBe(false);
+	});
+});

--- a/electron/ipc/project/manager.test.ts
+++ b/electron/ipc/project/manager.test.ts
@@ -64,4 +64,13 @@ describe("local media path policy", () => {
 
 		await expect(isAllowedLocalMediaPath(missingPath)).resolves.toBe(false);
 	});
+
+	it("allows approved media paths before the file exists", async () => {
+		const pendingExportPath = path.join(tempRoot, "Downloads", "pending-export.mp4");
+		const { isAllowedLocalMediaPath, rememberApprovedLocalReadPath } = await import("./manager");
+
+		await rememberApprovedLocalReadPath(pendingExportPath);
+
+		await expect(isAllowedLocalMediaPath(pendingExportPath)).resolves.toBe(true);
+	});
 });

--- a/electron/ipc/project/manager.ts
+++ b/electron/ipc/project/manager.ts
@@ -60,6 +60,16 @@ export function isAllowedLocalReadPath(candidatePath: string) {
 	);
 }
 
+// Keep media-server access rules aligned with read-local-file so exported videos
+// saved outside the active recording session can still be reopened in the editor.
+export async function isAllowedLocalMediaPath(candidatePath: string) {
+	const normalizedCandidatePath = normalizePath(candidatePath);
+	const realPath = await fs.realpath(normalizedCandidatePath).catch(() => normalizedCandidatePath);
+	return (
+		isAllowedLocalReadPath(normalizedCandidatePath) || isAllowedLocalReadPath(realPath)
+	);
+}
+
 export async function rememberApprovedLocalReadPath(filePath?: string | null) {
 	const normalizedPath = normalizeVideoSourcePath(filePath);
 	if (!normalizedPath) {

--- a/electron/ipc/project/manager.ts
+++ b/electron/ipc/project/manager.ts
@@ -64,10 +64,7 @@ export function isAllowedLocalReadPath(candidatePath: string) {
 // saved outside the active recording session can still be reopened in the editor.
 export async function isAllowedLocalMediaPath(candidatePath: string) {
 	const normalizedCandidatePath = normalizePath(candidatePath);
-	const realPath = await fs.realpath(normalizedCandidatePath).catch(() => normalizedCandidatePath);
-	return (
-		isAllowedLocalReadPath(normalizedCandidatePath) || isAllowedLocalReadPath(realPath)
-	);
+	return isAllowedLocalReadPath(normalizedCandidatePath);
 }
 
 export async function rememberApprovedLocalReadPath(filePath?: string | null) {

--- a/electron/ipc/register/export.ts
+++ b/electron/ipc/register/export.ts
@@ -29,6 +29,7 @@ import {
 	muxExportedVideoAudioBuffer,
 	type NativeVideoExportSession,
 } from "../export/native-video";
+import { approveUserPath } from "../utils";
 
 export function registerExportHandlers() {
   ipcMain.handle(
@@ -341,6 +342,7 @@ export function registerExportHandlers() {
       }
 
       await fs.writeFile(result.filePath, Buffer.from(videoData));
+      approveUserPath(result.filePath);
 
       return {
         success: true,
@@ -362,10 +364,11 @@ export function registerExportHandlers() {
       const resolvedPath = path.resolve(outputPath)
       await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
       await fs.writeFile(resolvedPath, Buffer.from(videoData));
+      approveUserPath(resolvedPath);
 
       return {
         success: true,
-        path: outputPath,
+        path: resolvedPath,
         message: 'Video exported successfully',
         canceled: false,
       };

--- a/electron/ipc/register/project.ts
+++ b/electron/ipc/register/project.ts
@@ -16,27 +16,25 @@ import {
 	currentRecordingSession,
 	setCurrentRecordingSession,
 } from "../state";
-import { normalizeVideoSourcePath } from "../utils";
 import {
+	getProjectsDir,
 	isAllowedLocalMediaPath,
 	isPathInsideDirectory,
+	isTrustedProjectPath,
+	listProjectLibraryEntries,
+	loadProjectFromPath,
+	persistRecordingsDirectorySetting,
 	replaceApprovedSessionLocalReadPaths,
+	rememberRecentProject,
+	saveProjectThumbnail,
 } from "../project/manager";
 import {
 	getTelemetryPathForVideo,
 	isAutoRecordingPath,
 	getRecordingsDir,
 	approveUserPath,
+	normalizeVideoSourcePath,
 } from "../utils";
-import {
-	getProjectsDir,
-	persistRecordingsDirectorySetting,
-	saveProjectThumbnail,
-	rememberRecentProject,
-	listProjectLibraryEntries,
-	loadProjectFromPath,
-	isTrustedProjectPath,
-} from "../project/manager";
 import { persistRecordingSessionManifest, resolveRecordingSession } from "../project/session";
 
 function normalizeRecordingTimeOffsetMs(value: unknown): number {

--- a/electron/ipc/register/project.ts
+++ b/electron/ipc/register/project.ts
@@ -15,10 +15,13 @@ import {
 	setCurrentVideoPath,
 	currentRecordingSession,
 	setCurrentRecordingSession,
-	approvedLocalReadPaths,
 } from "../state";
 import { normalizeVideoSourcePath } from "../utils";
-import { isPathInsideDirectory, replaceApprovedSessionLocalReadPaths } from "../project/manager";
+import {
+	isAllowedLocalMediaPath,
+	isPathInsideDirectory,
+	replaceApprovedSessionLocalReadPaths,
+} from "../project/manager";
 import {
 	getTelemetryPathForVideo,
 	isAutoRecordingPath,
@@ -391,8 +394,8 @@ export function registerProjectHandlers() {
     } catch {
       return { success: false as const };
     }
-    if (!approvedLocalReadPaths.has(resolved) && !approvedLocalReadPaths.has(normalized)) {
-      console.warn(`[get-local-media-url] Blocked unapproved path: ${resolved}`);
+    if (!(await isAllowedLocalMediaPath(resolved))) {
+      console.warn(`[get-local-media-url] Blocked disallowed path: ${resolved}`);
       return { success: false as const };
     }
     return { success: true as const, url: buildMediaUrl(baseUrl, resolved) };

--- a/src/components/video-editor/editorPreferences.test.ts
+++ b/src/components/video-editor/editorPreferences.test.ts
@@ -52,6 +52,10 @@ describe("editorPreferences", () => {
 		).toEqual(DEFAULT_EDITOR_PREFERENCES);
 	});
 
+	it("defaults MP4 exports to source quality", () => {
+		expect(DEFAULT_EDITOR_PREFERENCES.exportQuality).toBe("source");
+	});
+
 	it("loads stored editor control preferences", () => {
 		vi.stubGlobal(
 			"localStorage",

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -838,7 +838,7 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 			editor.exportQuality === "high" ||
 			editor.exportQuality === "source"
 				? editor.exportQuality
-				: "good",
+				: "source",
 		mp4FrameRate: normalizeExportMp4FrameRate(editor.mp4FrameRate),
 		exportFormat: editor.exportFormat === "gif" ? "gif" : "mp4",
 		gifFrameRate:


### PR DESCRIPTION
## Description
Fixes two export-path regressions in the editor:
- exported videos saved outside the active recording/project directories can now be reopened reliably in Recordly
- new editor sessions default MP4 exports to source quality instead of downscaling to the `good` preset

## Motivation
Users can export an MP4 successfully, but when they reopen that file in Recordly they may see `Failed to load video (format not supported)` even though Electron can decode the file. The issue was a policy mismatch: `read-local-file` already allowed existing user-selected files, but `get-local-media-url` only allowed paths remembered in the in-memory approved set.

The current default export quality also falls back to `good`, which scales output to 75% of the source dimensions. That makes screen recordings with small text look softer than users expect. Defaulting to `source` keeps new exports crisp unless the user explicitly chooses a smaller preset.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- Related symptom: #271

## Screenshots / Video
Not included.

## Testing Guide
1. Run `npx vitest --run src/components/video-editor/editorPreferences.test.ts electron/ipc/project/manager.test.ts`
2. Run `npx vitest --run src/hooks/recordingMimeType.test.ts src/hooks/useScreenRecorder.test.ts`
3. Run `npx tsc --noEmit`
4. Export an MP4 to a folder outside `Recordly/recordings` (for example `Downloads`)
5. Reopen the exported MP4 in Recordly and confirm the editor loads it instead of showing `Failed to load video (format not supported)`
6. In a fresh editor session, open the export menu and confirm the default MP4 quality is `Original`

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime validation for local media file access and updated the media URL handler to use it.
  * Export flow now records/approves exported file paths and returns the resolved filesystem path.

* **Bug Fixes**
  * Default export quality preference changed to "source".

* **Tests**
  * Added tests covering local media path policy and the export-quality default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->