### PR TITLE
fix(recording): preserve mic companion audio in editor/export

### DIFF
--- a/electron/ipc/recording/diagnostics.test.ts
+++ b/electron/ipc/recording/diagnostics.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ExecFileCallback = (error: Error | null, stdout?: string, stderr?: string) => void;
+
+describe("getCompanionAudioFallbackPaths", () => {
+	let tempRoot: string;
+	let appDataPath: string;
+	let userDataPath: string;
+	let tempPath: string;
+	let appPath: string;
+	let execFileMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "recordly-companion-audio-"));
+		appDataPath = path.join(tempRoot, "AppData");
+		userDataPath = path.join(tempRoot, "UserData");
+		tempPath = path.join(tempRoot, "Temp");
+		appPath = path.join(tempRoot, "App");
+		await Promise.all(
+			[appDataPath, userDataPath, tempPath, appPath].map((dirPath) =>
+				fs.mkdir(dirPath, { recursive: true }),
+			),
+		);
+		execFileMock = vi.fn(
+			(
+				_file: string,
+				_args: string[],
+				_options: Record<string, unknown>,
+				callback: ExecFileCallback,
+			) => {
+				callback(null, "", "");
+			},
+		);
+
+		vi.resetModules();
+		vi.doMock("electron", () => ({
+			app: {
+				isPackaged: false,
+				getAppPath: () => appPath,
+				getPath: (name: string) => {
+					if (name === "appData") return appDataPath;
+					if (name === "userData") return userDataPath;
+					if (name === "temp") return tempPath;
+					return tempRoot;
+				},
+				setPath: () => undefined,
+			},
+		}));
+		vi.doMock("node:child_process", () => ({
+			execFile: execFileMock,
+		}));
+		vi.doMock("../ffmpeg/binary", () => ({
+			getFfmpegBinaryPath: () => "ffmpeg",
+		}));
+	});
+
+	afterEach(async () => {
+		vi.resetModules();
+		vi.doUnmock("electron");
+		vi.doUnmock("node:child_process");
+		vi.doUnmock("../ffmpeg/binary");
+		if (tempRoot) {
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("returns companion audio files directly when the video has no embedded audio", async () => {
+		const videoPath = path.join(tempRoot, "recording.mp4");
+		const systemPath = path.join(tempRoot, "recording.system.wav");
+		const micPath = path.join(tempRoot, "recording.mic.wav");
+
+		await Promise.all([
+			fs.writeFile(videoPath, "video"),
+			fs.writeFile(systemPath, "system"),
+			fs.writeFile(micPath, "mic"),
+		]);
+
+		execFileMock.mockImplementation(
+			(
+				_file: string,
+				_args: string[],
+				_options: Record<string, unknown>,
+				callback: ExecFileCallback,
+			) => {
+				const error = new Error("ffmpeg probe failed") as Error & { stderr?: string };
+				error.stderr = "Stream #0:0: Video: h264";
+				callback(error, "", error.stderr);
+			},
+		);
+
+		const { getCompanionAudioFallbackPaths } = await import("./diagnostics");
+
+		await expect(getCompanionAudioFallbackPaths(videoPath)).resolves.toEqual([
+			systemPath,
+			micPath,
+		]);
+	});
+
+	it("keeps the embedded source audio and adds the mic companion when both are present", async () => {
+		const videoPath = path.join(tempRoot, "recording.mp4");
+		const systemPath = path.join(tempRoot, "recording.system.wav");
+		const micPath = path.join(tempRoot, "recording.mic.wav");
+
+		await Promise.all([
+			fs.writeFile(videoPath, "video"),
+			fs.writeFile(systemPath, "system"),
+			fs.writeFile(micPath, "mic"),
+		]);
+
+		execFileMock.mockImplementation(
+			(
+				_file: string,
+				_args: string[],
+				_options: Record<string, unknown>,
+				callback: ExecFileCallback,
+			) => {
+				const error = new Error("ffmpeg probe found embedded audio") as Error & {
+					stderr?: string;
+				};
+				error.stderr = "Stream #0:1: Audio: aac";
+				callback(error, "", error.stderr);
+			},
+		);
+
+		const { getCompanionAudioFallbackPaths } = await import("./diagnostics");
+
+		await expect(getCompanionAudioFallbackPaths(videoPath)).resolves.toEqual([
+			videoPath,
+			micPath,
+		]);
+	});
+});

--- a/electron/ipc/recording/diagnostics.ts
+++ b/electron/ipc/recording/diagnostics.ts
@@ -1,10 +1,10 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import { promisify } from "node:util";
-import { getFfmpegBinaryPath } from "../ffmpeg/binary";
 import { COMPANION_AUDIO_LAYOUTS } from "../constants";
-import type { NativeCaptureDiagnostics, CompanionAudioCandidate } from "../types";
+import { getFfmpegBinaryPath } from "../ffmpeg/binary";
 import { lastNativeCaptureDiagnostics, setLastNativeCaptureDiagnostics } from "../state";
+import type { CompanionAudioCandidate, NativeCaptureDiagnostics } from "../types";
 
 const execFileAsync = promisify(execFile);
 
@@ -123,10 +123,23 @@ export async function getCompanionAudioFallbackPaths(videoPath: string) {
 	}
 
 	if (await hasEmbeddedAudioStream(videoPath)) {
-		return [];
+		const microphoneCompanionPaths = Array.from(
+			new Set(
+				companionCandidates.flatMap((candidate) =>
+					candidate.usablePaths.filter(
+						(companionPath) => companionPath === candidate.micPath,
+					),
+				),
+			),
+		);
+		if (microphoneCompanionPaths.length === 0) {
+			return [];
+		}
+
+		return [videoPath, ...microphoneCompanionPaths];
 	}
 
-	return companionCandidates.flatMap((candidate) => candidate.usablePaths);
+	return Array.from(new Set(companionCandidates.flatMap((candidate) => candidate.usablePaths)));
 }
 
 export async function validateRecordedVideo(videoPath: string) {


### PR DESCRIPTION
# Pull Request Template

## Description
Fix recordings where the source video already contains audio but the microphone is saved as a companion sidecar file. The editor and export pipeline were dropping the mic track in that case, so microphone audio never appeared in playback or final exports.

## Motivation
Issue #250 reports that the microphone companion file exists on disk but is ignored by the editor/export pipeline. The companion-audio resolver returned no fallback sources whenever the video had any embedded audio stream, which hid separated microphone tracks from native and browser recording layouts.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- Closes #250

## Screenshots / Video
N/A (backend audio pipeline fix)

## Testing Guide
- `npx vitest --run electron/ipc/recording/diagnostics.test.ts src/lib/mediaTiming.test.ts`
- Regression coverage verifies:
  1. companion files are used when the video has no embedded audio
  2. embedded source audio is preserved and the mic companion is added when both exist

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for audio fallback path detection with various audio stream scenarios.

* **Bug Fixes**
  * Improved audio source detection to correctly identify embedded audio in videos and select appropriate fallback audio paths accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->