### PR TITLE
fix: improve video preview quality by deferring filter attachment

### DIFF
--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -1458,7 +1458,11 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			blurFilter.resolution = app.renderer.resolution;
 			blurFilter.blur = 0;
 			const motionBlurFilter = new MotionBlurFilter([0, 0], 5, 0);
-			videoContainer.filters = [blurFilter, motionBlurFilter];
+			// Don't attach filters by default — the filter pipeline forces the video
+			// through an intermediate RenderTexture at renderer resolution, downsampling
+			// the native video and destroying detail. Filters are attached conditionally
+			// in the ticker only when zoom motion blur is actually active.
+			videoContainer.filters = null;
 			blurFilterRef.current = blurFilter;
 			motionBlurFilterRef.current = motionBlurFilter;
 
@@ -1543,6 +1547,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				const appliedTransform = applyZoomTransform({
 					cameraContainer,
 					blurFilter: blurFilterRef.current,
+					motionBlurFilter: motionBlurFilterRef.current,
 					stageSize: stageSizeRef.current,
 					baseMask: baseMaskRef.current,
 					zoomScale: state.scale,
@@ -1553,7 +1558,6 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 					motionVector,
 					isPlaying: isPlayingRef.current,
 					motionBlurAmount: zoomMotionBlurRef.current,
-					motionBlurFilter: motionBlurFilterRef.current,
 					transformOverride: transform,
 					motionBlurState: motionBlurStateRef.current,
 					frameTimeMs: performance.now(),
@@ -1738,6 +1742,21 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 					motionIntensity,
 					motionVector,
 				);
+
+				// Conditionally attach motion blur filter only when the camera is
+				// actually moving. When filters are attached, PixiJS routes the video
+				// through an intermediate RenderTexture at renderer resolution, which
+				// downsamples the native video and degrades preview quality.
+				// Hysteresis prevents flickering when motionIntensity oscillates near threshold.
+				const filtersActive = Array.isArray(videoContainer.filters) && videoContainer.filters.length > 0;
+				const cameraIsMoving = filtersActive ? motionIntensity > 0.002 : motionIntensity > 0.008;
+				const needsFilters = zoomMotionBlurRef.current > 0 && isPlayingRef.current && cameraIsMoving;
+				if (needsFilters && !filtersActive && motionBlurFilterRef.current) {
+					videoContainer.filters = [motionBlurFilterRef.current];
+				} else if (!needsFilters && filtersActive) {
+					videoContainer.filters = null;
+				}
+
 				applyWebcamBubbleLayout(animationStateRef.current.appliedScale || 1);
 
 				const timeMs = currentTimeRef.current;


### PR DESCRIPTION
## Problem

The video preview is noticeably blurry and pixelated, especially with high-resolution screen recordings. Text, icons, and fine details become unreadable in the editor preview even though the source video is crisp.

**Root cause:** `BlurFilter` and `MotionBlurFilter` are always attached to `videoContainer.filters` at initialization, even when both are inactive (blur=0, motion blur velocity=0). PixiJS's filter pipeline forces the entire video container through an intermediate `RenderTexture` at the renderer's resolution whenever *any* filter is attached — regardless of whether the filter actually modifies the output. This intermediate texture is significantly smaller than the native video, so the video gets downsampled before it even reaches the screen.

## Fix

- Filters are no longer attached at initialization (`videoContainer.filters = null`)
- The `MotionBlurFilter` is only attached in the render ticker when zoom motion blur is enabled *and* the camera is actively moving (`motionIntensity > threshold`)
- Filters are detached as soon as the camera settles, restoring full preview quality
- A hysteresis threshold (0.008 to activate, 0.002 to deactivate) prevents rapid filter toggling when motion intensity oscillates near the boundary

No changes to the export pipeline — export quality is unaffected.

## Test plan

- [x] Open a high-res screen recording and verify text/icons are sharp in the preview
- [x] Play the video without zoom — preview should remain crisp throughout
- [x] Add zoom regions and play — motion blur should still appear during zoom transitions
- [x] After zoom settles, preview should return to full sharpness
- [x] Export a video and verify output quality is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Motion blur effects during video playback and zoom operations now activate dynamically based on zoom state, playback status, and movement intensity thresholds. The filter behavior has been refined to automatically enable and disable as conditions change, replacing the previous static initialization approach used at setup time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->