### PR TITLE
fix(export): skip redundant AAC re-encode during final mux

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="vite-plugin-electron/electron-env" />
 
-// biome-ignore lint/style/noNamespace: NodeJS.ProcessEnv augmentation requires a namespace declaration.
 declare namespace NodeJS {
 	interface ProcessEnv {
 		/**
@@ -185,6 +184,7 @@ interface Window {
 			options?: {
 				audioMode?: "none" | "copy-source" | "trim-source" | "edited-track";
 				audioSourcePath?: string | null;
+				audioCodec?: string | null;
 				trimSegments?: Array<{ startMs: number; endMs: number }>;
 				editedAudioData?: ArrayBuffer;
 				editedAudioMimeType?: string | null;
@@ -203,6 +203,7 @@ interface Window {
 			options?: {
 				audioMode?: "none" | "copy-source" | "trim-source" | "edited-track";
 				audioSourcePath?: string | null;
+				audioCodec?: string | null;
 				trimSegments?: Array<{ startMs: number; endMs: number }>;
 				editedAudioData?: ArrayBuffer;
 				editedAudioMimeType?: string | null;
@@ -330,9 +331,9 @@ interface Window {
 		getCurrentVideoPath: () => Promise<{ success: boolean; path?: string }>;
 		clearCurrentVideoPath: () => Promise<{ success: boolean }>;
 		deleteRecordingFile: (filePath: string) => Promise<{ success: boolean; error?: string }>;
-		getLocalMediaUrl: (filePath: string) => Promise<
-			{ success: true; url: string } | { success: false }
-		>;
+		getLocalMediaUrl: (
+			filePath: string,
+		) => Promise<{ success: true; url: string } | { success: false }>;
 		saveProjectFile: (
 			projectData: unknown,
 			suggestedName?: string,

--- a/electron/ipc/export/native-video.ts
+++ b/electron/ipc/export/native-video.ts
@@ -2,13 +2,24 @@ import type { ChildProcessByStdio } from "node:child_process";
 import { execFile, spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
 import type { Readable, Writable } from "node:stream";
-import { app } from "electron";
+import { promisify } from "node:util";
 import type { WebContents } from "electron";
+import { app } from "electron";
 import { getFfmpegBinaryPath } from "../ffmpeg/binary";
-import { buildTrimmedSourceAudioFilter, getEditedAudioExtension, getNativeVideoInputByteSize, getPreferredNativeVideoEncoders, buildNativeVideoExportArgs, parseAvailableFfmpegEncoders } from "../nativeVideoExport";
-import type { NativeExportEncodingMode, NativeVideoExportFinishOptions } from "../nativeVideoExport";
+import type {
+	NativeExportEncodingMode,
+	NativeVideoExportFinishOptions,
+} from "../nativeVideoExport";
+import {
+	buildNativeVideoExportArgs,
+	buildTrimmedSourceAudioFilter,
+	getEditedAudioExtension,
+	getNativeVideoInputByteSize,
+	getPreferredNativeVideoEncoders,
+	parseAvailableFfmpegEncoders,
+	shouldCopyNativeVideoExportAudio,
+} from "../nativeVideoExport";
 import { cachedNativeVideoEncoder, setCachedNativeVideoEncoder } from "../state";
 
 const execFileAsync = promisify(execFile);
@@ -72,7 +83,10 @@ export async function removeTemporaryExportFile(filePath: string | null | undefi
 	}
 }
 
-export function getNativeVideoExportSessionError(session: NativeVideoExportSession, fallback: string) {
+export function getNativeVideoExportSessionError(
+	session: NativeVideoExportSession,
+	fallback: string,
+) {
 	return (
 		session.stdinError?.message ||
 		session.processError?.message ||
@@ -199,7 +213,10 @@ export async function writeNativeVideoExportFrame(
 	session: NativeVideoExportSession,
 	frameData: Uint8Array | ArrayBuffer,
 ) {
-	if (session.inputMode !== "h264-stream" && getNativeVideoExportFrameLength(frameData) !== session.inputByteSize) {
+	if (
+		session.inputMode !== "h264-stream" &&
+		getNativeVideoExportFrameLength(frameData) !== session.inputByteSize
+	) {
 		throw new Error(
 			`Native video export expected ${session.inputByteSize} bytes per frame but received ${getNativeVideoExportFrameLength(frameData)}`,
 		);
@@ -398,6 +415,7 @@ export async function muxNativeVideoExportAudio(
 		"-i",
 		audioInputPath,
 	];
+	const shouldCopyAudio = shouldCopyNativeVideoExportAudio(options);
 
 	if (audioMode === "trim-source") {
 		const filter = buildTrimmedSourceAudioFilter(options.trimSegments ?? []);
@@ -410,18 +428,13 @@ export async function muxNativeVideoExportAudio(
 		args.push("-map", "0:v:0", "-map", "1:a:0");
 	}
 
-	args.push(
-		"-c:v",
-		"copy",
-		"-c:a",
-		"aac",
-		"-b:a",
-		"192k",
-		"-shortest",
-		"-movflags",
-		"+faststart",
-		outputPath,
-	);
+	args.push("-c:v", "copy", "-c:a", shouldCopyAudio ? "copy" : "aac");
+
+	if (!shouldCopyAudio) {
+		args.push("-b:a", "192k");
+	}
+
+	args.push("-shortest", "-movflags", "+faststart", outputPath);
 
 	try {
 		await execFileAsync(ffmpegPath, args, {

--- a/electron/ipc/nativeVideoExport.test.ts
+++ b/electron/ipc/nativeVideoExport.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+	isNativeVideoExportPassthroughAudioCodec,
+	shouldCopyNativeVideoExportAudio,
+} from "./nativeVideoExport";
+
+describe("isNativeVideoExportPassthroughAudioCodec", () => {
+	it("accepts AAC codec strings that MP4 can stream-copy", () => {
+		expect(isNativeVideoExportPassthroughAudioCodec("aac")).toBe(true);
+		expect(isNativeVideoExportPassthroughAudioCodec("mp4a.40.2")).toBe(true);
+		expect(isNativeVideoExportPassthroughAudioCodec("audio/mp4; codecs=mp4a.40.2")).toBe(true);
+	});
+
+	it("rejects codecs that still require transcoding", () => {
+		expect(isNativeVideoExportPassthroughAudioCodec("opus")).toBe(false);
+		expect(isNativeVideoExportPassthroughAudioCodec("vorbis")).toBe(false);
+		expect(isNativeVideoExportPassthroughAudioCodec(null)).toBe(false);
+	});
+});
+
+describe("shouldCopyNativeVideoExportAudio", () => {
+	it("copies copy-source audio when the source codec is AAC-compatible", () => {
+		expect(
+			shouldCopyNativeVideoExportAudio({
+				audioMode: "copy-source",
+				audioCodec: "mp4a.40.2",
+			}),
+		).toBe(true);
+	});
+
+	it("keeps trim-source on the transcode path", () => {
+		expect(
+			shouldCopyNativeVideoExportAudio({
+				audioMode: "trim-source",
+				audioCodec: "mp4a.40.2",
+			}),
+		).toBe(false);
+	});
+
+	it("allows future edited-track AAC payloads to skip re-encode", () => {
+		expect(
+			shouldCopyNativeVideoExportAudio({
+				audioMode: "edited-track",
+				editedAudioMimeType: "audio/mp4; codecs=mp4a.40.2",
+			}),
+		).toBe(true);
+	});
+});

--- a/electron/ipc/nativeVideoExport.ts
+++ b/electron/ipc/nativeVideoExport.ts
@@ -21,9 +21,46 @@ export interface NativeVideoExportAudioSegment {
 export interface NativeVideoExportFinishOptions {
 	audioMode?: NativeVideoExportAudioMode;
 	audioSourcePath?: string | null;
+	audioCodec?: string | null;
 	trimSegments?: NativeVideoExportAudioSegment[];
 	editedAudioData?: ArrayBuffer;
 	editedAudioMimeType?: string | null;
+}
+
+export function isNativeVideoExportPassthroughAudioCodec(
+	codecOrMimeType: string | null | undefined,
+): boolean {
+	if (!codecOrMimeType) {
+		return false;
+	}
+
+	const normalized = codecOrMimeType.toLowerCase();
+	return (
+		normalized === "aac" ||
+		normalized.startsWith("aac ") ||
+		normalized.startsWith("mp4a.40.2") ||
+		normalized.includes("mp4a.40.2") ||
+		normalized === "audio/aac" ||
+		(normalized.includes("audio/mp4") && normalized.includes("mp4a.40.2"))
+	);
+}
+
+export function shouldCopyNativeVideoExportAudio(
+	options: Pick<
+		NativeVideoExportFinishOptions,
+		"audioMode" | "audioCodec" | "editedAudioMimeType"
+	>,
+): boolean {
+	const audioMode = options.audioMode ?? "none";
+	if (audioMode === "copy-source") {
+		return isNativeVideoExportPassthroughAudioCodec(options.audioCodec);
+	}
+
+	if (audioMode === "edited-track") {
+		return isNativeVideoExportPassthroughAudioCodec(options.editedAudioMimeType);
+	}
+
+	return false;
 }
 
 export function getNativeVideoInputByteSize(width: number, height: number): number {
@@ -159,23 +196,28 @@ export function buildTrimmedSourceAudioFilter(
  * — no re-encoding step, no raw pixel IPC traffic.
  */
 export function buildNativeH264StreamExportArgs(config: {
-        frameRate: number
-        outputPath: string
+	frameRate: number;
+	outputPath: string;
 }): string[] {
-        return [
-                '-y',
-                '-hide_banner',
-                '-loglevel',
-                'error',
-                // Input 0: pre-encoded H.264 Annex B stream from browser VideoEncoder via stdin
-                '-f', 'h264',
-                '-r', String(config.frameRate),
-                '-i', 'pipe:0',
-                '-an', // audio handled separately by muxNativeVideoExportAudio
-                '-c:v', 'copy',
-                '-movflags', '+faststart',
-                config.outputPath,
-        ]
+	return [
+		"-y",
+		"-hide_banner",
+		"-loglevel",
+		"error",
+		// Input 0: pre-encoded H.264 Annex B stream from browser VideoEncoder via stdin
+		"-f",
+		"h264",
+		"-r",
+		String(config.frameRate),
+		"-i",
+		"pipe:0",
+		"-an", // audio handled separately by muxNativeVideoExportAudio
+		"-c:v",
+		"copy",
+		"-movflags",
+		"+faststart",
+		config.outputPath,
+	];
 }
 
 export function getEditedAudioExtension(mimeType?: string | null): string {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -134,6 +134,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		options?: {
 			audioMode?: "none" | "copy-source" | "trim-source" | "edited-track";
 			audioSourcePath?: string | null;
+			audioCodec?: string | null;
 			trimSegments?: Array<{ startMs: number; endMs: number }>;
 			editedAudioData?: ArrayBuffer;
 			editedAudioMimeType?: string | null;
@@ -171,6 +172,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		options?: {
 			audioMode?: "none" | "copy-source" | "trim-source" | "edited-track";
 			audioSourcePath?: string | null;
+			audioCodec?: string | null;
 			trimSegments?: Array<{ startMs: number; endMs: number }>;
 			editedAudioData?: ArrayBuffer;
 			editedAudioMimeType?: string | null;

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -100,6 +100,7 @@ type NativeAudioPlan =
 	| {
 			audioMode: "copy-source" | "trim-source";
 			audioSourcePath: string;
+			audioCodec?: string | null;
 			trimSegments?: Array<{ startMs: number; endMs: number }>;
 	  }
 	| {
@@ -737,6 +738,8 @@ export class ModernVideoExporter {
 			(videoInfo.hasAudio ? localVideoSourcePath : null) ??
 			sourceAudioFallbackPaths[0] ??
 			null;
+		const primaryAudioCodec =
+			primaryAudioSourcePath === localVideoSourcePath ? (videoInfo.audioCodec ?? null) : null;
 
 		if (
 			!videoInfo.hasAudio &&
@@ -771,6 +774,7 @@ export class ModernVideoExporter {
 			return {
 				audioMode: "trim-source",
 				audioSourcePath: primaryAudioSourcePath,
+				audioCodec: primaryAudioCodec,
 				trimSegments,
 			};
 		}
@@ -778,6 +782,7 @@ export class ModernVideoExporter {
 		return {
 			audioMode: "copy-source",
 			audioSourcePath: primaryAudioSourcePath,
+			audioCodec: primaryAudioCodec,
 		};
 	}
 
@@ -1000,6 +1005,10 @@ export class ModernVideoExporter {
 					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
 						? audioPlan.audioSourcePath
 						: null,
+				audioCodec:
+					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
+						? (audioPlan.audioCodec ?? null)
+						: null,
 				trimSegments:
 					audioPlan.audioMode === "trim-source" ? audioPlan.trimSegments : undefined,
 				editedAudioData: editedAudioBuffer,
@@ -1075,6 +1084,10 @@ export class ModernVideoExporter {
 				audioSourcePath:
 					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
 						? audioPlan.audioSourcePath
+						: null,
+				audioCodec:
+					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
+						? (audioPlan.audioCodec ?? null)
 						: null,
 				trimSegments:
 					audioPlan.audioMode === "trim-source" ? audioPlan.trimSegments : undefined,

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -83,6 +83,7 @@ type NativeAudioPlan =
 	| {
 			audioMode: "copy-source" | "trim-source";
 			audioSourcePath: string;
+			audioCodec?: string | null;
 			trimSegments?: Array<{ startMs: number; endMs: number }>;
 	  }
 	| {
@@ -469,6 +470,8 @@ export class VideoExporter {
 			(videoInfo.hasAudio ? localVideoSourcePath : null) ??
 			sourceAudioFallbackPaths[0] ??
 			null;
+		const primaryAudioCodec =
+			primaryAudioSourcePath === localVideoSourcePath ? (videoInfo.audioCodec ?? null) : null;
 
 		if (
 			!videoInfo.hasAudio &&
@@ -503,6 +506,7 @@ export class VideoExporter {
 			return {
 				audioMode: "trim-source",
 				audioSourcePath: primaryAudioSourcePath,
+				audioCodec: primaryAudioCodec,
 				trimSegments,
 			};
 		}
@@ -510,6 +514,7 @@ export class VideoExporter {
 		return {
 			audioMode: "copy-source",
 			audioSourcePath: primaryAudioSourcePath,
+			audioCodec: primaryAudioCodec,
 		};
 	}
 
@@ -717,6 +722,10 @@ export class VideoExporter {
 					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
 						? audioPlan.audioSourcePath
 						: null,
+				audioCodec:
+					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
+						? (audioPlan.audioCodec ?? null)
+						: null,
 				trimSegments:
 					audioPlan.audioMode === "trim-source" ? audioPlan.trimSegments : undefined,
 				editedAudioData: editedAudioBuffer,
@@ -786,6 +795,10 @@ export class VideoExporter {
 				audioSourcePath:
 					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
 						? audioPlan.audioSourcePath
+						: null,
+				audioCodec:
+					audioPlan.audioMode === "copy-source" || audioPlan.audioMode === "trim-source"
+						? (audioPlan.audioCodec ?? null)
 						: null,
 				trimSegments:
 					audioPlan.audioMode === "trim-source" ? audioPlan.trimSegments : undefined,


### PR DESCRIPTION
## Summary
- avoid re-encoding source audio during final FFmpeg mux when the export is in the safe `copy-source` path and the source audio is already AAC-compatible
- thread source audio codec metadata from the exporters to the native/fallback mux boundary
- add focused unit coverage for the copy-vs-transcode decision logic

## Root Cause
The final FFmpeg mux path always re-encoded audio to AAC, even when the export was simply reattaching an unedited source audio track that was already AAC-compatible for MP4. That extra transcode work made the FFmpeg subprocess the long pole near 99% finalization.

## Validation
- `node .\\node_modules\\typescript\\bin\\tsc --noEmit`
- `node .\\node_modules\\vitest\\vitest.mjs run electron/ipc/nativeVideoExport.test.ts`
- `node .\\node_modules\\@biomejs\\biome\\bin\\biome check electron/electron-env.d.ts electron/preload.ts electron/ipc/nativeVideoExport.ts electron/ipc/export/native-video.ts src/lib/exporter/modernVideoExporter.ts src/lib/exporter/videoExporter.ts electron/ipc/nativeVideoExport.test.ts`
- local FFmpeg A/B benchmark on `recording-1776619033302.mp4`:
  - `-c:a copy`: average `202.42 ms`
  - `-c:a aac -b:a 192k`: average `634.17 ms`

## Issues
- Closes part of #221
- Closes part of #194