### PR TITLE
fix: request screen permissions before countdown

### DIFF
--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -926,11 +926,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				}
 			}
 
-			const permissionsReady = await preparePermissions();
-			if (!permissionsReady) {
-				return;
-			}
-
 			recordingSessionTimestamp.current = Date.now();
 			resetRecordingClock(recordingSessionTimestamp.current);
 			await prepareWebcamRecorder();
@@ -1623,20 +1618,40 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			return;
 		}
 
-		// Start recording with optional countdown
-		if (countdownDelay > 0) {
-			setCountdownActive(true);
-			try {
-				const result = await window.electronAPI.startCountdown(countdownDelay);
-				if (!result.success || result.cancelled) {
-					return;
+		// Request permissions BEFORE the countdown so:
+		// 1. The permission dialog doesn't interrupt or visually overlap the countdown.
+		// 2. We don't run a countdown only to fail at the end if permissions are denied.
+		// Set `starting` to guard against duplicate toggle calls while the
+		// (possibly async) permission dialog is open.
+		setStarting(true);
+		try {
+			const permissionsReady = await preparePermissions();
+			if (!permissionsReady) {
+				return;
+			}
+
+			// Start recording with optional countdown
+			if (countdownDelay > 0) {
+				setCountdownActive(true);
+				try {
+					const result = await window.electronAPI.startCountdown(countdownDelay);
+					if (!result.success || result.cancelled) {
+						return;
+					}
+				} finally {
+					setCountdownActive(false);
 				}
-			} finally {
-				setCountdownActive(false);
+			}
+
+			startRecording();
+		} finally {
+			// startRecording sets/clears `starting` itself once it takes over.
+			// If we returned early (permissions denied, countdown cancelled, or
+			// startRecording never ran), make sure we clear the flag here.
+			if (!startInFlight.current) {
+				setStarting(false);
 			}
 		}
-
-		startRecording();
 	};
 
 	return {


### PR DESCRIPTION
## Summary

Move the `preparePermissions()` call out of `startRecording()` and into `toggleRecording()` so it runs **before** the countdown.

### Why
Previously the countdown could finish while a macOS screen-recording permission dialog was still open, or run uselessly only to fail at the end if permissions were denied.

### What changed
- `preparePermissions()` is now invoked at the top of `toggleRecording()`, before the countdown.
- The permissions + countdown sequence is wrapped in `setStarting(true/false)` to prevent duplicate `toggleRecording` invocations while the (async) permission dialog is open.
- `startRecording()` continues to manage the `starting` flag itself once it takes over; the `toggleRecording` `finally` block only clears it if `startRecording` never started.

### Notes
This iteration is intentionally minimal. Previous Wayland/portal pre-acquisition work from earlier commits was dropped during the rebase onto current `main`, since `main` has since evolved to include the reentrancy guards (`starting`, `startInFlight`, `finalizing`) that the original PR introduced. If Wayland-specific timing issues remain, they should be addressed in a separate, focused PR.

### Verification
- TypeScript compiles cleanly (`tsc --noEmit`).
- All 32 `useScreenRecorder` unit tests pass.