### PR TITLE
fix(editor): extend auto full-track clips when duration grows

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -155,6 +155,7 @@ import {
 	DEFAULT_ZOOM_OUT_DURATION_MS,
 	DEFAULT_ZOOM_OUT_EASING,
 	type EditorEffectSection,
+	extendAutoFullTrackClip,
 	type FigureData,
 	getClipSourceEndMs,
 	type PlaybackSpeed,
@@ -1507,6 +1508,8 @@ export default function VideoEditor() {
 			setTrimRegions(normalizedEditor.trimRegions);
 			setClipRegions(normalizedEditor.clipRegions);
 			clipInitializedRef.current = normalizedEditor.clipRegions.length > 0;
+			autoFullTrackClipIdRef.current = null;
+			autoFullTrackClipEndMsRef.current = null;
 			setSpeedRegions(normalizedEditor.speedRegions);
 			setAnnotationRegions(normalizedEditor.annotationRegions);
 			setAudioRegions(normalizedEditor.audioRegions);
@@ -2336,15 +2339,33 @@ export default function VideoEditor() {
 
 	// Initialize a full-track clip when duration is first known
 	const clipInitializedRef = useRef(false);
+	const autoFullTrackClipIdRef = useRef<string | null>(null);
+	const autoFullTrackClipEndMsRef = useRef<number | null>(null);
 	useEffect(() => {
 		const totalMs = Math.round(duration * 1000);
-		if (totalMs <= 0 || clipInitializedRef.current) return;
-		if (clipRegions.length === 0) {
-			const id = `clip-${nextClipIdRef.current++}`;
-			setClipRegions([{ id, startMs: 0, endMs: totalMs, speed: 1 }]);
+		if (totalMs <= 0) return;
+		if (!clipInitializedRef.current) {
+			if (clipRegions.length === 0) {
+				const id = `clip-${nextClipIdRef.current++}`;
+				autoFullTrackClipIdRef.current = id;
+				autoFullTrackClipEndMsRef.current = totalMs;
+				setClipRegions([{ id, startMs: 0, endMs: totalMs, speed: 1 }]);
+			}
+			clipInitializedRef.current = true;
+			return;
 		}
-		clipInitializedRef.current = true;
-	}, [duration, clipRegions.length]);
+
+		const extendedClipRegions = extendAutoFullTrackClip(
+			clipRegions,
+			autoFullTrackClipIdRef.current,
+			autoFullTrackClipEndMsRef.current,
+			totalMs,
+		);
+		if (!extendedClipRegions) return;
+
+		autoFullTrackClipEndMsRef.current = totalMs;
+		setClipRegions(extendedClipRegions);
+	}, [duration, clipRegions]);
 
 	// Derive trimRegions from clipRegions so export/playback pipelines stay unchanged
 	useEffect(() => {

--- a/src/components/video-editor/types.test.ts
+++ b/src/components/video-editor/types.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { extendAutoFullTrackClip } from "./types";
+
+describe("extendAutoFullTrackClip", () => {
+	it("extends the default full-track clip when metadata duration grows", () => {
+		expect(
+			extendAutoFullTrackClip(
+				[{ id: "clip-1", startMs: 0, endMs: 5_000, speed: 1 }],
+				"clip-1",
+				5_000,
+				8_000,
+			),
+		).toEqual([{ id: "clip-1", startMs: 0, endMs: 8_000, speed: 1 }]);
+	});
+
+	it("does not change a clip that no longer matches the auto-created shape", () => {
+		expect(
+			extendAutoFullTrackClip(
+				[{ id: "clip-1", startMs: 0, endMs: 4_000, speed: 1.5 }],
+				"clip-1",
+				5_000,
+				8_000,
+			),
+		).toBeNull();
+	});
+
+	it("does not change multi-clip timelines or non-growing durations", () => {
+		expect(
+			extendAutoFullTrackClip(
+				[
+					{ id: "clip-1", startMs: 0, endMs: 3_000, speed: 1 },
+					{ id: "clip-2", startMs: 4_000, endMs: 8_000, speed: 1 },
+				],
+				"clip-1",
+				8_000,
+				10_000,
+			),
+		).toBeNull();
+		expect(
+			extendAutoFullTrackClip(
+				[{ id: "clip-1", startMs: 0, endMs: 8_000, speed: 1 }],
+				"clip-1",
+				8_000,
+				8_000,
+			),
+		).toBeNull();
+	});
+});

--- a/src/components/video-editor/types.test.ts
+++ b/src/components/video-editor/types.test.ts
@@ -25,7 +25,7 @@ describe("extendAutoFullTrackClip", () => {
 		).toBeNull();
 	});
 
-	it("does not change multi-clip timelines or non-growing durations", () => {
+	it("does not change multi-clip timelines", () => {
 		expect(
 			extendAutoFullTrackClip(
 				[
@@ -37,11 +37,69 @@ describe("extendAutoFullTrackClip", () => {
 				10_000,
 			),
 		).toBeNull();
+	});
+
+	it("does not change clips when the duration does not grow", () => {
 		expect(
 			extendAutoFullTrackClip(
 				[{ id: "clip-1", startMs: 0, endMs: 8_000, speed: 1 }],
 				"clip-1",
 				8_000,
+				8_000,
+			),
+		).toBeNull();
+	});
+
+	it("does not change clips when the auto-created clip id is missing", () => {
+		expect(
+			extendAutoFullTrackClip(
+				[{ id: "clip-1", startMs: 0, endMs: 5_000, speed: 1 }],
+				null,
+				5_000,
+				8_000,
+			),
+		).toBeNull();
+	});
+
+	it("does not change clips when the previous auto-created end time is missing", () => {
+		expect(
+			extendAutoFullTrackClip(
+				[{ id: "clip-1", startMs: 0, endMs: 5_000, speed: 1 }],
+				"clip-1",
+				null,
+				8_000,
+			),
+		).toBeNull();
+	});
+
+	it("does not change clips when the reported duration shrinks", () => {
+		expect(
+			extendAutoFullTrackClip(
+				[{ id: "clip-1", startMs: 0, endMs: 8_000, speed: 1 }],
+				"clip-1",
+				8_000,
+				7_000,
+			),
+		).toBeNull();
+	});
+
+	it("does not change clips when the tracked clip id no longer matches", () => {
+		expect(
+			extendAutoFullTrackClip(
+				[{ id: "clip-1", startMs: 0, endMs: 5_000, speed: 1 }],
+				"clip-2",
+				5_000,
+				8_000,
+			),
+		).toBeNull();
+	});
+
+	it("does not change clips when the clip no longer starts at zero", () => {
+		expect(
+			extendAutoFullTrackClip(
+				[{ id: "clip-1", startMs: 250, endMs: 5_000, speed: 1 }],
+				"clip-1",
+				5_000,
 				8_000,
 			),
 		).toBeNull();

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -155,6 +155,35 @@ export function getClipSourceEndMs(clip: ClipRegion): number {
 	return Math.round(clip.startMs + displayDurationMs * speed);
 }
 
+export function extendAutoFullTrackClip(
+	clips: ClipRegion[],
+	autoClipId: string | null,
+	previousAutoEndMs: number | null,
+	nextTotalDurationMs: number,
+): ClipRegion[] | null {
+	if (
+		!autoClipId ||
+		!Number.isFinite(previousAutoEndMs) ||
+		!Number.isFinite(nextTotalDurationMs) ||
+		nextTotalDurationMs <= (previousAutoEndMs ?? 0) ||
+		clips.length !== 1
+	) {
+		return null;
+	}
+
+	const [clip] = clips;
+	if (
+		clip.id !== autoClipId ||
+		clip.startMs !== 0 ||
+		clip.speed !== 1 ||
+		clip.endMs !== previousAutoEndMs
+	) {
+		return null;
+	}
+
+	return [{ ...clip, endMs: nextTotalDurationMs }];
+}
+
 /** Convert clip regions (kept segments) to trim regions (gaps to remove). */
 export function clipsToTrims(clips: ClipRegion[], totalDurationMs: number): TrimRegion[] {
 	if (clips.length === 0) return [];


### PR DESCRIPTION
## Description
Keep the editor's default full-track clip in sync when the media duration grows after the first metadata pass.

## Motivation
Some recordings report a shorter initial duration when the editor opens. The editor immediately creates a full-track clip from that first value and never extends it, so playback and export can look cut off even after the media element later reports the full duration.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Related Issue(s)
- #296

## Screenshots / Video
- N/A

## Testing Guide
- `node ./node_modules/vitest/vitest.mjs run src/components/video-editor/types.test.ts`
- `node ./node_modules/typescript/bin/tsc --noEmit`
- Electron regression harness on a real MP4, forcing `loadedmetadata` to report `5s` before a later `durationchange` to `8s`
  - baseline `origin/main`: clip row stayed at `0.0s -> 5.0s`
  - this branch: clip row expanded to `0.0s -> 8.0s`

## Checklist
- [x] I have tested these changes locally.
- [x] I have kept the change scoped to the reported issue.
- [x] I have added regression coverage for the new helper logic.
- [x] I have verified the editor behavior against a before/after runtime repro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved automatic clip region initialization with proper state tracking across duration updates.
  * Auto-created full-track clips now correctly extend when video duration changes.
  * Fixed automatic clip state carryover when loading projects.

* **Tests**
  * Added comprehensive test coverage for automatic clip region extension behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->