### PR TITLE
fix(linux): avoid forcing EGL on Wayland

### DIFF
--- a/electron/gpuSwitches.test.ts
+++ b/electron/gpuSwitches.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { getGpuSwitches, shouldForceLinuxEgl } from "./gpuSwitches";
+
+describe("shouldForceLinuxEgl", () => {
+	it("does not force EGL in a Wayland session", () => {
+		expect(
+			shouldForceLinuxEgl({
+				XDG_SESSION_TYPE: "wayland",
+				WAYLAND_DISPLAY: "wayland-0",
+			}),
+		).toBe(false);
+	});
+
+	it("does not force EGL when Wayland is explicitly requested via Ozone", () => {
+		expect(
+			shouldForceLinuxEgl({
+				OZONE_PLATFORM: "wayland",
+				XDG_SESSION_TYPE: "x11",
+			}),
+		).toBe(false);
+	});
+
+	it("forces EGL in an X11 session", () => {
+		expect(shouldForceLinuxEgl({ XDG_SESSION_TYPE: "x11" })).toBe(true);
+	});
+
+	it("forces EGL when x11 is explicitly requested via Electron's ozone hint", () => {
+		expect(
+			shouldForceLinuxEgl({
+				ELECTRON_OZONE_PLATFORM_HINT: "x11",
+				WAYLAND_DISPLAY: "wayland-0",
+			}),
+		).toBe(true);
+	});
+});
+
+describe("getGpuSwitches", () => {
+	it("returns the Linux VAAPI workaround without forcing EGL on Wayland", () => {
+		expect(
+			getGpuSwitches("linux", {
+				XDG_SESSION_TYPE: "wayland",
+				WAYLAND_DISPLAY: "wayland-0",
+			}),
+		).toEqual({
+			useGl: undefined,
+			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
+		});
+	});
+
+	it("returns the X11 EGL workaround on Linux X11", () => {
+		expect(getGpuSwitches("linux", { XDG_SESSION_TYPE: "x11" })).toEqual({
+			useGl: "egl",
+			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
+		});
+	});
+});

--- a/electron/gpuSwitches.test.ts
+++ b/electron/gpuSwitches.test.ts
@@ -21,6 +21,16 @@ describe("shouldForceLinuxEgl", () => {
 		).toBe(false);
 	});
 
+	it("falls back to Electron's ozone hint when OZONE_PLATFORM is invalid", () => {
+		expect(
+			shouldForceLinuxEgl({
+				OZONE_PLATFORM: "auto",
+				ELECTRON_OZONE_PLATFORM_HINT: "wayland",
+				XDG_SESSION_TYPE: "x11",
+			}),
+		).toBe(false);
+	});
+
 	it("forces EGL in an X11 session", () => {
 		expect(shouldForceLinuxEgl({ XDG_SESSION_TYPE: "x11" })).toBe(true);
 	});

--- a/electron/gpuSwitches.ts
+++ b/electron/gpuSwitches.ts
@@ -1,0 +1,63 @@
+export interface GpuSwitches {
+	useAngle?: string;
+	useGl?: string;
+	disableFeatures?: string[];
+}
+
+function getForcedLinuxWindowSystem(env: NodeJS.ProcessEnv): "wayland" | "x11" | null {
+	const ozonePlatform =
+		env.OZONE_PLATFORM?.toLowerCase() ??
+		env.ELECTRON_OZONE_PLATFORM_HINT?.toLowerCase() ??
+		null;
+
+	if (ozonePlatform === "wayland" || ozonePlatform === "x11") {
+		return ozonePlatform;
+	}
+
+	return null;
+}
+
+export function shouldForceLinuxEgl(env: NodeJS.ProcessEnv): boolean {
+	const forcedWindowSystem = getForcedLinuxWindowSystem(env);
+	if (forcedWindowSystem === "wayland") {
+		return false;
+	}
+	if (forcedWindowSystem === "x11") {
+		return true;
+	}
+
+	const sessionType = env.XDG_SESSION_TYPE?.toLowerCase();
+	if (sessionType === "wayland") {
+		return false;
+	}
+	if (sessionType === "x11") {
+		return true;
+	}
+
+	return !env.WAYLAND_DISPLAY;
+}
+
+export function getGpuSwitches(
+	platform: NodeJS.Platform,
+	env: NodeJS.ProcessEnv = process.env,
+): GpuSwitches {
+	if (platform === "darwin") {
+		return {
+			useAngle: "metal",
+			disableFeatures: ["MacCatapLoopbackAudioForScreenShare"],
+		};
+	}
+
+	if (platform === "win32") {
+		return { useAngle: "d3d11" };
+	}
+
+	if (platform === "linux") {
+		return {
+			useGl: shouldForceLinuxEgl(env) ? "egl" : undefined,
+			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
+		};
+	}
+
+	return {};
+}

--- a/electron/gpuSwitches.ts
+++ b/electron/gpuSwitches.ts
@@ -4,17 +4,20 @@ export interface GpuSwitches {
 	disableFeatures?: string[];
 }
 
-function getForcedLinuxWindowSystem(env: NodeJS.ProcessEnv): "wayland" | "x11" | null {
-	const ozonePlatform =
-		env.OZONE_PLATFORM?.toLowerCase() ??
-		env.ELECTRON_OZONE_PLATFORM_HINT?.toLowerCase() ??
-		null;
-
-	if (ozonePlatform === "wayland" || ozonePlatform === "x11") {
-		return ozonePlatform;
+function normalizeLinuxWindowSystem(value: string | undefined): "wayland" | "x11" | null {
+	const normalized = value?.trim().toLowerCase();
+	if (normalized === "wayland" || normalized === "x11") {
+		return normalized;
 	}
 
 	return null;
+}
+
+function getForcedLinuxWindowSystem(env: NodeJS.ProcessEnv): "wayland" | "x11" | null {
+	return (
+		normalizeLinuxWindowSystem(env.OZONE_PLATFORM) ??
+		normalizeLinuxWindowSystem(env.ELECTRON_OZONE_PLATFORM_HINT)
+	);
 }
 
 export function shouldForceLinuxEgl(env: NodeJS.ProcessEnv): boolean {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,6 +17,7 @@ import {
 import { RECORDINGS_DIR } from "./appPaths";
 import { showCursor } from "./cursorHider";
 import { registerExtensionIpcHandlers } from "./extensions/extensionIpc";
+import { getGpuSwitches } from "./gpuSwitches";
 import {
 	cleanupNativeVideoExportSessions,
 	getSelectedSourceId,
@@ -58,22 +59,16 @@ app.commandLine.appendSwitch("enable-unsafe-webgpu");
 app.commandLine.appendSwitch("enable-gpu-rasterization");
 
 function configureGpuAccelerationSwitches() {
-	if (process.platform === "darwin") {
-		app.commandLine.appendSwitch("use-angle", "metal");
-		app.commandLine.appendSwitch("disable-features", "MacCatapLoopbackAudioForScreenShare");
-		return;
+	const { useAngle, useGl, disableFeatures } = getGpuSwitches(process.platform, process.env);
+	if (useAngle) {
+		app.commandLine.appendSwitch("use-angle", useAngle);
 	}
-
-	if (process.platform === "win32") {
-		app.commandLine.appendSwitch("use-angle", "d3d11");
-		return;
+	if (useGl) {
+		app.commandLine.appendSwitch("use-gl", useGl);
 	}
-
-	// Linux (and other Unix): prefer EGL over GLX for better Wayland compatibility.
-	// Disable VAAPI — many distros ship broken drivers that cause
-	// "vaInitialize failed" and prevent the renderer from loading.
-	app.commandLine.appendSwitch("use-gl", "egl");
-	app.commandLine.appendSwitch("disable-features", "VaapiVideoDecoder,VaapiVideoEncoder");
+	if (disableFeatures && disableFeatures.length > 0) {
+		app.commandLine.appendSwitch("disable-features", disableFeatures.join(","));
+	}
 }
 
 async function logSmokeExportGpuDiagnostics() {
@@ -905,8 +900,7 @@ app.whenReady().then(async () => {
 			// source picker entirely). This avoids calling getSources() which
 			// would itself trigger an extra portal dialog.
 			const isLinuxPortalSentinel =
-				process.platform === "linux" &&
-				(sourceId === "screen:linux-portal" || !sourceId);
+				process.platform === "linux" && (sourceId === "screen:linux-portal" || !sourceId);
 			if (isLinuxPortalSentinel) {
 				callback({ video: { id: "screen:0:0", name: "Entire screen" } });
 				return;


### PR DESCRIPTION
## Description
Stop forcing `--use-gl=egl` when Recordly is running in a native Wayland session.

## Motivation
Issue #301 shows Wayland runs failing GPU initialization with `Requested GL implementation (gl=egl-gles2,angle=none)` and then falling back into a very slow or unusable export/editing path.

## Root Cause
A Linux-wide workaround added in #261 always appended `--use-gl=egl`. On current Electron/Chromium Wayland-native sessions, that can force an invalid GL implementation even though Electron already defaults to native Wayland on recent versions.

## Changes
- extract GPU switch selection into a small helper with tests
- keep the existing VAAPI disable workaround on all Linux sessions
- only keep the `use-gl=egl` workaround for Linux sessions that are actually X11
- do not force EGL when Wayland is detected or explicitly requested

## Related Issue(s)
- #301
- #261

## Testing Guide
- `node ./node_modules/vitest/vitest.mjs run electron/gpuSwitches.test.ts`
- `node ./node_modules/typescript/bin/tsc --noEmit`
- `node ./node_modules/@biomejs/biome/bin/biome check electron/main.ts electron/gpuSwitches.ts electron/gpuSwitches.test.ts`

## Notes
The switch-selection logic was verified locally on Windows, and the PR has now also been confirmed by a user on Arch Linux + Hyprland who built the branch and reported that the Wayland editor/export path became usable again.

## Checklist
- [x] Self-reviewed the changes for minimal scope
- [x] Added focused tests for the new switch selection logic
- [x] Verified typecheck and formatting locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * GPU acceleration configuration has been moved into a dedicated module, simplifying platform-specific graphics setup and making behavior more consistent across macOS, Windows, and Linux.

* **Tests**
  * Added tests covering GPU configuration and environment-driven graphics selection to ensure reliable handling of graphics APIs and Linux environment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->