### PR TITLE
fix(recording): keep longer audio tracks anchored

### DIFF
--- a/electron/ipc/ffmpeg/filters.test.ts
+++ b/electron/ipc/ffmpeg/filters.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { appendSyncedAudioFilter, getAudioSyncAdjustment } from "./filters";
+
+describe("getAudioSyncAdjustment", () => {
+	it("does not speed up longer audio tracks that would advance speech", () => {
+		expect(getAudioSyncAdjustment(120, 122.5)).toEqual({
+			mode: "none",
+			delayMs: 0,
+			tempoRatio: 1,
+			durationDeltaMs: -2500,
+		});
+	});
+
+	it("still stretches slightly shorter audio tracks to match the video", () => {
+		expect(getAudioSyncAdjustment(120, 117)).toEqual({
+			mode: "tempo",
+			delayMs: 0,
+			tempoRatio: 0.975,
+			durationDeltaMs: 3000,
+		});
+	});
+
+	it("still delays much shorter audio tracks instead of extreme tempo correction", () => {
+		expect(getAudioSyncAdjustment(120, 110)).toEqual({
+			mode: "delay",
+			delayMs: 10000,
+			tempoRatio: 1,
+			durationDeltaMs: 10000,
+		});
+	});
+
+	it("does not inject atempo when longer audio stays on the anchored path", () => {
+		const filterParts: string[] = [];
+		appendSyncedAudioFilter(filterParts, "[1:a]", "aout", getAudioSyncAdjustment(120, 122.5));
+
+		expect(filterParts).toEqual([
+			"[1:a]aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[aout]",
+		]);
+	});
+
+	it("still injects atempo for slightly shorter audio tracks", () => {
+		const filterParts: string[] = [];
+		appendSyncedAudioFilter(filterParts, "[1:a]", "aout", getAudioSyncAdjustment(120, 117));
+
+		expect(filterParts).toEqual([
+			"[1:a]atempo=0.975000,aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[aout]",
+		]);
+	});
+});

--- a/electron/ipc/ffmpeg/filters.ts
+++ b/electron/ipc/ffmpeg/filters.ts
@@ -44,10 +44,17 @@ export function getAudioSyncAdjustment(
 		return { mode: "none", delayMs: 0, tempoRatio: 1, durationDeltaMs };
 	}
 
+	// When the recorded audio runs longer than the video, globally speeding it
+	// up can pull speech ahead of the picture. Keep the track anchored at the
+	// start instead and let the downstream mux path trim any trailing overrun.
+	if (durationDeltaMs < 0) {
+		return { mode: "none", delayMs: 0, tempoRatio: 1, durationDeltaMs };
+	}
+
 	const tempoRatio = Math.max(0.5, Math.min(2, audioDuration / videoDuration));
 	const relativeDelta = absDeltaMs / Math.max(videoDuration * 1000, 1);
 
-	if (relativeDelta <= 0.03 || absDeltaMs <= 1500 || durationDeltaMs < 0) {
+	if (relativeDelta <= 0.03 || absDeltaMs <= 1500) {
 		return { mode: "tempo", delayMs: 0, tempoRatio, durationDeltaMs };
 	}
 
@@ -78,9 +85,7 @@ export function formatFfmpegSeconds(milliseconds: number): string {
 	return (milliseconds / 1000).toFixed(3);
 }
 
-export function normalizePauseSegments(
-	pauseSegments: PauseSegment[] | undefined,
-): PauseSegment[] {
+export function normalizePauseSegments(pauseSegments: PauseSegment[] | undefined): PauseSegment[] {
 	if (!Array.isArray(pauseSegments) || pauseSegments.length === 0) {
 		return [];
 	}


### PR DESCRIPTION
## Description
Keeps longer companion audio tracks anchored to the start of the recording instead of globally speeding them up during native mux preparation.

## Motivation
Issue [#225](https://github.com/webadderall/Recordly/issues/225) reports that recordings longer than about two minutes can end up with audio leading the video by a few seconds. The native sync heuristic currently treats slightly longer audio the same as slightly shorter audio and applies a global `atempo` correction, which can pull speech ahead of the picture.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Related Issue(s)
- #225

## Testing Guide
- `node ./node_modules/vitest/vitest.mjs run electron/ipc/ffmpeg/filters.test.ts`
- `node ./node_modules/typescript/bin/tsc --noEmit`
- `node ./node_modules/@biomejs/biome/bin/biome check electron/ipc/ffmpeg/filters.ts electron/ipc/ffmpeg/filters.test.ts`
- Synthetic FFmpeg repro on Windows:
  - baseline tempo path moved a 118s beep to `115.571s`
  - patched anchored path kept the same beep at `118.000s`

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Notes
This is intentionally narrow. It only changes the native sync heuristic for the "audio longer than video" case; shorter-audio tempo and delay handling stay on their existing paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio synchronization handling to correctly manage cases where audio duration differs from video duration, with proper selection between no adjustment, tempo adjustment, or delay adjustment based on mismatch severity.

* **Tests**
  * Added comprehensive test coverage for audio synchronization adjustment logic, including multiple timing scenarios and filter composition validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->