### PR TITLE
fix(update): hide empty update toast

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,7 @@ import {
 	createEditorWindow,
 	createHudOverlayWindow,
 	createSourceSelectorWindow,
+	createUpdateToastWindow,
 	getHudOverlayWindow,
 	getUpdateToastWindow,
 	hideUpdateToastWindow,
@@ -582,7 +583,7 @@ function sendUpdateToastToWindows(channel: "update-toast-state", payload: unknow
 		return true;
 	}
 
-	const toastWindow = showUpdateToastWindow();
+	const toastWindow = getUpdateToastWindow() ?? createUpdateToastWindow();
 	const sendPayload = () => {
 		toastWindow.webContents.send(channel, payload);
 		showUpdateToastWindow();
@@ -905,8 +906,7 @@ app.whenReady().then(async () => {
 			// source picker entirely). This avoids calling getSources() which
 			// would itself trigger an extra portal dialog.
 			const isLinuxPortalSentinel =
-				process.platform === "linux" &&
-				(sourceId === "screen:linux-portal" || !sourceId);
+				process.platform === "linux" && (sourceId === "screen:linux-portal" || !sourceId);
 			if (isLinuxPortalSentinel) {
 				callback({ video: { id: "screen:0:0", name: "Entire screen" } });
 				return;

--- a/src/components/launch/UpdateToastWindow.test.tsx
+++ b/src/components/launch/UpdateToastWindow.test.tsx
@@ -1,0 +1,10 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { UpdateToastWindow } from "./UpdateToastWindow";
+
+describe("UpdateToastWindow", () => {
+	it("does not render a placeholder while waiting for a toast payload", () => {
+		expect(renderToStaticMarkup(<UpdateToastWindow />)).toBe("");
+	});
+});

--- a/src/components/launch/UpdateToastWindow.tsx
+++ b/src/components/launch/UpdateToastWindow.tsx
@@ -75,22 +75,22 @@ export function UpdateToastWindow() {
 
 		void window.electronAPI.getCurrentUpdateToastPayload().then((nextPayload) => {
 			if (mounted) {
-				setPayload(nextPayload);
+				setPayload(nextPayload ?? null);
 			}
 		});
 
 		pollTimer = setInterval(() => {
 			void window.electronAPI.getCurrentUpdateToastPayload().then((nextPayload) => {
-				if (!mounted || !nextPayload) {
+				if (!mounted) {
 					return;
 				}
 
-				setPayload((currentPayload) => currentPayload ?? nextPayload);
+				setPayload(nextPayload ?? null);
 			});
 		}, 750);
 
 		const dispose = window.electronAPI.onUpdateToastStateChanged((nextPayload) => {
-			setPayload(nextPayload);
+			setPayload(nextPayload ?? null);
 		});
 
 		return () => {
@@ -194,21 +194,7 @@ export function UpdateToastWindow() {
 	} as const;
 
 	if (!payload) {
-		return (
-			<div style={wrapperStyle}>
-				<div style={{ ...cardStyle, alignItems: "center" }}>
-					<div style={iconBoxStyle}>
-						<LoaderCircle size={20} />
-					</div>
-					<div>
-						<p style={titleStyle}>Checking for updates</p>
-						<p style={secondaryTextStyle}>
-							Waiting for updater state from the main process.
-						</p>
-					</div>
-				</div>
-			</div>
-		);
+		return null;
 	}
 
 	const normalizedProgress = Math.max(0, Math.min(100, Math.round(payload.progressPercent ?? 0)));


### PR DESCRIPTION
## Description
Prevent the macOS update toast window from showing a placeholder card before the main process has an actual updater payload to display.

## Motivation
Issue #306 shows a visible update toast stuck on "Checking for updates / Waiting for updater state from the main process." The current flow can show the toast window before the payload reaches the renderer, and the renderer treats a missing payload as user-facing content instead of "no toast".

## Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Tests

## Related Issue(s)
- #306

## Testing Guide
- `node ./node_modules/vitest/vitest.mjs run src/components/launch/UpdateToastWindow.test.tsx`
- `node ./node_modules/typescript/bin/tsc --noEmit`
- `node ./node_modules/@biomejs/biome/bin/biome check electron/main.ts src/components/launch/UpdateToastWindow.tsx src/components/launch/UpdateToastWindow.test.tsx`

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the code changes locally
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation
