### PR TITLE
fix(recording): recover from fullscreen countdown failures

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -154,7 +154,21 @@ function restoreWindowSafely(window: BrowserWindow | null) {
 		return;
 	}
 
-	window.restore();
+	if (!isEditorWindow(window) && process.platform === "win32") {
+		showHudOverlayFromTray();
+		return;
+	}
+
+	if (window.isMinimized()) {
+		window.restore();
+	}
+
+	if (!window.isVisible()) {
+		window.show();
+	}
+
+	window.moveTop();
+	window.focus();
 }
 
 // Tray Icons (lazily created after app is ready to avoid accessing Electron APIs too early)

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -904,7 +904,12 @@ export function createCountdownWindow(): BrowserWindow {
 
 	win.webContents.on("did-finish-load", () => {
 		if (!win.isDestroyed()) {
-			win.show();
+			if (process.platform === "win32") {
+				win.showInactive();
+				win.moveTop();
+			} else {
+				win.show();
+			}
 		}
 	});
 

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1300,9 +1300,14 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					: "Failed to start recording",
 			);
 			setRecording(false);
-			await window.electronAPI?.setRecordingState(false);
-			cleanupCapturedMedia();
-			await stopWebcamRecorder();
+			try {
+				await window.electronAPI?.setRecordingState(false);
+			} catch (stateError) {
+				console.warn("Failed to reset main-process recording state:", stateError);
+			} finally {
+				cleanupCapturedMedia();
+				await stopWebcamRecorder();
+			}
 		} finally {
 			startInFlight.current = false;
 			setStarting(false);

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1300,6 +1300,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					: "Failed to start recording",
 			);
 			setRecording(false);
+			await window.electronAPI?.setRecordingState(false);
 			cleanupCapturedMedia();
 			await stopWebcamRecorder();
 		} finally {


### PR DESCRIPTION
## Description
Improves recovery when starting a recording from Windows fullscreen sessions. The patch keeps the countdown window from stealing focus on Windows, explicitly clears the recording-state latch when start-up fails, and restores the HUD through the tray recovery path instead of leaving the app alive but unusable.

## Motivation
Issue [#241](https://github.com/webadderall/Recordly/issues/241) reports that starting a recording from fullscreen can finish the countdown, fail to begin recording, and then leave the app effectively stuck until it is force-closed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Related Issue(s)
- #241

## Testing Guide
- `node ..\\Recordly\\node_modules\\typescript\\bin\\tsc --noEmit`
- `node ..\\Recordly\\node_modules\\@biomejs\\biome\\bin\\biome lint electron\\main.ts electron\\windows.ts src\\hooks\\useScreenRecorder.ts`
- `npm run build:win`
- Windows Electron repro for countdown focus behavior:
  - `show()` path switched focus from the fullscreen target to the countdown overlay
  - `showInactive()` kept the fullscreen target focused while leaving the overlay visible on top

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Notes
This stays intentionally narrow and Windows-focused. I validated the countdown focus behavior locally with a minimal Electron fullscreen repro, but I still have not reproduced the exact multi-monitor Chrome setup from the issue report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window restoration on Windows: avoids unnecessary restores, ensures hidden/minimized windows become visible, and correctly adjusts z-order and activation.
  * Updated countdown window display on Windows to use inactive show mode for proper window management.
  * Enhanced recording failure handling to better reset recording state and ensure cleanup runs reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->