### PR TITLE
fix(launch): disable floating webcam preview without passthrough

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -88,6 +88,10 @@ interface Window {
 		setHudOverlayCompactWidth: (width: number) => void;
 		setHudOverlayMeasuredHeight: (height: number, expanded: boolean) => void;
 		getHudOverlayCaptureProtection: () => Promise<{ success: boolean; enabled: boolean }>;
+		getHudOverlayMousePassthroughSupported: () => Promise<{
+			success: boolean;
+			supported: boolean;
+		}>;
 		setHudOverlayCaptureProtection: (
 			enabled: boolean,
 		) => Promise<{ success: boolean; enabled: boolean }>;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -96,6 +96,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	getHudOverlayCaptureProtection: () => {
 		return ipcRenderer.invoke("get-hud-overlay-capture-protection");
 	},
+	getHudOverlayMousePassthroughSupported: () => {
+		return ipcRenderer.invoke("get-hud-overlay-mouse-passthrough-supported");
+	},
 	setHudOverlayCaptureProtection: (enabled: boolean) => {
 		return ipcRenderer.invoke("set-hud-overlay-capture-protection", enabled);
 	},

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -403,6 +403,13 @@ ipcMain.handle("get-hud-overlay-capture-protection", () => {
 	};
 });
 
+ipcMain.handle("get-hud-overlay-mouse-passthrough-supported", () => {
+	return {
+		success: true,
+		supported: isHudOverlayMousePassthroughSupported(),
+	};
+});
+
 ipcMain.handle("set-hud-overlay-capture-protection", (_event, enabled: boolean) => {
 	loadHudOverlayCaptureProtectionSetting();
 	hudOverlayHiddenFromCapture = Boolean(enabled);

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -42,6 +42,10 @@ import ProjectBrowserDialog, {
 	type ProjectLibraryEntry,
 } from "../video-editor/ProjectBrowserDialog";
 import {
+	canShowFloatingWebcamPreview,
+	canToggleFloatingWebcamPreview,
+} from "./floatingWebcamPreview";
+import {
 	mergeHudInteractiveBounds,
 	shouldRestoreHudMousePassthroughAfterDrag,
 } from "./hudMousePassthrough";
@@ -199,6 +203,9 @@ export function LaunchWindow() {
 	const [showFloatingWebcamPreview, setShowFloatingWebcamPreview] = useState(true);
 	const [webcamPreviewOffset, setWebcamPreviewOffset] = useState(DEFAULT_WEBCAM_PREVIEW_OFFSET);
 	const [recordingHudOffset, setRecordingHudOffset] = useState(DEFAULT_RECORDING_HUD_OFFSET);
+	const [hudOverlayMousePassthroughSupported, setHudOverlayMousePassthroughSupported] = useState<
+		boolean | null
+	>(null);
 	const [platform, setPlatform] = useState<string | null>(null);
 	const [appVersion, setAppVersion] = useState<string | null>(null);
 	const [updateStatus, setUpdateStatus] = useState<{
@@ -264,9 +271,14 @@ export function LaunchWindow() {
 	const micDropdownOpen = activeDropdown === "mic";
 	const webcamDropdownOpen = activeDropdown === "webcam";
 	const showWebcamControls = webcamEnabled && !recording;
-	const showRecordingWebcamPreview = webcamEnabled && showFloatingWebcamPreview;
+	const showRecordingWebcamPreview =
+		webcamEnabled &&
+		canShowFloatingWebcamPreview(
+			showFloatingWebcamPreview,
+			hudOverlayMousePassthroughSupported,
+		);
 	const shouldStreamWebcamPreview =
-		webcamEnabled && (showFloatingWebcamPreview || (showWebcamControls && webcamDropdownOpen));
+		webcamEnabled && (showRecordingWebcamPreview || (showWebcamControls && webcamDropdownOpen));
 	const { devices, selectedDeviceId, setSelectedDeviceId } = useMicrophoneDevices(
 		microphoneEnabled || micDropdownOpen,
 		microphoneDeviceId,
@@ -675,6 +687,24 @@ export function LaunchWindow() {
 			}
 		};
 		void loadPlatform();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+		const loadHudOverlayMousePassthroughSupport = async () => {
+			try {
+				const result = await window.electronAPI.getHudOverlayMousePassthroughSupported();
+				if (!cancelled && result.success) {
+					setHudOverlayMousePassthroughSupported(result.supported);
+				}
+			} catch (error) {
+				console.error("Failed to load HUD overlay mouse passthrough support:", error);
+			}
+		};
+		void loadHudOverlayMousePassthroughSupport();
 		return () => {
 			cancelled = true;
 		};
@@ -1403,25 +1433,29 @@ export function LaunchWindow() {
 											>
 												{t("recording.turnOffWebcam")}
 											</DropdownItem>
-											<DropdownItem
-												icon={
-													showFloatingWebcamPreview ? (
-														<EyeOff size={16} />
-													) : (
-														<Eye size={16} />
-													)
-												}
-												selected={showFloatingWebcamPreview}
-												onClick={() => {
-													setShowFloatingWebcamPreview(
-														(current) => !current,
-													);
-												}}
-											>
-												{showFloatingWebcamPreview
-													? t("recording.hideFloatingWebcamPreview")
-													: t("recording.showFloatingWebcamPreview")}
-											</DropdownItem>
+											{canToggleFloatingWebcamPreview(
+												hudOverlayMousePassthroughSupported,
+											) ? (
+												<DropdownItem
+													icon={
+														showFloatingWebcamPreview ? (
+															<EyeOff size={16} />
+														) : (
+															<Eye size={16} />
+														)
+													}
+													selected={showFloatingWebcamPreview}
+													onClick={() => {
+														setShowFloatingWebcamPreview(
+															(current) => !current,
+														);
+													}}
+												>
+													{showFloatingWebcamPreview
+														? t("recording.hideFloatingWebcamPreview")
+														: t("recording.showFloatingWebcamPreview")}
+												</DropdownItem>
+											) : null}
 										</>
 									)}
 									{!webcamEnabled && (

--- a/src/components/launch/floatingWebcamPreview.test.ts
+++ b/src/components/launch/floatingWebcamPreview.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	canShowFloatingWebcamPreview,
+	canToggleFloatingWebcamPreview,
+} from "./floatingWebcamPreview";
+
+describe("canShowFloatingWebcamPreview", () => {
+	it("shows the floating preview only when it was requested and passthrough is supported", () => {
+		expect(canShowFloatingWebcamPreview(true, true)).toBe(true);
+		expect(canShowFloatingWebcamPreview(false, true)).toBe(false);
+		expect(canShowFloatingWebcamPreview(true, false)).toBe(false);
+		expect(canShowFloatingWebcamPreview(true, null)).toBe(false);
+	});
+});
+
+describe("canToggleFloatingWebcamPreview", () => {
+	it("keeps the toggle visible while support is unknown or available", () => {
+		expect(canToggleFloatingWebcamPreview(null)).toBe(true);
+		expect(canToggleFloatingWebcamPreview(true)).toBe(true);
+	});
+
+	it("hides the toggle when the platform cannot support the floating preview", () => {
+		expect(canToggleFloatingWebcamPreview(false)).toBe(false);
+	});
+});

--- a/src/components/launch/floatingWebcamPreview.ts
+++ b/src/components/launch/floatingWebcamPreview.ts
@@ -1,0 +1,12 @@
+export function canShowFloatingWebcamPreview(
+	requested: boolean,
+	hudOverlayMousePassthroughSupported: boolean | null,
+): boolean {
+	return requested && hudOverlayMousePassthroughSupported === true;
+}
+
+export function canToggleFloatingWebcamPreview(
+	hudOverlayMousePassthroughSupported: boolean | null,
+): boolean {
+	return hudOverlayMousePassthroughSupported !== false;
+}


### PR DESCRIPTION
## Description
Disable the floating webcam preview when the HUD overlay cannot support mouse passthrough.

## Motivation
Issue #320 reports that enabling the floating webcam preview on Windows 10 makes the desktop unusable outside the HUD. The problem is that the recording HUD expands to the full viewport for the draggable preview, but Windows 10 currently falls back to a non-passthrough overlay window.

## Root Cause
When `showRecordingWebcamPreview` is enabled, the renderer reports a full-viewport HUD size so the floating preview can be dragged anywhere on screen. On platforms where `isHudOverlayMousePassthroughSupported()` is false, that turns the transparent HUD overlay into a fullscreen click blocker.

## Changes
- expose HUD mouse passthrough support to the renderer
- only render the floating webcam preview when passthrough support is available
- hide the floating preview toggle when the platform cannot safely support it
- add focused helper tests for the gating logic

## Related Issue(s)
- #320
- #300

## Testing Guide
- `node ./node_modules/vitest/vitest.mjs run src/components/launch/floatingWebcamPreview.test.ts`
- `node ./node_modules/typescript/bin/tsc --noEmit`
- `node ./node_modules/@biomejs/biome/bin/biome check electron/windows.ts electron/preload.ts electron/electron-env.d.ts src/components/launch/LaunchWindow.tsx src/components/launch/floatingWebcamPreview.ts src/components/launch/floatingWebcamPreview.test.ts`

## Notes
This keeps the existing floating preview behavior on platforms where HUD passthrough is supported, while falling back to the non-floating webcam controls on platforms where a fullscreen transparent overlay would block the desktop.