### PR TITLE
fix(editor): place added audio on the first free track

### DIFF
--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -1273,7 +1273,11 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				}
 
 				if (isAudioItem) {
-					return checkOverlap(audioRegions);
+					const currentAudio = audioRegions.find((region) => region.id === excludeId);
+					const trackIndex = currentAudio?.trackIndex ?? 0;
+					return checkOverlap(
+						audioRegions.filter((region) => (region.trackIndex ?? 0) === trackIndex),
+					);
 				}
 
 				return false;

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -1,5 +1,3 @@
-import type { Range, Span } from "dnd-timeline";
-import { useTimelineContext } from "dnd-timeline";
 import {
 	Check,
 	CaretDown as ChevronDown,
@@ -11,6 +9,8 @@ import {
 	MagicWand as WandSparkles,
 	MagnifyingGlassPlus as ZoomIn,
 } from "@phosphor-icons/react";
+import type { Range, Span } from "dnd-timeline";
+import { useTimelineContext } from "dnd-timeline";
 import {
 	forwardRef,
 	type KeyboardEvent as ReactKeyboardEvent,
@@ -56,6 +56,7 @@ import type {
 	ZoomRegion,
 } from "../types";
 import AudioWaveform from "./AudioWaveform";
+import { findAudioTrackPlacement } from "./audioTrackPlacement";
 import Item from "./Item";
 import KeyframeMarkers from "./KeyframeMarkers";
 import Row from "./Row";
@@ -1526,14 +1527,8 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			}
 
 			const startPos = Math.max(0, Math.min(currentTimeMs, totalMs));
-			const sorted = [...audioRegions].sort((a, b) => a.startMs - b.startMs);
-			const nextRegion = sorted.find((region) => region.startMs > startPos);
-			const gapToNext = nextRegion ? nextRegion.startMs - startPos : totalMs - startPos;
-
-			const isOverlapping = sorted.some(
-				(region) => startPos >= region.startMs && startPos < region.endMs,
-			);
-			if (isOverlapping || gapToNext <= 0) {
+			const placement = findAudioTrackPlacement(audioRegions, startPos, totalMs);
+			if (!placement) {
 				toast.error("Cannot place audio here", {
 					description:
 						"Audio region already exists at this location or not enough space available.",
@@ -1541,9 +1536,12 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				return;
 			}
 
-			// Use full audio duration, but clamp to available gap and video length
-			const actualDuration = Math.min(audioDurationMs, gapToNext, totalMs - startPos);
-			onAudioAdded({ start: startPos, end: startPos + actualDuration }, result.path);
+			const actualDuration = Math.min(audioDurationMs, placement.availableDurationMs);
+			onAudioAdded(
+				{ start: startPos, end: startPos + actualDuration },
+				result.path,
+				placement.trackIndex,
+			);
 		}, [videoDuration, totalMs, currentTimeMs, audioRegions, onAudioAdded]);
 
 		const handleAddAnnotation = useCallback(

--- a/src/components/video-editor/timeline/audioTrackPlacement.test.ts
+++ b/src/components/video-editor/timeline/audioTrackPlacement.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { findAudioTrackPlacement } from "./audioTrackPlacement";
+
+describe("findAudioTrackPlacement", () => {
+	it("places audio on the first track when the playhead is free there", () => {
+		expect(
+			findAudioTrackPlacement(
+				[{ id: "audio-1", startMs: 3_000, endMs: 5_000, audioPath: "a.wav", volume: 1 }],
+				1_000,
+				10_000,
+			),
+		).toEqual({ trackIndex: 0, availableDurationMs: 2_000 });
+	});
+
+	it("moves audio to the next track when the current track overlaps", () => {
+		expect(
+			findAudioTrackPlacement(
+				[
+					{ id: "audio-1", startMs: 0, endMs: 4_000, audioPath: "a.wav", volume: 1 },
+					{
+						id: "audio-2",
+						startMs: 5_000,
+						endMs: 7_000,
+						audioPath: "b.wav",
+						volume: 1,
+						trackIndex: 1,
+					},
+				],
+				2_000,
+				10_000,
+			),
+		).toEqual({ trackIndex: 1, availableDurationMs: 3_000 });
+	});
+
+	it("creates a new track when all existing tracks overlap at the playhead", () => {
+		expect(
+			findAudioTrackPlacement(
+				[
+					{ id: "audio-1", startMs: 0, endMs: 4_000, audioPath: "a.wav", volume: 1 },
+					{
+						id: "audio-2",
+						startMs: 1_000,
+						endMs: 6_000,
+						audioPath: "b.wav",
+						volume: 1,
+						trackIndex: 1,
+					},
+				],
+				2_000,
+				10_000,
+			),
+		).toEqual({ trackIndex: 2, availableDurationMs: 8_000 });
+	});
+
+	it("returns null when there is no time left in the timeline", () => {
+		expect(findAudioTrackPlacement([], 10_000, 10_000)).toBeNull();
+	});
+
+	it("returns null for invalid negative start positions", () => {
+		expect(findAudioTrackPlacement([], -1, 10_000)).toBeNull();
+	});
+});

--- a/src/components/video-editor/timeline/audioTrackPlacement.ts
+++ b/src/components/video-editor/timeline/audioTrackPlacement.ts
@@ -1,0 +1,51 @@
+import type { AudioRegion } from "../types";
+
+export interface AudioTrackPlacement {
+	trackIndex: number;
+	availableDurationMs: number;
+}
+
+export function findAudioTrackPlacement(
+	audioRegions: AudioRegion[],
+	startMs: number,
+	totalDurationMs: number,
+): AudioTrackPlacement | null {
+	if (
+		!Number.isFinite(startMs) ||
+		!Number.isFinite(totalDurationMs) ||
+		totalDurationMs <= 0 ||
+		startMs < 0 ||
+		startMs >= totalDurationMs
+	) {
+		return null;
+	}
+
+	const normalizedRegions = audioRegions.map((region) => ({
+		startMs: region.startMs,
+		endMs: region.endMs,
+		trackIndex: region.trackIndex ?? 0,
+	}));
+	const maxTrackIndex = normalizedRegions.reduce(
+		(max, region) => Math.max(max, region.trackIndex),
+		0,
+	);
+
+	for (let trackIndex = 0; trackIndex <= maxTrackIndex + 1; trackIndex += 1) {
+		const trackRegions = normalizedRegions
+			.filter((region) => region.trackIndex === trackIndex)
+			.sort((left, right) => left.startMs - right.startMs);
+		const nextRegion = trackRegions.find((region) => region.startMs > startMs);
+		const availableDurationMs = nextRegion
+			? nextRegion.startMs - startMs
+			: totalDurationMs - startMs;
+		const isOverlapping = trackRegions.some(
+			(region) => startMs >= region.startMs && startMs < region.endMs,
+		);
+
+		if (!isOverlapping && availableDurationMs > 0) {
+			return { trackIndex, availableDurationMs };
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Description
Fix the editor add-audio flow so a new audio region is placed on the first non-overlapping audio track instead of being rejected immediately when the playhead is already inside another audio region.

## Motivation
Issue #322 comes from the editor already supporting audio track rows internally, but the current Add Audio flow still blocks insertion as soon as the current timestamp overlaps any existing audio region. That makes it impossible to add a second overlapping audio source on a separate track.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #322

## Changes Made
- add a small pure helper to find the first audio track that is free at the current playhead position
- keep using the existing track 0 behavior when that row is already free
- move overlapping inserts onto the next available audio track instead of showing an immediate placement error
- keep the existing duration clamping behavior per chosen track
- add focused unit coverage for the new placement logic

## Testing Guide
1. Open the editor with an existing audio region already covering the current playhead time.
2. Click `Add Audio` and choose another audio file.
3. Verify the new region is added on a separate audio track instead of being blocked.
4. Verify non-overlapping inserts on track 0 still behave the same as before.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the new behavior.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `vitest run src/components/video-editor/timeline/audioTrackPlacement.test.ts src/components/video-editor/types.test.ts`
- `tsc --noEmit`
- `biome check src/components/video-editor/timeline/audioTrackPlacement.ts src/components/video-editor/timeline/audioTrackPlacement.test.ts src/components/video-editor/timeline/TimelineEditor.tsx`

Runtime A/B smoke on Windows (same local project state in both runs):
- baseline `origin/main`: one existing audio region at `0ms` on track 0, then Add Audio at `0ms` leaves the editor with only that original region
- patched branch: the same Add Audio action adds a second region at `0ms` on `trackIndex: 1`
- patched UI result: `existing-track` stays on the first audio row and `added-track` appears on the next row


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved audio placement logic in the timeline editor to better determine track assignment and available space for audio segments.

* **Tests**
  * Added comprehensive test suite to validate audio track placement behavior and ensure correct track assignment based on existing clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->