### PR TITLE
fix(linux): allow dragging HUD overlay on Wayland

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -301,6 +301,16 @@ let hudDragFixedSize: { width: number; height: number } | null = null;
 ipcMain.on("hud-overlay-drag", (_event, phase: string, screenX: number, screenY: number) => {
 	if (!hudOverlayWindow || hudOverlayWindow.isDestroyed()) return;
 
+	// On Linux the compositor (especially Wayland) refuses programmatic window
+	// placement, so BrowserWindow.setBounds() with x/y is silently ignored and
+	// the HUD appears "stuck".  The renderer marks the drag handle as
+	// -webkit-app-region: drag on Linux, letting the OS move the window for us.
+	// The resulting position is captured by the win.on("moved", ...) listener
+	// below so `hudUserPosition` stays in sync for in-place resize.
+	if (process.platform === "linux") {
+		return;
+	}
+
 	if (phase === "start") {
 		const bounds = hudOverlayWindow.getBounds();
 		hudDragOffset = { x: screenX - bounds.x, y: screenY - bounds.y };
@@ -510,6 +520,18 @@ export function createHudOverlayWindow(): BrowserWindow {
 	});
 
 	hudOverlayWindow = win;
+
+	// On Linux the HUD is dragged by the OS via -webkit-app-region (Wayland
+	// forbids client-side positioning).  Mirror the resulting bounds into
+	// hudUserPosition so subsequent expand/collapse resizes stay in place
+	// instead of snapping back to the default centered spot.
+	if (process.platform === "linux") {
+		win.on("moved", () => {
+			if (win.isDestroyed()) return;
+			const { x, y } = win.getBounds();
+			hudUserPosition = { x, y };
+		});
+	}
 
 	// Reset the user's saved HUD position when displays change so the bar
 	// doesn't end up stranded off-screen after a monitor is disconnected.

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -1587,7 +1587,17 @@ export function LaunchWindow() {
 							className={`${styles.bar} mb-2`}
 						>
 							<div
-								className="flex items-center px-0.5 cursor-grab active:cursor-grabbing"
+								// On Linux (especially Wayland) the compositor owns window
+								// placement, so BrowserWindow.setBounds() is silently ignored.
+								// Fall back to a native OS drag via -webkit-app-region on the
+								// handle.  We still need JS pointer handlers in webcam-preview
+								// mode (which translates via CSS inside the window), so only
+								// mark the handle as a native drag region for the IPC path.
+								className={`flex items-center px-0.5 cursor-grab active:cursor-grabbing ${
+									platform === "linux" && !showRecordingWebcamPreview
+										? styles.electronDrag
+										: ""
+								}`}
 								onPointerDown={handleHudBarPointerDown}
 								onPointerMove={handleHudBarPointerMove}
 								onPointerUp={handleHudBarPointerUp}


### PR DESCRIPTION
## Summary
- On Linux (especially Wayland) the HUD bar couldn't be dragged: the cursor switched to `grabbing` but the window stayed put.
- Root cause: the IPC-driven drag in `electron/windows.ts` calls `BrowserWindow.setBounds({x, y, ...})` on every `pointermove`, which Wayland silently ignores — the compositor owns window placement.

## Fix
- In `LaunchWindow.tsx`, mark the drag handle as `-webkit-app-region: drag` on Linux only, and only in the "overlay" IPC path. The webcam-preview mode keeps its JS handlers because it animates via CSS `transform` inside the window (works on Wayland).
- In `electron/windows.ts`, early-return the `hud-overlay-drag` IPC handler on Linux (no-op to avoid churn), and add a `win.on("moved", ...)` listener that mirrors the OS-driven position into `hudUserPosition` so the "preserve user-dragged position across recording state changes" behavior from a78f7d4 keeps working on Linux.

## Scope / risk
- macOS and Windows paths untouched.
- Webcam-preview drag path untouched.
- Only new behavior on Linux: the drag handle becomes a native drag region.