### PR TITLE
fix(build): stage Whisper runtime in macOS CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build macOS app
         run: |
-          npm run build:native-helpers
+          npm run build:platform-native-helpers
           npx tsc
           npx vite build
           npx electron-builder --mac dmg zip --publish never

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
         run: npx electron-builder install-app-deps
 
       - name: Build native macOS helpers
-        run: npm run build:native-helpers
+        run: npm run build:platform-native-helpers
 
       - name: Build macOS x64
         run: |
@@ -213,7 +213,7 @@ jobs:
         run: npx electron-builder install-app-deps
 
       - name: Build native macOS helpers
-        run: npm run build:native-helpers
+        run: npm run build:platform-native-helpers
 
       - name: Build macOS arm64
         run: |


### PR DESCRIPTION
Description
This is a focused fix for the macOS packaging path behind auto-captions. The GitHub macOS build and release jobs were still calling `npm run build:native-helpers`, which skips the bundled Whisper runtime. This switches those jobs to `npm run build:platform-native-helpers` so packaged macOS artifacts stage `whisper-cli` before Electron Builder runs.

Motivation
Issue #220 reports auto-captions failing immediately after pressing Generate. On current `main`, source builds already run `build:platform-native-helpers`, but the macOS CI packaging jobs did not, so packaged macOS builds could ship without the Whisper runtime and fail before transcription starts. I kept this scoped to the macOS packaging path only; the Windows reports in #220 may still need separate investigation.

Type of Change
- [x] Bug Fix

Related Issue(s)
Related: #220

Screenshots / Video
Not included. This is a workflow-only change.

Testing Guide
- Reviewed the current caption generation path in `electron/ipc/captions/generate.ts` and the packaging workflows on `main`
- Confirmed the bundled Whisper runtime is built by `npm run build:platform-native-helpers`
- Confirmed the macOS jobs in `.github/workflows/build.yml` and `.github/workflows/release.yml` were still using `npm run build:native-helpers`
- Updated those macOS jobs to `npm run build:platform-native-helpers`
- Ran `git diff --check`
- Verified via grep that every macOS workflow path now uses `build:platform-native-helpers`

Checklist
- [x] I kept the scope narrow
- [x] I verified the changed workflow paths locally
- [ ] I did not run a real macOS build locally from this Windows host
