### PR TITLE
fix(recording): normalize native Windows mic loudness

### DIFF
--- a/electron/ipc/ffmpeg/filters.test.ts
+++ b/electron/ipc/ffmpeg/filters.test.ts
@@ -69,6 +69,21 @@ describe("getAudioSyncAdjustment", () => {
 			"[1:a]apad=pad_dur=120.000,aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[aout]",
 		]);
 	});
+
+	it("can add a small gain boost before resampling", () => {
+		const filterParts: string[] = [];
+		appendSyncedAudioFilter(
+			filterParts,
+			"[1:a]",
+			"aout",
+			getAudioSyncAdjustment(120, 120),
+			1.4,
+		);
+
+		expect(filterParts).toEqual([
+			"[1:a]volume=1.400,aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[aout]",
+		]);
+	});
 });
 
 describe("applyRecordedAudioStartDelay", () => {

--- a/electron/ipc/ffmpeg/filters.test.ts
+++ b/electron/ipc/ffmpeg/filters.test.ts
@@ -84,6 +84,17 @@ describe("getAudioSyncAdjustment", () => {
 			"[1:a]volume=1.400,aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[aout]",
 		]);
 	});
+
+	it("can prepend mic normalization filters before sync handling", () => {
+		const filterParts: string[] = [];
+		appendSyncedAudioFilter(filterParts, "[1:a]", "aout", getAudioSyncAdjustment(120, 120), {
+			preFilters: ["loudnorm=I=-16:TP=-1.5:LRA=11"],
+		});
+
+		expect(filterParts).toEqual([
+			"[1:a]loudnorm=I=-16:TP=-1.5:LRA=11,aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[aout]",
+		]);
+	});
 });
 
 describe("applyRecordedAudioStartDelay", () => {

--- a/electron/ipc/ffmpeg/filters.ts
+++ b/electron/ipc/ffmpeg/filters.ts
@@ -102,6 +102,7 @@ export function appendSyncedAudioFilter(
 	inputLabel: string,
 	outputLabel: string,
 	adjustment: AudioSyncAdjustment,
+	volumeMultiplier = 1,
 ) {
 	const filters: string[] = [];
 
@@ -115,6 +116,14 @@ export function appendSyncedAudioFilter(
 
 	if (adjustment.mode === "pad" && adjustment.durationDeltaMs > 0) {
 		filters.push(`apad=pad_dur=${formatFfmpegSeconds(adjustment.durationDeltaMs)}`);
+	}
+
+	if (
+		Number.isFinite(volumeMultiplier) &&
+		volumeMultiplier > 0 &&
+		Math.abs(volumeMultiplier - 1) > 0.0005
+	) {
+		filters.push(`volume=${volumeMultiplier.toFixed(3)}`);
 	}
 
 	filters.push("aresample=async=1:first_pts=0", "asetpts=PTS-STARTPTS");

--- a/electron/ipc/ffmpeg/filters.ts
+++ b/electron/ipc/ffmpeg/filters.ts
@@ -102,9 +102,12 @@ export function appendSyncedAudioFilter(
 	inputLabel: string,
 	outputLabel: string,
 	adjustment: AudioSyncAdjustment,
-	volumeMultiplier = 1,
+	options: number | { volumeMultiplier?: number; preFilters?: string[] } = 1,
 ) {
-	const filters: string[] = [];
+	const volumeMultiplier =
+		typeof options === "number" ? options : (options.volumeMultiplier ?? 1);
+	const preFilters = typeof options === "number" ? [] : (options.preFilters ?? []);
+	const filters: string[] = [...preFilters];
 
 	if (adjustment.mode === "delay" && adjustment.delayMs > 0) {
 		filters.push(`adelay=${adjustment.delayMs}|${adjustment.delayMs}`);

--- a/electron/ipc/recording/windows.ts
+++ b/electron/ipc/recording/windows.ts
@@ -33,6 +33,7 @@ import {
 import { emitRecordingInterrupted } from "./events";
 
 const execFileAsync = promisify(execFile);
+const WINDOWS_NATIVE_MIC_GAIN_BOOST = 1.4;
 
 export async function isNativeWindowsCaptureAvailable(): Promise<boolean> {
 	if (process.platform !== "win32") return false;
@@ -266,7 +267,15 @@ export async function muxNativeWindowsVideoWithAudio(
 			const micLabel = micPauseFilter ? "[mic_trimmed]" : "[2:a]";
 
 			appendSyncedAudioFilter(filterParts, systemLabel, "s", systemAdjustment);
-			appendSyncedAudioFilter(filterParts, micLabel, "m", micAdjustment);
+			// Keep native Windows mic loudness closer to the browser-recording path,
+			// which already applies a small gain boost before mixing.
+			appendSyncedAudioFilter(
+				filterParts,
+				micLabel,
+				"m",
+				micAdjustment,
+				WINDOWS_NATIVE_MIC_GAIN_BOOST,
+			);
 			filterParts.push("[s][m]amix=inputs=2:duration=longest:normalize=0[aout]");
 
 			await execFileAsync(
@@ -312,7 +321,13 @@ export async function muxNativeWindowsVideoWithAudio(
 				filterParts.push(pauseFilter);
 			}
 			const srcLabel = pauseFilter ? "[trimmed_audio]" : "[1:a]";
-			appendSyncedAudioFilter(filterParts, srcLabel, "aout", singleAdjustment);
+			appendSyncedAudioFilter(
+				filterParts,
+				srcLabel,
+				"aout",
+				singleAdjustment,
+				audioInputs[0] === "mic" ? WINDOWS_NATIVE_MIC_GAIN_BOOST : 1,
+			);
 
 			await execFileAsync(
 				ffmpegPath,

--- a/electron/ipc/recording/windows.ts
+++ b/electron/ipc/recording/windows.ts
@@ -33,7 +33,9 @@ import {
 import { emitRecordingInterrupted } from "./events";
 
 const execFileAsync = promisify(execFile);
-const WINDOWS_NATIVE_MIC_GAIN_BOOST = 1.4;
+// Match the browser path's "usable speech level" intent with a standard
+// loudness pass on native Windows mic audio instead of a fixed tiny boost.
+const WINDOWS_NATIVE_MIC_PRE_FILTERS = ["loudnorm=I=-16:TP=-1.5:LRA=11"];
 
 export async function isNativeWindowsCaptureAvailable(): Promise<boolean> {
 	if (process.platform !== "win32") return false;
@@ -267,15 +269,9 @@ export async function muxNativeWindowsVideoWithAudio(
 			const micLabel = micPauseFilter ? "[mic_trimmed]" : "[2:a]";
 
 			appendSyncedAudioFilter(filterParts, systemLabel, "s", systemAdjustment);
-			// Keep native Windows mic loudness closer to the browser-recording path,
-			// which already applies a small gain boost before mixing.
-			appendSyncedAudioFilter(
-				filterParts,
-				micLabel,
-				"m",
-				micAdjustment,
-				WINDOWS_NATIVE_MIC_GAIN_BOOST,
-			);
+			appendSyncedAudioFilter(filterParts, micLabel, "m", micAdjustment, {
+				preFilters: WINDOWS_NATIVE_MIC_PRE_FILTERS,
+			});
 			filterParts.push("[s][m]amix=inputs=2:duration=longest:normalize=0[aout]");
 
 			await execFileAsync(
@@ -326,7 +322,7 @@ export async function muxNativeWindowsVideoWithAudio(
 				srcLabel,
 				"aout",
 				singleAdjustment,
-				audioInputs[0] === "mic" ? WINDOWS_NATIVE_MIC_GAIN_BOOST : 1,
+				audioInputs[0] === "mic" ? { preFilters: WINDOWS_NATIVE_MIC_PRE_FILTERS } : 1,
 			);
 
 			await execFileAsync(


### PR DESCRIPTION
﻿## Description
Normalize microphone loudness during Windows native recording finalization so mic-only captures and system+mic captures no longer come out nearly muted compared with the browser recording path.

## Motivation
Issue #341 is separate from the long-recording sync bug fixed in #340: sync now looks correct, but microphone audio still records far quieter than expected. A fixed `1.4x` gain bump was still too weak in runtime retesting. The Windows native finalization path needs a stronger speech-level correction than a tiny static boost.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #341

## Changes Made
- extend the synced-audio filter helper so callers can prepend audio-processing filters before sync handling
- run the Windows native mic leg through `loudnorm=I=-16:TP=-1.5:LRA=11` before the existing sync/resample path
- apply the same mic normalization for both mic-only recordings and system+mic recordings
- keep the sync logic from #340 intact while replacing the earlier fixed `1.4x` mic boost experiment
- add focused regression coverage for prepended mic-normalization filters in the FFmpeg filter helper

## Testing Guide
1. On Windows, record a short clip with only microphone enabled.
2. Record another short clip with both microphone and system audio enabled.
3. Verify microphone audio is no longer nearly muted relative to the pre-patch behavior.
4. Verify sync and duration still behave the same as before.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the new behavior.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `vitest run electron/ipc/ffmpeg/filters.test.ts`
- `tsc --noEmit`
- `biome check electron/ipc/ffmpeg/filters.ts electron/ipc/ffmpeg/filters.test.ts electron/ipc/recording/windows.ts`

Additional validation:
- measured a recent mic-only runtime sample from `Recordly-dev\recordings` at roughly `mean_volume -42 dB` / `max_volume -27 dB`
- ran the same sample through the proposed `loudnorm` chain and saw it move to roughly `mean_volume -19 dB` / `max_volume -4.7 dB`

Notes:
- This keeps the scope narrow on Windows native mic loudness, without reopening the sync work from #340.
- I still have not completed a fresh in-app retest on this exact branch, so this stays draft pending runtime verification.
