### PR TITLE
feat(recording): add zoom marker shortcut

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -636,6 +636,7 @@ interface CursorTelemetryPoint {
 		| "double-click"
 		| "right-click"
 		| "middle-click"
+		| "manual-zoom"
 		| "mouseup";
 	cursorType?:
 		| "arrow"

--- a/electron/ipc/cursor/telemetry.ts
+++ b/electron/ipc/cursor/telemetry.ts
@@ -1,24 +1,24 @@
 import fs from "node:fs/promises";
-import { getTelemetryPathForVideo, getScreen } from "../utils";
 import {
+	CURSOR_SAMPLE_INTERVAL_MS,
 	CURSOR_TELEMETRY_VERSION,
 	MAX_CURSOR_SAMPLES,
-	CURSOR_SAMPLE_INTERVAL_MS,
 } from "../constants";
-import type { CursorVisualType, CursorInteractionType, CursorTelemetryPoint } from "../types";
 import {
-	cursorCaptureInterval,
-	setCursorCaptureInterval,
-	cursorCaptureStartTimeMs,
 	activeCursorSamples,
-	pendingCursorSamples,
-	setPendingCursorSamples,
-	isCursorCaptureActive,
 	currentCursorVisualType,
+	cursorCaptureInterval,
+	cursorCaptureStartTimeMs,
+	isCursorCaptureActive,
 	linuxCursorScreenPoint,
+	pendingCursorSamples,
 	selectedSource,
 	selectedWindowBounds,
+	setCursorCaptureInterval,
+	setPendingCursorSamples,
 } from "../state";
+import type { CursorInteractionType, CursorTelemetryPoint, CursorVisualType } from "../types";
+import { getScreen, getTelemetryPathForVideo } from "../utils";
 
 export function clamp(value: number, min: number, max: number) {
 	return Math.min(max, Math.max(min, value));
@@ -120,6 +120,21 @@ export function sampleCursorPoint() {
 	pushCursorSample(point.cx, point.cy, Date.now() - cursorCaptureStartTimeMs, "move");
 }
 
+export function captureManualZoomMarker() {
+	if (!isCursorCaptureActive) {
+		return false;
+	}
+
+	const point = getNormalizedCursorPoint();
+	pushCursorSample(
+		point.cx,
+		point.cy,
+		Date.now() - cursorCaptureStartTimeMs,
+		"manual-zoom",
+	);
+	return true;
+}
+
 export async function persistPendingCursorTelemetry(videoPath: string) {
 	const telemetryPath = getTelemetryPathForVideo(videoPath);
 	if (pendingCursorSamples.length > 0) {
@@ -184,6 +199,6 @@ export function startCursorSampling() {
 	setCursorCaptureInterval(setTimeout(tick, CURSOR_SAMPLE_INTERVAL_MS));
 }
 
+export { CURSOR_SAMPLE_INTERVAL_MS } from "../constants";
 // Re-export for consumers that use it from this module
 export { getTelemetryPathForVideo } from "../utils";
-export { CURSOR_SAMPLE_INTERVAL_MS } from "../constants";

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -95,6 +95,7 @@ export type CursorInteractionType =
 	| "double-click"
 	| "right-click"
 	| "middle-click"
+	| "manual-zoom"
 	| "mouseup";
 
 export interface CursorTelemetryPoint {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,7 @@ import {
 	BrowserWindow,
 	desktopCapturer,
 	dialog,
+	globalShortcut,
 	ipcMain,
 	Menu,
 	Notification,
@@ -18,6 +19,7 @@ import { RECORDINGS_DIR } from "./appPaths";
 import { showCursor } from "./cursorHider";
 import { registerExtensionIpcHandlers } from "./extensions/extensionIpc";
 import { getGpuSwitches } from "./gpuSwitches";
+import { captureManualZoomMarker } from "./ipc/cursor/telemetry";
 import {
 	cleanupAllExportStreams,
 	cleanupNativeVideoExportSessions,
@@ -54,6 +56,8 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const IS_SMOKE_EXPORT = process.env.RECORDLY_SMOKE_EXPORT === "1";
+const RECORDING_ZOOM_SHORTCUT = "CommandOrControl+Alt+Z";
+const RECORDING_ZOOM_SHORTCUT_THROTTLE_MS = 500;
 
 app.commandLine.appendSwitch("ignore-gpu-blocklist");
 app.commandLine.appendSwitch("enable-unsafe-webgpu");
@@ -127,6 +131,8 @@ let editorHasUnsavedChanges = false;
 let isForceClosing = false;
 let activeUpdateNotification: Notification | null = null;
 let activeUpdateNotificationKey: string | null = null;
+let recordingZoomShortcutRegistered = false;
+let lastRecordingZoomShortcutAtMs = 0;
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 
 if (!hasSingleInstanceLock) {
@@ -165,6 +171,45 @@ function restoreWindowSafely(window: BrowserWindow | null) {
 
 	window.moveTop();
 	window.focus();
+}
+
+function addRecordingZoomMarkerFromShortcut() {
+	const now = Date.now();
+	if (now - lastRecordingZoomShortcutAtMs < RECORDING_ZOOM_SHORTCUT_THROTTLE_MS) {
+		return;
+	}
+
+	lastRecordingZoomShortcutAtMs = now;
+	if (captureManualZoomMarker()) {
+		console.log(`[recording-zoom] Added zoom marker via ${RECORDING_ZOOM_SHORTCUT}`);
+	}
+}
+
+function registerRecordingZoomShortcut() {
+	if (recordingZoomShortcutRegistered) {
+		return;
+	}
+
+	recordingZoomShortcutRegistered = globalShortcut.register(
+		RECORDING_ZOOM_SHORTCUT,
+		addRecordingZoomMarkerFromShortcut,
+	);
+
+	if (!recordingZoomShortcutRegistered) {
+		console.warn(
+			`[recording-zoom] Failed to register ${RECORDING_ZOOM_SHORTCUT}; another app may already be using it.`,
+		);
+	}
+}
+
+function unregisterRecordingZoomShortcut() {
+	if (!recordingZoomShortcutRegistered) {
+		return;
+	}
+
+	globalShortcut.unregister(RECORDING_ZOOM_SHORTCUT);
+	recordingZoomShortcutRegistered = false;
+	lastRecordingZoomShortcutAtMs = 0;
 }
 
 // Tray Icons (lazily created after app is ready to avoid accessing Electron APIs too early)
@@ -783,6 +828,7 @@ function createSourceSelectorWindowWrapper() {
 // On macOS, applications and their menu bar stay active until the user quits
 // explicitly with Cmd + Q.
 app.on("before-quit", () => {
+	unregisterRecordingZoomShortcut();
 	killWindowsCaptureProcess();
 	showCursor();
 	cleanupNativeVideoExportSessions();
@@ -882,9 +928,11 @@ app.whenReady().then(async () => {
 			if (!tray) createTray();
 			updateTrayMenu(recording);
 			if (recording) {
+				registerRecordingZoomShortcut();
 				reassertHudOverlayMouseState();
 			}
 			if (!recording) {
+				unregisterRecordingZoomShortcut();
 				restoreWindowSafely(mainWindow);
 			}
 		},

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -124,6 +124,7 @@ import {
 	RECORDLY_ISSUES_URL,
 } from "./TutorialHelp";
 import TimelineEditor, { type TimelineEditorHandle } from "./timeline/TimelineEditor";
+import { buildManualRecordingZoomRegions } from "./timeline/recordingZoomMarkers";
 import { normalizeCursorTelemetry } from "./timeline/zoomSuggestionUtils";
 import {
 	type AnnotationRegion,
@@ -684,6 +685,8 @@ export default function VideoEditor() {
 	const exporterRef = useRef<CancelableExporter | null>(null);
 	const autoSuggestedVideoPathRef = useRef<string | null>(null);
 	const pendingFreshRecordingAutoZoomPathRef = useRef<string | null>(null);
+	const pendingFreshRecordingManualZoomPathRef = useRef<string | null>(null);
+	const manualRecordingZoomsAppliedVideoPathRef = useRef<string | null>(null);
 	const historyPastRef = useRef<EditorHistorySnapshot[]>([]);
 	const historyFutureRef = useRef<EditorHistorySnapshot[]>([]);
 	const historyCurrentRef = useRef<EditorHistorySnapshot | null>(null);
@@ -715,6 +718,7 @@ export default function VideoEditor() {
 
 	useEffect(() => {
 		autoSuggestedVideoPathRef.current = null;
+		manualRecordingZoomsAppliedVideoPathRef.current = null;
 		pendingFreshRecordingAutoSuggestTelemetryCountRef.current = 0;
 		if (pendingFreshRecordingAutoSuggestTimeoutRef.current !== null) {
 			window.clearTimeout(pendingFreshRecordingAutoSuggestTimeoutRef.current);
@@ -1566,6 +1570,7 @@ export default function VideoEditor() {
 			setVideoPath(await resolveVideoUrl(sourcePath));
 			setCurrentProjectPath(path ?? null);
 			pendingFreshRecordingAutoZoomPathRef.current = null;
+			pendingFreshRecordingManualZoomPathRef.current = null;
 			if (normalizedEditor.webcam.sourcePath) {
 				await window.electronAPI.setCurrentRecordingSession?.({
 					videoPath: sourcePath,
@@ -1845,6 +1850,7 @@ export default function VideoEditor() {
 					setCurrentProjectPath(null);
 					setLastSavedSnapshot(null);
 					pendingFreshRecordingAutoZoomPathRef.current = null;
+					pendingFreshRecordingManualZoomPathRef.current = null;
 					setWebcam((prev) => ({
 						...prev,
 						enabled: !!smokeWebcamSourcePath,
@@ -1901,6 +1907,7 @@ export default function VideoEditor() {
 					setVideoPath(sourceVideoUrl);
 					setCurrentProjectPath(null);
 					setLastSavedSnapshot(null);
+					pendingFreshRecordingManualZoomPathRef.current = sourceVideoUrl;
 					pendingFreshRecordingAutoZoomPathRef.current = autoApplyFreshRecordingAutoZooms
 						? sourceVideoUrl
 						: null;
@@ -1923,6 +1930,7 @@ export default function VideoEditor() {
 					setCurrentProjectPath(null);
 					setLastSavedSnapshot(null);
 					pendingFreshRecordingAutoZoomPathRef.current = null;
+					pendingFreshRecordingManualZoomPathRef.current = null;
 					setWebcam((prev) => ({
 						...prev,
 						enabled: false,
@@ -2817,6 +2825,52 @@ export default function VideoEditor() {
 		},
 		[videoPath],
 	);
+
+	useEffect(() => {
+		if (!videoPath || loading || duration <= 0 || normalizedCursorTelemetry.length === 0) {
+			return;
+		}
+
+		if (pendingFreshRecordingManualZoomPathRef.current !== videoPath) {
+			return;
+		}
+
+		if (manualRecordingZoomsAppliedVideoPathRef.current === videoPath) {
+			return;
+		}
+
+		const totalMs = Math.round(duration * 1000);
+		const manualRegions = buildManualRecordingZoomRegions({
+			cursorTelemetry: normalizedCursorTelemetry,
+			totalMs,
+			defaultDurationMs: Math.min(1000, totalMs),
+			reservedSpans: zoomRegions.map((region) => ({
+				start: region.startMs,
+				end: region.endMs,
+			})),
+		});
+
+		manualRecordingZoomsAppliedVideoPathRef.current = videoPath;
+		pendingFreshRecordingManualZoomPathRef.current = null;
+
+		if (manualRegions.length === 0) {
+			return;
+		}
+
+		setZoomRegions((prev) => [
+			...prev,
+			...manualRegions.map((region) => ({
+				id: `zoom-${nextZoomIdRef.current++}`,
+				startMs: region.start,
+				endMs: region.end,
+				depth: DEFAULT_ZOOM_DEPTH,
+				focus: clampFocusToDepth(region.focus, DEFAULT_ZOOM_DEPTH),
+				mode: "manual" as const,
+			})),
+		]);
+		autoSuggestedVideoPathRef.current = videoPath;
+		pendingFreshRecordingAutoZoomPathRef.current = null;
+	}, [videoPath, loading, duration, normalizedCursorTelemetry, zoomRegions]);
 
 	useEffect(() => {
 		if (

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -1813,6 +1813,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 							if (
 								p.interactionType &&
 								p.interactionType !== "move" &&
+								p.interactionType !== "manual-zoom" &&
 								p.timeMs !== lastEmittedClickTimeMsRef.current
 							) {
 								const extensionCursor = mapCursorToCanvasNormalized(

--- a/src/components/video-editor/timeline/recordingZoomMarkers.test.ts
+++ b/src/components/video-editor/timeline/recordingZoomMarkers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildManualRecordingZoomRegions } from "./recordingZoomMarkers";
+
+describe("buildManualRecordingZoomRegions", () => {
+	it("places a manual zoom at the shortcut timestamp with the cursor focus", () => {
+		const regions = buildManualRecordingZoomRegions({
+			cursorTelemetry: [{ timeMs: 1200, cx: 0.25, cy: 0.75, interactionType: "manual-zoom" }],
+			totalMs: 5000,
+			defaultDurationMs: 1000,
+		});
+
+		expect(regions).toEqual([{ start: 1200, end: 2200, focus: { cx: 0.25, cy: 0.75 } }]);
+	});
+
+	it("skips markers that would start inside an existing zoom span", () => {
+		const regions = buildManualRecordingZoomRegions({
+			cursorTelemetry: [
+				{ timeMs: 1500, cx: 0.25, cy: 0.75, interactionType: "manual-zoom" },
+				{ timeMs: 2500, cx: 0.4, cy: 0.6, interactionType: "manual-zoom" },
+			],
+			totalMs: 5000,
+			defaultDurationMs: 1000,
+			reservedSpans: [{ start: 1000, end: 2000 }],
+		});
+
+		expect(regions).toEqual([{ start: 2500, end: 3500, focus: { cx: 0.4, cy: 0.6 } }]);
+	});
+
+	it("clips a manual zoom before the next reserved span", () => {
+		const regions = buildManualRecordingZoomRegions({
+			cursorTelemetry: [{ timeMs: 2100, cx: 2, cy: -1, interactionType: "manual-zoom" }],
+			totalMs: 5000,
+			defaultDurationMs: 1000,
+			reservedSpans: [{ start: 2600, end: 3400 }],
+		});
+
+		expect(regions).toEqual([{ start: 2100, end: 2600, focus: { cx: 1, cy: 0 } }]);
+	});
+});

--- a/src/components/video-editor/timeline/recordingZoomMarkers.ts
+++ b/src/components/video-editor/timeline/recordingZoomMarkers.ts
@@ -1,0 +1,74 @@
+import type { CursorTelemetryPoint, ZoomFocus } from "../types";
+
+export const MANUAL_ZOOM_INTERACTION_TYPE = "manual-zoom";
+
+export interface ManualRecordingZoomRegion {
+	start: number;
+	end: number;
+	focus: ZoomFocus;
+}
+
+export function buildManualRecordingZoomRegions(params: {
+	cursorTelemetry: CursorTelemetryPoint[];
+	totalMs: number;
+	defaultDurationMs: number;
+	reservedSpans?: Array<{ start: number; end: number }>;
+}): ManualRecordingZoomRegion[] {
+	const { cursorTelemetry, totalMs, defaultDurationMs, reservedSpans = [] } = params;
+	const duration = Math.min(defaultDurationMs, totalMs);
+	if (duration <= 0) {
+		return [];
+	}
+
+	const reserved = reservedSpans
+		.filter((span) => Number.isFinite(span.start) && Number.isFinite(span.end))
+		.map((span) => ({
+			start: Math.max(0, Math.min(Math.round(span.start), totalMs)),
+			end: Math.max(0, Math.min(Math.round(span.end), totalMs)),
+		}))
+		.filter((span) => span.end > span.start)
+		.sort((a, b) => a.start - b.start);
+
+	const regions: ManualRecordingZoomRegion[] = [];
+	const markers = cursorTelemetry
+		.filter(
+			(sample) =>
+				sample.interactionType === MANUAL_ZOOM_INTERACTION_TYPE &&
+				Number.isFinite(sample.timeMs) &&
+				Number.isFinite(sample.cx) &&
+				Number.isFinite(sample.cy),
+		)
+		.sort((a, b) => a.timeMs - b.timeMs);
+
+	for (const marker of markers) {
+		const start = Math.max(0, Math.min(Math.round(marker.timeMs), totalMs));
+		if (start >= totalMs) {
+			continue;
+		}
+
+		const overlapsExisting = reserved.some((span) => start >= span.start && start < span.end);
+		if (overlapsExisting) {
+			continue;
+		}
+
+		const nextSpan = reserved.find((span) => span.start > start);
+		const end = Math.min(start + duration, nextSpan?.start ?? totalMs, totalMs);
+		if (end <= start) {
+			continue;
+		}
+
+		const region = {
+			start,
+			end,
+			focus: {
+				cx: Math.max(0, Math.min(marker.cx, 1)),
+				cy: Math.max(0, Math.min(marker.cy, 1)),
+			},
+		};
+		regions.push(region);
+		reserved.push(region);
+		reserved.sort((a, b) => a.start - b.start);
+	}
+
+	return regions;
+}

--- a/src/components/video-editor/timeline/zoomSuggestionUtils.ts
+++ b/src/components/video-editor/timeline/zoomSuggestionUtils.ts
@@ -186,7 +186,11 @@ export function detectInteractionCandidates(
 ): CursorInteractionCandidate[] {
 	// --- Phase 1: Explicit interaction events (from uiohook telemetry) ---
 	const clickEvents = samples.filter(
-		(s) => s.interactionType && s.interactionType !== "move" && s.interactionType !== "mouseup",
+		(s) =>
+			s.interactionType &&
+			s.interactionType !== "move" &&
+			s.interactionType !== "mouseup" &&
+			s.interactionType !== "manual-zoom",
 	);
 
 	const explicitInteractionCandidates: CursorInteractionCandidate[] = [];

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -27,6 +27,7 @@ export interface CursorTelemetryPoint {
 		| "double-click"
 		| "right-click"
 		| "middle-click"
+		| "manual-zoom"
 		| "mouseup";
 	cursorType?:
 		| "arrow"

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -1164,7 +1164,13 @@ export class FrameRenderer {
 		for (const point of telemetry) {
 			if (point.timeMs > timeMs) break;
 			if (point.timeMs < timeMs - 100) continue;
-			if (!point.interactionType || point.interactionType === "move") continue;
+			if (
+				!point.interactionType ||
+				point.interactionType === "move" ||
+				point.interactionType === "manual-zoom"
+			) {
+				continue;
+			}
 			if (point.timeMs === this.lastEmittedClickTimeMs) continue;
 
 			const mappedCursor = mapCursorToCanvasNormalized(

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -2413,7 +2413,11 @@ export class FrameRenderer {
 			if (point.timeMs < timeMs - 100) {
 				continue;
 			}
-			if (!point.interactionType || point.interactionType === "move") {
+			if (
+				!point.interactionType ||
+				point.interactionType === "move" ||
+				point.interactionType === "manual-zoom"
+			) {
 				continue;
 			}
 			if (point.timeMs === this.lastEmittedClickTimeMs) {


### PR DESCRIPTION
## Description
Add a recording-time shortcut so pressing `CommandOrControl+Alt+Z` while recording creates a manual zoom marker that is converted into a zoom region when the new recording opens in the editor.

## Motivation
Issue #352 asks for a keyboard shortcut during recording to add a zoom. Recordly already writes cursor telemetry while recording and builds editor zoom regions from recording metadata, so this keeps the implementation narrow by storing an explicit `manual-zoom` marker in the existing telemetry sidecar instead of adding a new project format or settings surface.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #352

## Changes Made
- register `CommandOrControl+Alt+Z` only while an active recording is running
- store shortcut presses as `manual-zoom` cursor telemetry markers with the current cursor focus
- convert manual markers from fresh recordings into manual zoom regions in the editor
- keep manual zoom markers out of automatic zoom suggestion and cursor click-effect paths
- add focused unit coverage for marker-to-region placement behavior

## Testing Guide
1. Start a screen recording.
2. Press `CommandOrControl+Alt+Z` at moments where a zoom should be added.
3. Stop recording and open the editor.
4. Verify manual zoom regions appear at those timestamps and focus around the cursor position.
5. Verify recordings without manual markers keep the existing auto-zoom suggestion behavior.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the new behavior.
- [ ] I have completed a manual recording runtime smoke test.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `vitest run src/components/video-editor/timeline/recordingZoomMarkers.test.ts`
- `tsc --noEmit`
- `biome check src/components/video-editor/timeline/recordingZoomMarkers.ts src/components/video-editor/timeline/recordingZoomMarkers.test.ts`
- `biome check --formatter-enabled=false src/components/video-editor/timeline/recordingZoomMarkers.ts src/components/video-editor/timeline/recordingZoomMarkers.test.ts electron/ipc/cursor/telemetry.ts electron/main.ts`

Notes:
- The shortcut is intentionally fixed to `CommandOrControl+Alt+Z` for this first pass. If you prefer a different accelerator or a configurable shortcut, I can adjust in a follow-up without expanding this PR into a settings change.
- Keeping this as draft until the shortcut is verified in a real recording session.