### PR TITLE
feat(editor): add audio region volume control

### DIFF
--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { useTheme } from "@/contexts/ThemeContext";
 import { getAssetPath, getRenderableAssetUrl, getWallpaperThumbnailUrl } from "@/lib/assetPath";
 import type { ExtensionSettingField } from "@/lib/extensions";
 import { extensionHost, type FrameInstance } from "@/lib/extensions";
@@ -27,7 +28,6 @@ import minimalCursorUrl from "../../../Minimal Cursor.svg";
 import { useI18n, useScopedT } from "../../contexts/I18nContext";
 import type { AppLocale } from "../../i18n/config";
 import { SUPPORTED_LOCALES } from "../../i18n/config";
-import { useTheme } from "@/contexts/ThemeContext";
 import { AnnotationSettingsPanel } from "./AnnotationSettingsPanel";
 import { loadEditorPreferences, saveEditorPreferences } from "./editorPreferences";
 import { SliderControl } from "./SliderControl";
@@ -51,9 +51,6 @@ import type {
 	ZoomTransitionEasing,
 } from "./types";
 import {
-	isZeroPadding,
-} from "./videoPlayback/layoutUtils";
-import {
 	DEFAULT_AUTO_CAPTION_SETTINGS,
 	DEFAULT_CROP_REGION,
 	DEFAULT_CURSOR_CLICK_BOUNCE,
@@ -76,6 +73,7 @@ import {
 	SPEED_OPTIONS,
 } from "./types";
 import { fromCursorSwaySliderValue, toCursorSwaySliderValue } from "./videoPlayback/cursorSway";
+import { isZeroPadding } from "./videoPlayback/layoutUtils";
 import {
 	cursorSetAssets,
 	getCursorStyleSizeMultiplier,
@@ -348,6 +346,10 @@ interface SettingsPanelProps {
 	onClipSpeedChange?: (speed: number) => void;
 	onClipMutedChange?: (muted: boolean) => void;
 	onClipDelete?: (id: string) => void;
+	selectedAudioId?: string | null;
+	selectedAudioVolume?: number | null;
+	onAudioVolumeChange?: (volume: number) => void;
+	onAudioDelete?: (id: string) => void;
 	shadowIntensity?: number;
 	onShadowChange?: (intensity: number) => void;
 	backgroundBlur?: number;
@@ -721,6 +723,10 @@ export function SettingsPanel({
 	onClipSpeedChange,
 	onClipMutedChange,
 	onClipDelete,
+	selectedAudioId,
+	selectedAudioVolume,
+	onAudioVolumeChange,
+	onAudioDelete,
 	shadowIntensity = 0.67,
 	onShadowChange,
 	backgroundBlur = 0,
@@ -3031,7 +3037,7 @@ export function SettingsPanel({
 			<div
 				className={cn(
 					"flex-shrink-0 border-t border-foreground/10 bg-editor-header p-4 pt-3",
-					!selectedTrimId && !selectedSpeedId && "hidden",
+					!selectedTrimId && !selectedSpeedId && !selectedAudioId && "hidden",
 				)}
 			>
 				{selectedTrimId && (
@@ -3091,6 +3097,39 @@ export function SettingsPanel({
 						>
 							<Trash2 className="h-3 w-3" />
 							{tSettings("speed.deleteRegion")}
+						</Button>
+					</div>
+				)}
+
+				{selectedAudioId && (
+					<div>
+						<div className="mb-3 flex items-center justify-between">
+							<span className="text-sm font-medium text-foreground">
+								{tSettings("audio.volumeTitle", "Audio Volume")}
+							</span>
+							<span className="rounded-full bg-[#2563EB]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[#2563EB]">
+								{Math.round((selectedAudioVolume ?? 1) * 100)}%
+							</span>
+						</div>
+						<SliderControl
+							label={tSettings("audio.volume", "Volume")}
+							value={selectedAudioVolume ?? 1}
+							defaultValue={1}
+							min={0}
+							max={1}
+							step={0.01}
+							onChange={(v) => onAudioVolumeChange?.(v)}
+							formatValue={(v) => `${Math.round(v * 100)}%`}
+							parseInput={(text) => parseFloat(text.replace(/%$/, "")) / 100}
+						/>
+						<Button
+							onClick={() => selectedAudioId && onAudioDelete?.(selectedAudioId)}
+							variant="destructive"
+							size="sm"
+							className="mt-2 h-8 w-full gap-2 border border-red-500/20 bg-red-500/10 text-xs text-red-400 transition-all hover:border-red-500/30 hover:bg-red-500/20"
+						>
+							<Trash2 className="h-3 w-3" />
+							{tSettings("audio.deleteRegion", "Delete Audio")}
 						</Button>
 					</div>
 				)}

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -3257,6 +3257,19 @@ export default function VideoEditor() {
 		);
 	}, []);
 
+	const handleAudioVolumeChange = useCallback((volume: number) => {
+		if (!selectedAudioId) {
+			return;
+		}
+
+		const nextVolume = Number.isFinite(volume) ? Math.max(0, Math.min(1, volume)) : 1;
+		setAudioRegions((prev) =>
+			prev.map((region) =>
+				region.id === selectedAudioId ? { ...region, volume: nextVolume } : region,
+			),
+		);
+	}, [selectedAudioId]);
+
 	const handleAudioDelete = useCallback(
 		(id: string) => {
 			setAudioRegions((prev) => prev.filter((region) => region.id !== id));
@@ -5188,6 +5201,15 @@ export default function VideoEditor() {
 									selectedClipId && handleClipMutedChange(muted)
 								}
 								onClipDelete={handleClipDelete}
+								selectedAudioId={selectedAudioId}
+								selectedAudioVolume={
+									selectedAudioId
+										? (audioRegions.find((r) => r.id === selectedAudioId)
+												?.volume ?? null)
+										: null
+								}
+								onAudioVolumeChange={handleAudioVolumeChange}
+								onAudioDelete={handleAudioDelete}
 								shadowIntensity={shadowIntensity}
 								onShadowChange={setShadowIntensity}
 								backgroundBlur={backgroundBlur}

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -4409,6 +4409,8 @@ export default function VideoEditor() {
 			effectiveSpeedRegions,
 			frame,
 			smokeExportConfig.encodingMode,
+			smokeExportConfig.fps,
+			smokeExportConfig.quality,
 		],
 	);
 

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -3262,7 +3262,11 @@ export default function VideoEditor() {
 			return;
 		}
 
-		const nextVolume = Number.isFinite(volume) ? Math.max(0, Math.min(1, volume)) : 1;
+		if (!Number.isFinite(volume)) {
+			return;
+		}
+
+		const nextVolume = Math.max(0, Math.min(1, volume));
 		setAudioRegions((prev) =>
 			prev.map((region) =>
 				region.id === selectedAudioId ? { ...region, volume: nextVolume } : region,

--- a/src/components/video-editor/timeline/Row.tsx
+++ b/src/components/video-editor/timeline/Row.tsx
@@ -30,7 +30,11 @@ export default function Row({ id, children, label, hint, isEmpty, labelColor = "
 					<span className="text-[11px] text-foreground/15 font-medium">{hint}</span>
 				</div>
 			)}
-			<div ref={setNodeRef} className="relative h-full min-h-0 overflow-hidden" style={rowStyle}>
+			<div
+				ref={setNodeRef}
+				className="relative h-full min-h-[26px] overflow-hidden"
+				style={rowStyle}
+			>
 				{children}
 			</div>
 		</div>


### PR DESCRIPTION
## Description
Add a volume control for the currently selected added-audio region in the editor settings footer, and keep timeline row hit targets visible so added-audio regions can be selected reliably.

## Motivation
Issue #187 reports that added background audio can overpower the original recording, but there is no in-app way to lower that added audio after inserting it. #360 also reports a volume-control problem in the new multi-audio-track editor flow.

Recordly already stores `AudioRegion.volume`, applies it during preview playback, persists it in projects, and uses it during export. This PR keeps the change focused on exposing that existing control path in the UI and making the selected-audio row target reachable.

## Type of Change
- [x] Bug Fix
- [x] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #187
- #360 (volume-control sub-issue only)

## Changes Made
- show an `Audio Volume` panel when an added audio region is selected on the timeline
- add a 0-100% slider backed by the existing `AudioRegion.volume` field
- clamp UI updates to the existing `[0, 1]` volume range
- ignore invalid/non-finite volume input so the existing region volume is preserved instead of jumping to 100%
- keep the existing delete-audio action available from the same selected-audio panel
- keep timeline row content at the same minimum hit height as the row wrapper, so selected audio items are clickable instead of being covered by adjacent rows
- include the missing smoke-export config dependencies in the export callback dependency list

## Scope Note
This PR only addresses added-audio volume control and the small timeline hit-target issue needed to make that control reachable. The audio-track scrolling fix is handled by #361, and the 1.5x export speed fix is handled by #362.

## Testing Guide
1. Open a project in the editor.
2. Add an audio file from the timeline toolbar.
3. Select the added audio region on the timeline.
4. Verify the `Audio Volume` panel appears in the settings footer.
5. Move the slider and verify preview volume changes for that added audio region.
6. Export and verify the added audio volume matches the selected level.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have completed focused runtime preview and export smoke tests.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `vitest run src/components/video-editor/audio.test.ts src/components/video-editor/timeline/timelineLayout.test.ts`
- `tsc --noEmit`
- `biome check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/SettingsPanel.tsx src/components/video-editor/timeline/Row.tsx`
- `git diff --check`
- `vite build --config vite.config.ts`

Runtime UI smoke:
- production Electron editor loaded through `vite preview` on a clean port
- fixture: 5s silent video plus 5s generated tone as an added audio region
- selected the `tone` audio region on the timeline
- `Audio Volume` panel appeared in the settings footer
- slider set to `25%`
- UI badge updated to `25%`
- preview audio element observed with `volume = 0.25`

Runtime export smoke:
- combined local #360 smoke fixture, native/modern export path
- source: 5s silent video plus 5s generated tone as an added audio region
- volume `100%` export: success, 5.00s output, AAC audio, `mean_volume: -21.1 dB`
- volume `0%` export: success, 5.00s output, AAC audio, `mean_volume: -91.0 dB`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio volume control slider (0–100%) for individual tracks in the settings panel
  * Added ability to delete audio tracks directly from the settings interface
  * Settings panel remains accessible when an audio track is selected for streamlined editing

* **Bug Fixes**
  * Export now respects updated export FPS and quality settings

* **Style/UI**
  * Timeline rows maintain a minimum content height for more consistent spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->