### PR TITLE
feat(captions): export subtitle files

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -342,6 +342,17 @@ interface Window {
 			videoData: ArrayBuffer,
 			fileName: string,
 		) => Promise<{ success: boolean; path?: string; message?: string; canceled?: boolean }>;
+		saveSubtitleFile: (
+			content: string,
+			fileName: string,
+			format: "srt" | "vtt",
+		) => Promise<{
+			success: boolean;
+			path?: string;
+			message?: string;
+			error?: string;
+			canceled?: boolean;
+		}>;
 		writeExportedVideoToPath: (
 			videoData: ArrayBuffer,
 			outputPath: string,

--- a/electron/ipc/register/export.ts
+++ b/electron/ipc/register/export.ts
@@ -518,6 +518,74 @@ export function registerExportHandlers() {
 	);
 
 	ipcMain.handle(
+		"save-subtitle-file",
+		async (event, content: string, fileName: string, format: "srt" | "vtt") => {
+			const normalizedFormat = format === "vtt" ? "vtt" : "srt";
+			const defaultFileName =
+				typeof fileName === "string" && fileName.trim().length > 0
+					? path.basename(fileName.trim())
+					: `captions-${Date.now()}.${normalizedFormat}`;
+			const fileNameWithExtension = defaultFileName
+				.toLowerCase()
+				.endsWith(`.${normalizedFormat}`)
+				? defaultFileName
+				: `${defaultFileName}.${normalizedFormat}`;
+
+			try {
+				if (typeof content !== "string" || content.trim().length === 0) {
+					return {
+						success: false,
+						canceled: false,
+						message: "No captions to export",
+					};
+				}
+
+				const filters =
+					normalizedFormat === "vtt"
+						? [{ name: "WebVTT Subtitle", extensions: ["vtt"] }]
+						: [{ name: "SubRip Subtitle", extensions: ["srt"] }];
+				const parentWindow = BrowserWindow.fromWebContents(event.sender);
+				const saveDialogOptions: SaveDialogOptions = {
+					title: normalizedFormat === "vtt" ? "Save WebVTT Subtitle" : "Save SRT Subtitle",
+					defaultPath: path.join(app.getPath("downloads"), fileNameWithExtension),
+					filters,
+					properties: ["createDirectory", "showOverwriteConfirmation"],
+				};
+
+				const result = parentWindow
+					? await dialog.showSaveDialog(parentWindow, saveDialogOptions)
+					: await dialog.showSaveDialog(saveDialogOptions);
+
+				if (result.canceled || !result.filePath) {
+					return {
+						success: false,
+						canceled: true,
+						message: "Subtitle export canceled",
+					};
+				}
+
+				await fs.writeFile(result.filePath, content, "utf8");
+				approveUserPath(result.filePath);
+
+				return {
+					success: true,
+					path: result.filePath,
+					message: "Subtitles exported successfully",
+					canceled: false,
+				};
+			} catch (error) {
+				console.error("Failed to save subtitle file:", error);
+				return {
+					success: false,
+					canceled: false,
+					message: "Failed to save subtitle file",
+					error: String(error),
+				};
+			}
+		},
+	);
+
+	ipcMain.handle(
 		"write-exported-video-to-path",
 		async (_event, videoData: ArrayBuffer, outputPath: string) => {
 			try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -378,6 +378,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	saveExportedVideo: (videoData: ArrayBuffer, fileName: string) => {
 		return ipcRenderer.invoke("save-exported-video", videoData, fileName);
 	},
+	saveSubtitleFile: (content: string, fileName: string, format: "srt" | "vtt") => {
+		return ipcRenderer.invoke("save-subtitle-file", content, fileName, format);
+	},
 	writeExportedVideoToPath: (videoData: ArrayBuffer, outputPath: string) => {
 		return ipcRenderer.invoke("write-exported-video-to-path", videoData, outputPath);
 	},

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -1,4 +1,10 @@
-import { Palette, Trash as Trash2, UploadSimple as Upload, X } from "@phosphor-icons/react";
+import {
+	DownloadSimple as Download,
+	Palette,
+	Trash as Trash2,
+	UploadSimple as Upload,
+	X,
+} from "@phosphor-icons/react";
 import { AnimatePresence, LayoutGroup, motion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -12,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { useTheme } from "@/contexts/ThemeContext";
 import { getAssetPath, getRenderableAssetUrl, getWallpaperThumbnailUrl } from "@/lib/assetPath";
 import type { ExtensionSettingField } from "@/lib/extensions";
 import { extensionHost, type FrameInstance } from "@/lib/extensions";
@@ -27,7 +34,6 @@ import minimalCursorUrl from "../../../Minimal Cursor.svg";
 import { useI18n, useScopedT } from "../../contexts/I18nContext";
 import type { AppLocale } from "../../i18n/config";
 import { SUPPORTED_LOCALES } from "../../i18n/config";
-import { useTheme } from "@/contexts/ThemeContext";
 import { AnnotationSettingsPanel } from "./AnnotationSettingsPanel";
 import { loadEditorPreferences, saveEditorPreferences } from "./editorPreferences";
 import { SliderControl } from "./SliderControl";
@@ -51,9 +57,6 @@ import type {
 	ZoomTransitionEasing,
 } from "./types";
 import {
-	isZeroPadding,
-} from "./videoPlayback/layoutUtils";
-import {
 	DEFAULT_AUTO_CAPTION_SETTINGS,
 	DEFAULT_CROP_REGION,
 	DEFAULT_CURSOR_CLICK_BOUNCE,
@@ -76,6 +79,7 @@ import {
 	SPEED_OPTIONS,
 } from "./types";
 import { fromCursorSwaySliderValue, toCursorSwaySliderValue } from "./videoPlayback/cursorSway";
+import { isZeroPadding } from "./videoPlayback/layoutUtils";
 import {
 	cursorSetAssets,
 	getCursorStyleSizeMultiplier,
@@ -431,6 +435,7 @@ interface SettingsPanelProps {
 	onPickWhisperModel?: () => void;
 	onGenerateAutoCaptions?: () => void;
 	onClearAutoCaptions?: () => void;
+	onExportCaptions?: (format: "srt" | "vtt") => void;
 	onDownloadWhisperSmallModel?: () => void;
 	onDeleteWhisperSmallModel?: () => void;
 	selectedSpeedId?: string | null;
@@ -786,6 +791,7 @@ export function SettingsPanel({
 	onPickWhisperModel,
 	onGenerateAutoCaptions,
 	onClearAutoCaptions,
+	onExportCaptions,
 	onDownloadWhisperSmallModel,
 	onDeleteWhisperSmallModel,
 	selectedSpeedId,
@@ -2156,6 +2162,28 @@ export function SettingsPanel({
 								? tSettings("captions.regenerateFull", "Regenerate Captions")
 								: tSettings("captions.generateFull", "Generate Captions")}
 					</Button>
+					<div className="grid grid-cols-2 gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => onExportCaptions?.("srt")}
+							disabled={captionCueCount === 0}
+							className="h-9 gap-1.5 rounded-xl border-foreground/10 bg-foreground/5 px-3 text-xs text-foreground hover:bg-foreground/10 hover:text-foreground disabled:opacity-50"
+						>
+							<Download className="h-3 w-3" />
+							{tSettings("captions.exportSrt", "Export SRT")}
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => onExportCaptions?.("vtt")}
+							disabled={captionCueCount === 0}
+							className="h-9 gap-1.5 rounded-xl border-foreground/10 bg-foreground/5 px-3 text-xs text-foreground hover:bg-foreground/10 hover:text-foreground disabled:opacity-50"
+						>
+							<Download className="h-3 w-3" />
+							{tSettings("captions.exportVtt", "Export VTT")}
+						</Button>
+					</div>
 					{isGeneratingCaptions ? (
 						<div className="space-y-1">
 							<div className="text-xs text-muted-foreground">

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -116,6 +116,7 @@ import {
 	validateProjectData,
 } from "./projectPersistence";
 import { SettingsPanel } from "./SettingsPanel";
+import { type SubtitleExportFormat, serializeCaptions } from "./subtitleExport";
 import {
 	APP_HEADER_ICON_BUTTON_CLASS,
 	DiscordLinkButton,
@@ -2235,6 +2236,40 @@ export default function VideoEditor() {
 		setAutoCaptions([]);
 		setAutoCaptionSettings((prev) => ({ ...prev, enabled: false }));
 	}, []);
+
+	const handleExportCaptions = useCallback(
+		async (format: SubtitleExportFormat) => {
+			const content = serializeCaptions(autoCaptions, format);
+			if (!content.trim()) {
+				toast.error("No captions to export");
+				return;
+			}
+
+			let result: Awaited<ReturnType<typeof window.electronAPI.saveSubtitleFile>>;
+			try {
+				result = await window.electronAPI.saveSubtitleFile(
+					content,
+					`${projectDisplayName}.${format}`,
+					format,
+				);
+			} catch (error) {
+				toast.error(getErrorMessage(error));
+				return;
+			}
+
+			if (result.canceled) {
+				return;
+			}
+
+			if (!result.success) {
+				toast.error(result.message || "Failed to export captions");
+				return;
+			}
+
+			toast.success(result.message || "Captions exported");
+		},
+		[autoCaptions, projectDisplayName],
+	);
 
 	const saveProject = useCallback(
 		async (forceSaveAs: boolean) => {
@@ -5266,6 +5301,7 @@ export default function VideoEditor() {
 								onPickWhisperModel={handlePickWhisperModel}
 								onGenerateAutoCaptions={handleGenerateAutoCaptions}
 								onClearAutoCaptions={handleClearAutoCaptions}
+								onExportCaptions={handleExportCaptions}
 								onDownloadWhisperSmallModel={handleDownloadWhisperSmallModel}
 								onDeleteWhisperSmallModel={handleDeleteWhisperSmallModel}
 								onAnnotationContentChange={handleAnnotationContentChange}

--- a/src/components/video-editor/subtitleExport.test.ts
+++ b/src/components/video-editor/subtitleExport.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatSubtitleTimestamp,
+	serializeCaptionsAsSrt,
+	serializeCaptionsAsWebVtt,
+} from "./subtitleExport";
+import type { CaptionCue } from "./types";
+
+describe("subtitle export", () => {
+	const cues: CaptionCue[] = [
+		{ id: "b", startMs: 2400, endMs: 3800, text: " second cue " },
+		{ id: "a", startMs: 100, endMs: 1234, text: "First   cue" },
+	];
+
+	it("formats SRT and WebVTT timestamps", () => {
+		expect(formatSubtitleTimestamp(3_661_234, "srt")).toBe("01:01:01,234");
+		expect(formatSubtitleTimestamp(3_661_234, "vtt")).toBe("01:01:01.234");
+	});
+
+	it("serializes captions as ordered SRT cues", () => {
+		expect(serializeCaptionsAsSrt(cues)).toBe(
+			"1\n00:00:00,100 --> 00:00:01,234\nFirst cue\n\n2\n00:00:02,400 --> 00:00:03,800\nsecond cue",
+		);
+	});
+
+	it("serializes captions as WebVTT", () => {
+		expect(serializeCaptionsAsWebVtt(cues)).toBe(
+			"WEBVTT\n\n00:00:00.100 --> 00:00:01.234\nFirst cue\n\n00:00:02.400 --> 00:00:03.800\nsecond cue\n",
+		);
+	});
+
+	it("skips empty or zero-length cues", () => {
+		expect(
+			serializeCaptionsAsSrt([
+				{ id: "empty", startMs: 0, endMs: 1000, text: " " },
+				{ id: "zero", startMs: 1000, endMs: 1000, text: "no duration" },
+			]),
+		).toBe("");
+	});
+});

--- a/src/components/video-editor/subtitleExport.ts
+++ b/src/components/video-editor/subtitleExport.ts
@@ -1,0 +1,66 @@
+import type { CaptionCue } from "./types";
+
+export type SubtitleExportFormat = "srt" | "vtt";
+
+function normalizeSubtitleText(text: string) {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+function toTimestampParts(timeMs: number) {
+	const clampedMs = Math.max(0, Math.round(timeMs));
+	const hours = Math.floor(clampedMs / 3_600_000);
+	const minutes = Math.floor((clampedMs % 3_600_000) / 60_000);
+	const seconds = Math.floor((clampedMs % 60_000) / 1000);
+	const milliseconds = clampedMs % 1000;
+
+	return {
+		hours: String(hours).padStart(2, "0"),
+		minutes: String(minutes).padStart(2, "0"),
+		seconds: String(seconds).padStart(2, "0"),
+		milliseconds: String(milliseconds).padStart(3, "0"),
+	};
+}
+
+export function formatSubtitleTimestamp(timeMs: number, format: SubtitleExportFormat) {
+	const { hours, minutes, seconds, milliseconds } = toTimestampParts(timeMs);
+	const separator = format === "srt" ? "," : ".";
+	return `${hours}:${minutes}:${seconds}${separator}${milliseconds}`;
+}
+
+function getExportableCues(cues: CaptionCue[]) {
+	return cues
+		.map((cue) => ({
+			...cue,
+			startMs: Math.max(0, Math.round(cue.startMs)),
+			endMs: Math.max(0, Math.round(cue.endMs)),
+			text: normalizeSubtitleText(cue.text),
+		}))
+		.filter((cue) => cue.text.length > 0 && cue.endMs > cue.startMs)
+		.sort((a, b) => a.startMs - b.startMs || a.endMs - b.endMs);
+}
+
+export function serializeCaptionsAsSrt(cues: CaptionCue[]) {
+	return getExportableCues(cues)
+		.map((cue, index) => {
+			const start = formatSubtitleTimestamp(cue.startMs, "srt");
+			const end = formatSubtitleTimestamp(cue.endMs, "srt");
+			return `${index + 1}\n${start} --> ${end}\n${cue.text}`;
+		})
+		.join("\n\n");
+}
+
+export function serializeCaptionsAsWebVtt(cues: CaptionCue[]) {
+	const body = getExportableCues(cues)
+		.map((cue) => {
+			const start = formatSubtitleTimestamp(cue.startMs, "vtt");
+			const end = formatSubtitleTimestamp(cue.endMs, "vtt");
+			return `${start} --> ${end}\n${cue.text}`;
+		})
+		.join("\n\n");
+
+	return body ? `WEBVTT\n\n${body}\n` : "WEBVTT\n";
+}
+
+export function serializeCaptions(cues: CaptionCue[], format: SubtitleExportFormat) {
+	return format === "vtt" ? serializeCaptionsAsWebVtt(cues) : serializeCaptionsAsSrt(cues);
+}


### PR DESCRIPTION
## Description
Add separate subtitle-file export for generated captions, with SRT and WebVTT output options in the Captions panel.

## Motivation
Issue #334 asks for exporting captions/subtitles as a separate file rather than baking captions into the rendered video. This keeps the feature scoped to caption-file export and avoids coupling it to the video render pipeline.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #334

## Changes Made
- add SRT and WebVTT serializers for existing caption cues
- add focused serializer coverage for timestamps, cue ordering, whitespace cleanup, and invalid cue filtering
- add `Export SRT` and `Export VTT` actions to the Captions panel when captions exist
- add a dedicated Electron save path for subtitle files with subtitle-specific filters and UTF-8 output

## Testing Guide
1. Generate captions in the editor.
2. Open the Captions panel.
3. Click `Export SRT` and save the file.
4. Click `Export VTT` and save the file.
5. Verify each file opens as text and contains the expected timestamps and caption text.
6. Verify the export buttons are disabled when no captions exist.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the new behavior.
- [ ] I have completed a manual Electron save-dialog smoke test.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `vitest run src/components/video-editor/subtitleExport.test.ts`
- `tsc --noEmit`
- `biome check --formatter-enabled=false electron/ipc/register/export.ts electron/preload.ts electron/electron-env.d.ts src/components/video-editor/SettingsPanel.tsx src/components/video-editor/VideoEditor.tsx src/components/video-editor/subtitleExport.ts src/components/video-editor/subtitleExport.test.ts`

Notes:
- The scoped Biome check still reports the existing `handleExport` smoke-export dependency warnings in `VideoEditor.tsx`; this PR leaves those unrelated warnings untouched.