### PR TITLE
fix: syntax error for bash commands 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,6 @@
 Thank you for considering contributing to this project! By contributing, you help make this project better for everyone. Please take a moment to review these guidelines to ensure a smooth contribution process.
 
 Areas where help is especially valuable:
-
 - Export optimisations
 - Native screen recording for Linux
 - Wallpaper submissions
@@ -17,7 +16,7 @@ Areas where help is especially valuable:
 2. **Clone Your Fork**
    - Clone your forked repository to your local machine:
      ```bash
-   git clone https://github.com/your-username/Recordly.git
+     git clone https://github.com/your-username/Recordly.git
      ```
 
 3. **Create a New Branch**


### PR DESCRIPTION
Updated formatting and fixed minor text inconsistencies in the CONTRIBUTING.md file as the bash commands had their intro text inside the code block

## Description
The CONTRIBUTING.md had a minor issue where the bash commands in the steps 2,3,6 and 7 were placed inside the code block instead of being placed above it.

## Motivation
Helps beginners understand the contribution document better and is very handy to copy and paste commands directly into the terminal from the code blocks.

## Type of Change
- [ ] Documentation Update

**Screenshot** :

<img width="1246" height="576" alt="image" src="https://github.com/user-attachments/assets/1d6a9ec5-782d-4df7-a72c-8b0c1588ffd7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guide with formatting improvements and removed extraneous entries to enhance clarity for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->