### PR TITLE
feat(editor): add precise crop pixel inputs

### DIFF
--- a/src/components/video-editor/CropControl.tsx
+++ b/src/components/video-editor/CropControl.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
-import { type AspectRatio } from "@/utils/aspectRatioUtils";
-
-interface CropRegion {
-	x: number; // 0-1 normalized
-	y: number; // 0-1 normalized
-	width: number; // 0-1 normalized
-	height: number; // 0-1 normalized
-}
+import type { AspectRatio } from "@/utils/aspectRatioUtils";
+import {
+	type CropRegionPixels,
+	cropRegionFromPixels,
+	cropRegionToPixels,
+	getCropSourceDimensions,
+} from "./cropRegionPixels";
+import type { CropRegion } from "./types";
 
 interface CropControlProps {
 	videoElement: HTMLVideoElement | null;
@@ -148,12 +148,28 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 	const cropPixelY = cropRegion.y * 100;
 	const cropPixelWidth = cropRegion.width * 100;
 	const cropPixelHeight = cropRegion.height * 100;
-	const videoAspectRatio = videoElement
-		? videoElement.videoWidth / videoElement.videoHeight
-		: 16 / 9;
+	const cropSourceDimensions = getCropSourceDimensions(videoElement);
+	const preciseCropPixels = cropRegionToPixels(
+		cropRegion,
+		cropSourceDimensions.width,
+		cropSourceDimensions.height,
+	);
+	const videoAspectRatio = cropSourceDimensions.width / cropSourceDimensions.height;
 	const isVideoPortrait = videoAspectRatio < 1;
 	const maxContainerWidth = isVideoPortrait ? "40vw" : "75vw";
 	const maxContainerHeight = "75vh";
+	const handlePixelInputChange = (field: keyof CropRegionPixels, value: number) => {
+		onCropChange(
+			cropRegionFromPixels(
+				{
+					...preciseCropPixels,
+					[field]: value,
+				},
+				cropSourceDimensions.width,
+				cropSourceDimensions.height,
+			),
+		);
+	};
 
 	return (
 		<div className="w-full p-8">
@@ -269,6 +285,46 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 					}}
 					onPointerDown={(e) => handlePointerDown(e, "right")}
 				/>
+			</div>
+			<div className="mx-auto mt-4 max-w-2xl rounded-xl border border-white/10 bg-black/80 p-3 shadow-lg backdrop-blur">
+				<div className="mb-2 flex items-center justify-between">
+					<span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-white/70">
+						Precise crop
+					</span>
+					<span className="text-[10px] text-white/45">
+						{cropSourceDimensions.width} x {cropSourceDimensions.height}px source
+					</span>
+				</div>
+				<div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+					{(
+						[
+							{ key: "x", label: "X", max: cropSourceDimensions.width - 1 },
+							{ key: "y", label: "Y", max: cropSourceDimensions.height - 1 },
+							{ key: "width", label: "W", max: cropSourceDimensions.width },
+							{ key: "height", label: "H", max: cropSourceDimensions.height },
+						] as const
+					).map((input) => (
+						<label key={input.key} className="space-y-1">
+							<span className="text-[10px] font-medium uppercase tracking-[0.12em] text-white/50">
+								{input.label}
+							</span>
+							<div className="flex items-center rounded-lg border border-white/10 bg-white/5 px-2 focus-within:border-[#2563EB]/70">
+								<input
+									type="number"
+									min={0}
+									max={input.max}
+									step={1}
+									value={preciseCropPixels[input.key]}
+									onChange={(event) =>
+										handlePixelInputChange(input.key, Number(event.currentTarget.value))
+									}
+									className="min-w-0 flex-1 bg-transparent py-1.5 text-sm tabular-nums text-white outline-none"
+								/>
+								<span className="text-[10px] text-white/35">px</span>
+							</div>
+						</label>
+					))}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/video-editor/cropRegionPixels.test.ts
+++ b/src/components/video-editor/cropRegionPixels.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { cropRegionFromPixels, cropRegionToPixels } from "./cropRegionPixels";
+
+describe("cropRegionPixels", () => {
+	it("converts normalized crop regions into source pixel values", () => {
+		expect(
+			cropRegionToPixels(
+				{
+					x: 0.25,
+					y: 0.1,
+					width: 0.5,
+					height: 0.75,
+				},
+				1920,
+				1080,
+			),
+		).toEqual({
+			x: 480,
+			y: 108,
+			width: 960,
+			height: 810,
+		});
+	});
+
+	it("converts source pixel values back into normalized crop regions", () => {
+		expect(cropRegionFromPixels({ x: 100, y: 50, width: 500, height: 300 }, 1000, 500))
+			.toEqual({
+				x: 0.1,
+				y: 0.1,
+				width: 0.5,
+				height: 0.6,
+			});
+	});
+
+	it("clamps pixel input to the source bounds and minimum crop size", () => {
+		expect(cropRegionFromPixels({ x: 995, y: 498, width: 1, height: 1 }, 1000, 500))
+			.toEqual({
+				x: 0.99,
+				y: 0.99,
+				width: 0.01,
+				height: 0.01,
+			});
+	});
+});

--- a/src/components/video-editor/cropRegionPixels.ts
+++ b/src/components/video-editor/cropRegionPixels.ts
@@ -1,0 +1,72 @@
+import type { CropRegion } from "./types";
+
+export interface CropRegionPixels {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+const DEFAULT_SOURCE_WIDTH = 1920;
+const DEFAULT_SOURCE_HEIGHT = 1080;
+const MIN_CROP_RATIO = 0.01;
+
+function clamp(value: number, min: number, max: number) {
+	return Math.min(max, Math.max(min, value));
+}
+
+function normalizeSourceDimension(value: number, fallback: number) {
+	return Number.isFinite(value) && value > 0 ? Math.round(value) : fallback;
+}
+
+function normalizePixelValue(value: number) {
+	return Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+export function getCropSourceDimensions(videoElement: HTMLVideoElement | null) {
+	return {
+		width: normalizeSourceDimension(videoElement?.videoWidth ?? 0, DEFAULT_SOURCE_WIDTH),
+		height: normalizeSourceDimension(videoElement?.videoHeight ?? 0, DEFAULT_SOURCE_HEIGHT),
+	};
+}
+
+export function cropRegionToPixels(
+	cropRegion: CropRegion,
+	sourceWidth: number,
+	sourceHeight: number,
+): CropRegionPixels {
+	const width = normalizeSourceDimension(sourceWidth, DEFAULT_SOURCE_WIDTH);
+	const height = normalizeSourceDimension(sourceHeight, DEFAULT_SOURCE_HEIGHT);
+
+	const x = clamp(Math.round(cropRegion.x * width), 0, width - 1);
+	const y = clamp(Math.round(cropRegion.y * height), 0, height - 1);
+	return {
+		x,
+		y,
+		width: clamp(Math.round(cropRegion.width * width), 1, width - x),
+		height: clamp(Math.round(cropRegion.height * height), 1, height - y),
+	};
+}
+
+export function cropRegionFromPixels(
+	pixels: CropRegionPixels,
+	sourceWidth: number,
+	sourceHeight: number,
+): CropRegion {
+	const width = normalizeSourceDimension(sourceWidth, DEFAULT_SOURCE_WIDTH);
+	const height = normalizeSourceDimension(sourceHeight, DEFAULT_SOURCE_HEIGHT);
+	const minWidth = Math.max(1, Math.ceil(width * MIN_CROP_RATIO));
+	const minHeight = Math.max(1, Math.ceil(height * MIN_CROP_RATIO));
+
+	const x = clamp(normalizePixelValue(pixels.x), 0, width - minWidth);
+	const y = clamp(normalizePixelValue(pixels.y), 0, height - minHeight);
+	const cropWidth = clamp(normalizePixelValue(pixels.width), minWidth, width - x);
+	const cropHeight = clamp(normalizePixelValue(pixels.height), minHeight, height - y);
+
+	return {
+		x: x / width,
+		y: y / height,
+		width: cropWidth / width,
+		height: cropHeight / height,
+	};
+}


### PR DESCRIPTION
## Description
Add precise pixel inputs to the existing visual crop editor so users can adjust `X`, `Y`, `W`, and `H` directly against the source video dimensions.

This keeps the current drag handles intact and adds a narrow manual-control layer instead of rewriting the crop workflow.

## Motivation
Issue #212 asks for better crop precision, especially for high-resolution recordings where slider or drag-only adjustments are hard to dial in. This PR addresses the manual pixel-input part of that request while leaving the larger workflow/sidebar redesign for a separate follow-up.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #212

## Changes Made
- add a small pure helper for converting crop regions between normalized coordinates and source pixels
- clamp manual pixel input to the source bounds and the existing minimum crop size behavior
- add `X`, `Y`, `W`, and `H` pixel inputs under the visual crop overlay
- keep existing drag-handle crop editing unchanged
- add focused unit coverage for crop pixel conversion and clamping

## Testing Guide
1. Open a recording in the editor and open the crop editor.
2. Drag the crop handles and verify the pixel inputs update.
3. Type specific values into `X`, `Y`, `W`, and `H`.
4. Verify the crop overlay updates immediately and values stay within the source video bounds.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the new behavior.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `vitest run src/components/video-editor/cropRegionPixels.test.ts`
- `tsc --noEmit`
- `biome check --formatter-enabled=false src/components/video-editor/CropControl.tsx src/components/video-editor/cropRegionPixels.ts src/components/video-editor/cropRegionPixels.test.ts`

Notes:
- Kept as draft until the crop editor UI is smoke-tested in the app.
- This intentionally does not move crop/aspect controls into the sidebar; that is broader UX work related to #117.