### PR TITLE
fix(editor): allow scrolling all audio tracks

### DIFF
--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -60,6 +60,10 @@ import Item from "./Item";
 import KeyframeMarkers from "./KeyframeMarkers";
 import Row from "./Row";
 import TimelineWrapper from "./TimelineWrapper";
+import {
+	getTimelineContentMinHeightPx,
+	getTimelineRowsMinHeightPx,
+} from "./timelineLayout";
 import { type AudioPeaksData, useAudioPeaks } from "./useAudioPeaks";
 import { buildInteractionZoomSuggestions } from "./zoomSuggestionUtils";
 
@@ -702,12 +706,18 @@ function Timeline({
 			).sort((left, right) => getAnnotationTrackIndex(left) - getAnnotationTrackIndex(right)),
 		[annotationItems],
 	);
+	const timelineRowCount = 2 + annotationRowIds.length + audioRowIds.length;
+	const timelineRowsMinHeightPx = getTimelineRowsMinHeightPx(timelineRowCount);
+	const timelineContentMinHeightPx = getTimelineContentMinHeightPx(timelineRowCount);
 
 	return (
 		<div
 			ref={setRefs}
-			style={style}
-			className="select-none bg-editor-bg h-full min-h-0 relative cursor-pointer group flex flex-col"
+			style={{
+				...style,
+				minHeight: `max(100%, ${timelineContentMinHeightPx}px)`,
+			}}
+			className="select-none bg-editor-bg relative cursor-pointer group flex flex-col"
 			onClick={handleTimelineClick}
 		>
 			<div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--foreground)/0.03)_1px,transparent_1px)] bg-[length:20px_100%] pointer-events-none" />
@@ -720,7 +730,10 @@ function Timeline({
 				keyframes={keyframes}
 			/>
 
-			<div className="relative z-10 flex flex-1 min-h-0 flex-col">
+			<div
+				className="relative z-10 flex flex-1 min-h-0 flex-col"
+				style={{ minHeight: timelineRowsMinHeightPx }}
+			>
 				<Row id={CLIP_ROW_ID} isEmpty={clipItems.length === 0} hint="Press C to split clip">
 					{audioPeaks && <AudioWaveform peaks={audioPeaks} />}
 					<ClipMarkerOverlay videoDurationMs={videoDurationMs} />

--- a/src/components/video-editor/timeline/TimelineWrapper.tsx
+++ b/src/components/video-editor/timeline/TimelineWrapper.tsx
@@ -375,7 +375,7 @@ export default function TimelineWrapper({
 			autoScroll={{ enabled: false }}
 			resizeHandleWidth={28}
 		>
-			<div className="relative h-full min-h-0">
+			<div className="relative min-h-full">
 				{children}
 				{/* Floating tooltip shown during drag/resize */}
 				<div

--- a/src/components/video-editor/timeline/timelineLayout.test.ts
+++ b/src/components/video-editor/timeline/timelineLayout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+	getTimelineContentMinHeightPx,
+	getTimelineRowsMinHeightPx,
+	TIMELINE_AXIS_HEIGHT_PX,
+	TIMELINE_ROW_MIN_HEIGHT_PX,
+} from "./timelineLayout";
+
+describe("timelineLayout", () => {
+	it("reserves vertical space for every rendered timeline row", () => {
+		expect(getTimelineRowsMinHeightPx(5)).toBe(5 * TIMELINE_ROW_MIN_HEIGHT_PX);
+		expect(getTimelineContentMinHeightPx(5)).toBe(
+			TIMELINE_AXIS_HEIGHT_PX + 5 * TIMELINE_ROW_MIN_HEIGHT_PX,
+		);
+	});
+
+	it("ignores invalid row counts", () => {
+		expect(getTimelineRowsMinHeightPx(-1)).toBe(0);
+		expect(getTimelineRowsMinHeightPx(Number.NaN)).toBe(0);
+		expect(getTimelineContentMinHeightPx(Number.POSITIVE_INFINITY)).toBe(
+			TIMELINE_AXIS_HEIGHT_PX,
+		);
+	});
+});

--- a/src/components/video-editor/timeline/timelineLayout.test.ts
+++ b/src/components/video-editor/timeline/timelineLayout.test.ts
@@ -21,4 +21,11 @@ describe("timelineLayout", () => {
 			TIMELINE_AXIS_HEIGHT_PX,
 		);
 	});
+
+	it("floors fractional row counts", () => {
+		expect(getTimelineRowsMinHeightPx(2.9)).toBe(2 * TIMELINE_ROW_MIN_HEIGHT_PX);
+		expect(getTimelineContentMinHeightPx(2.9)).toBe(
+			TIMELINE_AXIS_HEIGHT_PX + 2 * TIMELINE_ROW_MIN_HEIGHT_PX,
+		);
+	});
 });

--- a/src/components/video-editor/timeline/timelineLayout.ts
+++ b/src/components/video-editor/timeline/timelineLayout.ts
@@ -1,0 +1,18 @@
+export const TIMELINE_AXIS_HEIGHT_PX = 32;
+export const TIMELINE_ROW_MIN_HEIGHT_PX = 28;
+
+function normalizeRowCount(rowCount: number) {
+	if (!Number.isFinite(rowCount)) {
+		return 0;
+	}
+
+	return Math.max(0, Math.floor(rowCount));
+}
+
+export function getTimelineRowsMinHeightPx(rowCount: number) {
+	return normalizeRowCount(rowCount) * TIMELINE_ROW_MIN_HEIGHT_PX;
+}
+
+export function getTimelineContentMinHeightPx(rowCount: number) {
+	return TIMELINE_AXIS_HEIGHT_PX + getTimelineRowsMinHeightPx(rowCount);
+}


### PR DESCRIPTION
## Description
Fix the editor timeline layout so additional audio rows increase the timeline content height and remain reachable through the existing scroll container.

## Motivation
Issue #360 reports that the third audio track can be clipped and unreachable in v1.2.0 beta-2. The timeline root was still locked to the visible viewport height while `dnd-timeline` applies `overflow: hidden`, so extra rows could be cut off instead of contributing to scroll height.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #360

## Changes Made
- add a small timeline layout helper for row/content minimum height calculations
- reserve vertical space for the clip row, zoom row, annotation rows, and audio rows
- allow the timeline wrapper to grow beyond the visible viewport so the existing scroll container can reach lower rows
- add focused unit coverage for the layout height calculation

## Scope Note
This PR addresses only the first #360 report: the third audio track being clipped or unreachable. The per-track volume and 1.5x export issues are separate paths tracked by #354 and #362.

## Testing Guide
1. Open a project in the editor.
2. Add three audio regions on separate audio tracks.
3. Verify the timeline can scroll down to the third audio track.
4. Verify the existing clip, zoom, annotation, and first audio rows still render normally.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the new behavior.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `vitest run src/components/video-editor/timeline/timelineLayout.test.ts`
- `tsc --noEmit`
- `biome check --formatter-enabled=false src/components/video-editor/timeline/TimelineEditor.tsx src/components/video-editor/timeline/TimelineWrapper.tsx src/components/video-editor/timeline/timelineLayout.ts src/components/video-editor/timeline/timelineLayout.test.ts`
- `git diff --check`
- `vite build --config vite.config.ts`

Runtime UI smoke:
- production Electron renderer opened a `.recordly` fixture with three added-audio regions on `trackIndex` 0, 1, and 2
- timeline container measured `clientHeight: 160`, `scrollHeight: 172`, and scrolled to `scrollTop: 12`
- after scrolling, all three audio labels were visible in the timeline, including the third track


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced minimum timeline heights based on rendered rows to maintain consistent spacing and prevent layout collapse.
  * Switched timeline container from forced full height to using a minimum height for better flexibility and responsive behavior.

* **Tests**
  * Added tests validating minimum-height calculations and edge-case handling (negative, fractional, and non-finite inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->