### PR TITLE
fix(export): use tempo filters for speed audio

### DIFF
--- a/electron/ipc/ffmpeg/filters.ts
+++ b/electron/ipc/ffmpeg/filters.ts
@@ -1,6 +1,7 @@
 import type { AudioSyncAdjustment, PauseSegment } from "../types";
 
 const MAX_AUDIO_SYNC_DELAY_MS = 15000;
+export const ATEMPO_FILTER_EPSILON = 0.0005;
 
 export function buildAtempoFilters(tempoRatio: number): string[] {
 	if (!Number.isFinite(tempoRatio) || tempoRatio <= 0) {
@@ -20,7 +21,7 @@ export function buildAtempoFilters(tempoRatio: number): string[] {
 		remaining /= 2.0;
 	}
 
-	if (Math.abs(remaining - 1) > 0.0005) {
+	if (Math.abs(remaining - 1) > ATEMPO_FILTER_EPSILON) {
 		filters.push(`atempo=${remaining.toFixed(6)}`);
 	}
 

--- a/electron/ipc/nativeVideoExport.test.ts
+++ b/electron/ipc/nativeVideoExport.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { ATEMPO_FILTER_EPSILON } from "./ffmpeg/filters";
 import {
 	buildEditedTrackSourceAudioFilter,
 	buildTrimmedSourceAudioFilter,
@@ -58,6 +59,20 @@ describe("buildEditedTrackSourceAudioFilter", () => {
 			"[1:a]atrim=start=0.000:end=2.000,asetpts=PTS-STARTPTS[edited_audio_0];" +
 				"[edited_audio_0]anull[aout]",
 		);
+	});
+
+	it("treats exact epsilon speed changes as unchanged audio", () => {
+		for (const speed of [1 - ATEMPO_FILTER_EPSILON, 1 + ATEMPO_FILTER_EPSILON]) {
+			const filter = buildEditedTrackSourceAudioFilter(
+				[{ startMs: 0, endMs: 2_000, speed }],
+				44_100,
+			);
+
+			expect(filter).toBe(
+				"[1:a]atrim=start=0.000:end=2.000,asetpts=PTS-STARTPTS[edited_audio_0];" +
+					"[edited_audio_0]anull[aout]",
+			);
+		}
 	});
 
 	it("returns null when the edited-track filtergraph inputs are incomplete", () => {

--- a/electron/ipc/nativeVideoExport.test.ts
+++ b/electron/ipc/nativeVideoExport.test.ts
@@ -20,7 +20,7 @@ describe("buildTrimmedSourceAudioFilter", () => {
 });
 
 describe("buildEditedTrackSourceAudioFilter", () => {
-	it("builds a concat filtergraph that pitch-shifts via asetrate for speed changes", () => {
+	it("builds a concat filtergraph that applies tempo filters for speed changes", () => {
 		const filter = buildEditedTrackSourceAudioFilter(
 			[
 				{ startMs: 0, endMs: 2_000, speed: 1 },
@@ -31,19 +31,19 @@ describe("buildEditedTrackSourceAudioFilter", () => {
 
 		expect(filter).toBe(
 			"[1:a]atrim=start=0.000:end=2.000,asetpts=PTS-STARTPTS[edited_audio_0];" +
-				"[1:a]atrim=start=2.000:end=6.000,asetpts=PTS-STARTPTS,asetrate=66150,aresample=44100[edited_audio_1];" +
+				"[1:a]atrim=start=2.000:end=6.000,asetpts=PTS-STARTPTS,atempo=1.500000[edited_audio_1];" +
 				"[edited_audio_0][edited_audio_1]concat=n=2:v=0:a=1[aout]",
 		);
 	});
 
-	it("builds a filtergraph for slowdown segments by lowering then resampling the source rate", () => {
+	it("builds a filtergraph for slowdown segments with a tempo filter", () => {
 		const filter = buildEditedTrackSourceAudioFilter(
 			[{ startMs: 0, endMs: 2_000, speed: 0.5 }],
 			44_100,
 		);
 
 		expect(filter).toBe(
-			"[1:a]atrim=start=0.000:end=2.000,asetpts=PTS-STARTPTS,asetrate=22050,aresample=44100[edited_audio_0];" +
+			"[1:a]atrim=start=0.000:end=2.000,asetpts=PTS-STARTPTS,atempo=0.500000[edited_audio_0];" +
 				"[edited_audio_0]anull[aout]",
 		);
 	});

--- a/electron/ipc/nativeVideoExport.test.ts
+++ b/electron/ipc/nativeVideoExport.test.ts
@@ -48,6 +48,18 @@ describe("buildEditedTrackSourceAudioFilter", () => {
 		);
 	});
 
+	it("treats near-unity speed changes as unchanged audio", () => {
+		const filter = buildEditedTrackSourceAudioFilter(
+			[{ startMs: 0, endMs: 2_000, speed: 1.0002 }],
+			44_100,
+		);
+
+		expect(filter).toBe(
+			"[1:a]atrim=start=0.000:end=2.000,asetpts=PTS-STARTPTS[edited_audio_0];" +
+				"[edited_audio_0]anull[aout]",
+		);
+	});
+
 	it("returns null when the edited-track filtergraph inputs are incomplete", () => {
 		expect(buildEditedTrackSourceAudioFilter([], 44_100)).toBeNull();
 		expect(

--- a/electron/ipc/nativeVideoExport.ts
+++ b/electron/ipc/nativeVideoExport.ts
@@ -1,4 +1,4 @@
-import { buildAtempoFilters } from "./ffmpeg/filters";
+import { ATEMPO_FILTER_EPSILON, buildAtempoFilters } from "./ffmpeg/filters";
 
 const NATIVE_EXPORT_INPUT_BYTES_PER_PIXEL = 4;
 const MIN_EDITED_TRACK_TEMPO_SPEED = 0.5;
@@ -225,14 +225,12 @@ export function buildEditedTrackSourceAudioFilter(
 			"asetpts=PTS-STARTPTS",
 		];
 
-		if (Math.abs(speed - 1) > 0.0001) {
-			const tempoFilters = buildAtempoFilters(speed);
-			if (tempoFilters.length === 0) {
-				hasInvalidSegment = true;
-				return;
-			}
-
+		const tempoFilters = buildAtempoFilters(speed);
+		if (tempoFilters.length > 0) {
 			segmentFilter.push(...tempoFilters);
+		} else if (Math.abs(speed - 1) > ATEMPO_FILTER_EPSILON) {
+			hasInvalidSegment = true;
+			return;
 		}
 
 		filterParts.push(`${segmentFilter.join(",")}[${label}]`);

--- a/electron/ipc/nativeVideoExport.ts
+++ b/electron/ipc/nativeVideoExport.ts
@@ -1,4 +1,8 @@
+import { buildAtempoFilters } from "./ffmpeg/filters";
+
 const NATIVE_EXPORT_INPUT_BYTES_PER_PIXEL = 4;
+const MIN_EDITED_TRACK_TEMPO_SPEED = 0.5;
+const MAX_EDITED_TRACK_TEMPO_SPEED = 2;
 
 export type NativeExportEncodingMode = "fast" | "balanced" | "quality";
 
@@ -207,7 +211,11 @@ export function buildEditedTrackSourceAudioFilter(
 
 		const label = `edited_audio_${index}`;
 		const speed = segment.speed;
-		if (!Number.isFinite(speed) || speed <= 0) {
+		if (
+			!Number.isFinite(speed) ||
+			speed < MIN_EDITED_TRACK_TEMPO_SPEED ||
+			speed > MAX_EDITED_TRACK_TEMPO_SPEED
+		) {
 			hasInvalidSegment = true;
 			return;
 		}
@@ -218,16 +226,13 @@ export function buildEditedTrackSourceAudioFilter(
 		];
 
 		if (Math.abs(speed - 1) > 0.0001) {
-			const adjustedSampleRate = Math.round(normalizedSourceSampleRate * speed);
-			if (!Number.isSafeInteger(adjustedSampleRate) || adjustedSampleRate < 1) {
+			const tempoFilters = buildAtempoFilters(speed);
+			if (tempoFilters.length === 0) {
 				hasInvalidSegment = true;
 				return;
 			}
 
-			segmentFilter.push(
-				`asetrate=${adjustedSampleRate}`,
-				`aresample=${normalizedSourceSampleRate}`,
-			);
+			segmentFilter.push(...tempoFilters);
 		}
 
 		filterParts.push(`${segmentFilter.join(",")}[${label}]`);


### PR DESCRIPTION
## Description
Fix the native edited-track audio fast path so speed segments use FFmpeg tempo filters instead of resampling-rate tricks.

## Motivation
Issue #360 reports that 1.5x playback works in preview but breaks after export. The likely export-side suspect is the native `filtergraph-fast-path` added for simple speed edits: it currently speeds audio by changing the interpreted sample rate with `asetrate` and then resampling back. That can produce unnatural or broken-sounding audio for speed edits, while the safer FFmpeg primitive for this range is `atempo`.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #360

## Changes Made
- use the existing `buildAtempoFilters` helper for native edited-track speed segments
- keep the native helper guarded to the same conservative 0.5x-2.0x speed range as the renderer classifier
- update native export filtergraph tests for 1.5x and 0.5x speed segments

## Scope Note
This only targets the native edited-track audio fast path for simple speed edits. It does not change video frame scheduling, recording sync, or the audio-track scrolling fix in #361.

## Testing Guide
1. Open a project with embedded source audio.
2. Set a clip or speed region to 1.5x.
3. Export with the native/Breeze path enabled.
4. Verify the exported video is playable and the audio tempo follows the 1.5x edit without the previous broken/chipmunk-style fast-path behavior.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the changed filtergraph.
- [x] I have completed a manual runtime export smoke test.

Local checks run:
- `vitest run electron/ipc/nativeVideoExport.test.ts src/lib/exporter/editedTrackStrategy.test.ts`
- `tsc --noEmit`
- `biome check --formatter-enabled=false electron/ipc/nativeVideoExport.ts electron/ipc/nativeVideoExport.test.ts`
- `git diff --check`

Runtime smoke:
- combined local #360 smoke branch, native/modern export path
- source: 10.00s MP4 with embedded AAC audio
- project edit: one full-length `1.5x` speed region
- result: success report, `pipelineModel: modern`, `backendPreference: breeze`, 6.67s output, H.264 video and AAC audio present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate and reliable audio tempo adjustments during video export, with stricter validation of allowed speed ranges to prevent playback issues.
  * Correct handling of small, near‑unity speed changes so unchanged audio remains untouched.

* **Tests**
  * Updated tests to validate tempo-based processing and edge cases for speed increases, slowdowns, and near‑1 speeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->