### PR TITLE
ci: smoke and attest packaged artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,7 @@ jobs:
           path: |
             release/**/*.dmg
             release/**/*.zip
+            release/**/*.blockmap
             release/latest-mac.yml
             release/SHA256SUMS*.txt
           if-no-files-found: error
@@ -193,6 +194,7 @@ jobs:
           name: recordly-linux-${{ github.sha }}
           path: |
             release/**/*.AppImage
+            release/**/*.blockmap
             release/latest-linux.yml
             release/SHA256SUMS*.txt
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Upload Windows build
         uses: actions/upload-artifact@v4
         with:
-          name: recordly-windows-${{ github.sha }}
+          name: windows-x64-release
           path: |
             release/*.exe
             release/*.blockmap
@@ -128,7 +128,7 @@ jobs:
       - name: Upload macOS build
         uses: actions/upload-artifact@v4
         with:
-          name: recordly-macos-${{ matrix.arch }}-${{ github.sha }}
+          name: macos-${{ matrix.arch }}-release
           path: |
             release/**/*.dmg
             release/**/*.zip
@@ -191,7 +191,7 @@ jobs:
       - name: Upload Linux build
         uses: actions/upload-artifact@v4
         with:
-          name: recordly-linux-${{ github.sha }}
+          name: linux-x64-release
           path: |
             release/**/*.AppImage
             release/**/*.blockmap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,12 @@ name: Build Electron App
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -40,6 +46,14 @@ jobs:
       - name: Smoke test packaged Windows paths
         run: npm run smoke:packaged-binaries
 
+      - name: Generate Windows artifact checksums
+        run: npm run checksums:release -- SHA256SUMS-windows.txt
+
+      - name: Attest Windows artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS-windows.txt
+
       - name: Upload Windows build
         uses: actions/upload-artifact@v4
         with:
@@ -48,6 +62,7 @@ jobs:
             release/*.exe
             release/*.blockmap
             release/latest*.yml
+            release/SHA256SUMS*.txt
           if-no-files-found: error
           retention-days: 30
 
@@ -102,6 +117,14 @@ jobs:
           PACKAGED_SMOKE_ARCH_TAGS: ${{ matrix.arch_tag }}
         run: npm run smoke:packaged-binaries
 
+      - name: Generate macOS artifact checksums
+        run: npm run checksums:release -- SHA256SUMS-macos-${{ matrix.arch }}.txt
+
+      - name: Attest macOS artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS-macos-${{ matrix.arch }}.txt
+
       - name: Upload macOS build
         uses: actions/upload-artifact@v4
         with:
@@ -110,6 +133,7 @@ jobs:
             release/**/*.dmg
             release/**/*.zip
             release/latest-mac.yml
+            release/SHA256SUMS*.txt
           if-no-files-found: error
           retention-days: 30
 
@@ -155,6 +179,14 @@ jobs:
       - name: Smoke test packaged Linux paths
         run: npm run smoke:packaged-binaries
 
+      - name: Generate Linux artifact checksums
+        run: npm run checksums:release -- SHA256SUMS-linux.txt
+
+      - name: Attest Linux artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS-linux.txt
+
       - name: Upload Linux build
         uses: actions/upload-artifact@v4
         with:
@@ -162,5 +194,6 @@ jobs:
           path: |
             release/**/*.AppImage
             release/latest-linux.yml
+            release/SHA256SUMS*.txt
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,17 +35,34 @@ jobs:
           npm run build:platform-native-helpers
           npx tsc
           npx vite build
-          npx electron-builder --win nsis --x64 --publish never
+          npx electron-builder --win dir nsis --x64 --publish never
+
+      - name: Smoke test packaged Windows paths
+        run: npm run smoke:packaged-binaries
 
       - name: Upload Windows build
         uses: actions/upload-artifact@v4
         with:
-          name: windows-installer
-          path: release/**/*.exe
+          name: recordly-windows-${{ github.sha }}
+          path: |
+            release/*.exe
+            release/*.blockmap
+            release/latest*.yml
+          if-no-files-found: error
           retention-days: 30
 
   build-macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            arch_tag: darwin-x64
+            runner: macos-15-intel
+          - arch: arm64
+            arch_tag: darwin-arm64
+            runner: macos-14
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -78,16 +95,22 @@ jobs:
           npm run build:platform-native-helpers
           npx tsc
           npx vite build
-          npx electron-builder --mac dmg zip --publish never
+          npx electron-builder --mac dir dmg zip --${{ matrix.arch }} --publish never
+
+      - name: Smoke test packaged macOS paths
+        env:
+          PACKAGED_SMOKE_ARCH_TAGS: ${{ matrix.arch_tag }}
+        run: npm run smoke:packaged-binaries
 
       - name: Upload macOS build
         uses: actions/upload-artifact@v4
         with:
-          name: macos-installer
+          name: recordly-macos-${{ matrix.arch }}-${{ github.sha }}
           path: |
             release/**/*.dmg
             release/**/*.zip
             release/latest-mac.yml
+          if-no-files-found: error
           retention-days: 30
 
   build-linux:
@@ -127,13 +150,17 @@ jobs:
           npm run build:platform-native-helpers
           npx tsc
           npx vite build
-          npx electron-builder --linux AppImage --x64 --publish never
+          npx electron-builder --linux dir AppImage --x64 --publish never
+
+      - name: Smoke test packaged Linux paths
+        run: npm run smoke:packaged-binaries
 
       - name: Upload Linux build
         uses: actions/upload-artifact@v4
         with:
-          name: linux-installer
+          name: recordly-linux-${{ github.sha }}
           path: |
             release/**/*.AppImage
             release/latest-linux.yml
+          if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,12 @@ jobs:
         run: |
           npx tsc
           npx vite build
-          npx electron-builder --mac dmg zip --x64 --publish never
+          npx electron-builder --mac dir dmg zip --x64 --publish never
+
+      - name: Smoke test packaged macOS x64 paths
+        env:
+          PACKAGED_SMOKE_ARCH_TAGS: darwin-x64
+        run: npm run smoke:packaged-binaries
 
       - name: Upload macOS x64 artifacts
         uses: actions/upload-artifact@v4
@@ -233,7 +238,12 @@ jobs:
         run: |
           npx tsc
           npx vite build
-          npx electron-builder --mac dmg zip --arm64 --publish never
+          npx electron-builder --mac dir dmg zip --arm64 --publish never
+
+      - name: Smoke test packaged macOS arm64 paths
+        env:
+          PACKAGED_SMOKE_ARCH_TAGS: darwin-arm64
+        run: npm run smoke:packaged-binaries
 
       - name: Upload macOS arm64 artifacts
         uses: actions/upload-artifact@v4
@@ -384,7 +394,10 @@ jobs:
           npm run build:platform-native-helpers
           npx tsc
           npx vite build
-          npx electron-builder --win nsis --x64 --publish never
+          npx electron-builder --win dir nsis --x64 --publish never
+
+      - name: Smoke test packaged Windows x64 paths
+        run: npm run smoke:packaged-binaries
 
       - name: Upload Windows x64 artifacts
         uses: actions/upload-artifact@v4
@@ -446,7 +459,10 @@ jobs:
           npm run build:platform-native-helpers
           npx tsc
           npx vite build
-          npx electron-builder --linux AppImage --x64 --publish never
+          npx electron-builder --linux dir AppImage --x64 --publish never
+
+      - name: Smoke test packaged Linux x64 paths
+        run: npm run smoke:packaged-binaries
 
       - name: Upload Linux x64 artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: write
   actions: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 concurrency:
   group: release-${{ github.event.release.tag_name || github.event.inputs.tag_name || github.run_id }}
@@ -153,6 +156,14 @@ jobs:
           PACKAGED_SMOKE_ARCH_TAGS: darwin-x64
         run: npm run smoke:packaged-binaries
 
+      - name: Generate macOS x64 artifact checksums
+        run: npm run checksums:release -- SHA256SUMS-macos-x64.txt
+
+      - name: Attest macOS x64 artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS-macos-x64.txt
+
       - name: Upload macOS x64 artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -162,6 +173,7 @@ jobs:
             release/*.zip
             release/*.blockmap
             release/latest-mac.yml
+            release/SHA256SUMS*.txt
           if-no-files-found: error
 
   build-macos-arm64:
@@ -245,6 +257,14 @@ jobs:
           PACKAGED_SMOKE_ARCH_TAGS: darwin-arm64
         run: npm run smoke:packaged-binaries
 
+      - name: Generate macOS arm64 artifact checksums
+        run: npm run checksums:release -- SHA256SUMS-macos-arm64.txt
+
+      - name: Attest macOS arm64 artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS-macos-arm64.txt
+
       - name: Upload macOS arm64 artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -254,6 +274,7 @@ jobs:
             release/*.zip
             release/*.blockmap
             release/latest-mac.yml
+            release/SHA256SUMS*.txt
           if-no-files-found: error
 
   merge-macos-update-metadata:
@@ -399,6 +420,14 @@ jobs:
       - name: Smoke test packaged Windows x64 paths
         run: npm run smoke:packaged-binaries
 
+      - name: Generate Windows x64 artifact checksums
+        run: npm run checksums:release -- SHA256SUMS-windows-x64.txt
+
+      - name: Attest Windows x64 artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS-windows-x64.txt
+
       - name: Upload Windows x64 artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -407,6 +436,7 @@ jobs:
             release/*.exe
             release/*.blockmap
             release/latest*.yml
+            release/SHA256SUMS*.txt
           if-no-files-found: error
 
   build-linux-x64:
@@ -464,6 +494,14 @@ jobs:
       - name: Smoke test packaged Linux x64 paths
         run: npm run smoke:packaged-binaries
 
+      - name: Generate Linux x64 artifact checksums
+        run: npm run checksums:release -- SHA256SUMS-linux-x64.txt
+
+      - name: Attest Linux x64 artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS-linux-x64.txt
+
       - name: Upload Linux x64 artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -472,6 +510,7 @@ jobs:
             release/*.AppImage
             release/*.blockmap
             release/latest-linux.yml
+            release/SHA256SUMS*.txt
           if-no-files-found: error
 
   publish-release-assets:
@@ -515,6 +554,45 @@ jobs:
           name: linux-x64-release
           path: release-assets/linux-x64
 
+      - name: Generate release asset checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          assets=(
+            release-assets/macos-x64/*.dmg
+            release-assets/macos-x64/*.zip
+            release-assets/macos-x64/*.blockmap
+            release-assets/macos-arm64/*.dmg
+            release-assets/macos-arm64/*.zip
+            release-assets/macos-arm64/*.blockmap
+            release-assets/macos-merged/latest-mac.yml
+            release-assets/windows-x64/*.exe
+            release-assets/windows-x64/*.blockmap
+            release-assets/windows-x64/latest*.yml
+            release-assets/linux-x64/*.AppImage
+            release-assets/linux-x64/*.blockmap
+            release-assets/linux-x64/latest-linux.yml
+          )
+
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No release assets found to checksum."
+            exit 1
+          fi
+
+          : > release-assets/SHA256SUMS.txt
+          for file in "${assets[@]}"; do
+            digest="$(sha256sum "$file" | awk '{print $1}')"
+            printf '%s  %s\n' "$digest" "$(basename "$file")" >> release-assets/SHA256SUMS.txt
+          done
+          sort -k2,2 release-assets/SHA256SUMS.txt -o release-assets/SHA256SUMS.txt
+
+      - name: Attest release assets
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release-assets/SHA256SUMS.txt
+
       - name: Upload release assets to GitHub
         shell: bash
         run: |
@@ -535,6 +613,7 @@ jobs:
             release-assets/linux-x64/*.AppImage
             release-assets/linux-x64/*.blockmap
             release-assets/linux-x64/latest-linux.yml
+            release-assets/SHA256SUMS.txt
           )
 
           if [ ${#assets[@]} -eq 0 ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -554,12 +554,13 @@ jobs:
           name: linux-x64-release
           path: release-assets/linux-x64
 
-      - name: Generate release asset checksums
+      - name: Stage release assets
         shell: bash
         run: |
           set -euo pipefail
           shopt -s nullglob
 
+          mkdir -p release-assets/upload
           assets=(
             release-assets/macos-x64/*.dmg
             release-assets/macos-x64/*.zip
@@ -581,17 +582,27 @@ jobs:
             exit 1
           fi
 
-          : > release-assets/SHA256SUMS.txt
           for file in "${assets[@]}"; do
-            digest="$(sha256sum "$file" | awk '{print $1}')"
-            printf '%s  %s\n' "$digest" "$(basename "$file")" >> release-assets/SHA256SUMS.txt
+            target="release-assets/upload/$(basename "$file")"
+            if [ -e "$target" ]; then
+              echo "Duplicate release asset name: $(basename "$file")"
+              exit 1
+            fi
+            cp "$file" "$target"
           done
-          sort -k2,2 release-assets/SHA256SUMS.txt -o release-assets/SHA256SUMS.txt
+
+      - name: Generate release asset checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release-assets/upload
+          sha256sum * | sort -k2,2 > SHA256SUMS.txt
+          sha256sum -c SHA256SUMS.txt
 
       - name: Attest release assets
         uses: actions/attest@v4
         with:
-          subject-checksums: release-assets/SHA256SUMS.txt
+          subject-checksums: release-assets/upload/SHA256SUMS.txt
 
       - name: Upload release assets to GitHub
         shell: bash
@@ -600,20 +611,7 @@ jobs:
           shopt -s nullglob
 
           assets=(
-            release-assets/macos-x64/*.dmg
-            release-assets/macos-x64/*.zip
-            release-assets/macos-x64/*.blockmap
-            release-assets/macos-arm64/*.dmg
-            release-assets/macos-arm64/*.zip
-            release-assets/macos-arm64/*.blockmap
-            release-assets/macos-merged/latest-mac.yml
-            release-assets/windows-x64/*.exe
-            release-assets/windows-x64/*.blockmap
-            release-assets/windows-x64/latest*.yml
-            release-assets/linux-x64/*.AppImage
-            release-assets/linux-x64/*.blockmap
-            release-assets/linux-x64/latest-linux.yml
-            release-assets/SHA256SUMS.txt
+            release-assets/upload/*
           )
 
           if [ ${#assets[@]} -eq 0 ]; then

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"build:linux": "npm run build:platform-native-helpers && tsc && vite build --config vite.config.ts && electron-builder --linux",
 		"i18n:check": "node scripts/i18n-check.mjs",
 		"benchmark:export-queues": "node scripts/benchmark-export-queues.mjs",
+		"smoke:packaged-binaries": "node scripts/smoke-packaged-binaries.mjs",
 		"release:create": "node scripts/create-release.mjs",
 		"test": "vitest --run",
 		"test:watch": "vitest"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"i18n:check": "node scripts/i18n-check.mjs",
 		"benchmark:export-queues": "node scripts/benchmark-export-queues.mjs",
 		"smoke:packaged-binaries": "node scripts/smoke-packaged-binaries.mjs",
+		"checksums:release": "node scripts/write-release-checksums.mjs",
 		"release:create": "node scripts/create-release.mjs",
 		"test": "vitest --run",
 		"test:watch": "vitest"

--- a/scripts/smoke-packaged-binaries.mjs
+++ b/scripts/smoke-packaged-binaries.mjs
@@ -1,0 +1,269 @@
+import { execFileSync } from "node:child_process";
+import { accessSync, constants, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const projectRoot = process.cwd();
+const releaseRoot = path.join(projectRoot, "release");
+const packageJson = JSON.parse(readFileSync(path.join(projectRoot, "package.json"), "utf8"));
+const productName = packageJson.productName ?? packageJson.name ?? "Recordly";
+const packageName = packageJson.name ?? "recordly";
+
+function relativePath(filePath) {
+	return path.relative(projectRoot, filePath).replaceAll("\\", "/");
+}
+
+function fail(message) {
+	throw new Error(`[packaged-smoke] ${message}`);
+}
+
+function assertFile(filePath, label, { executable = false } = {}) {
+	if (!existsSync(filePath)) {
+		fail(`${label} is missing at ${relativePath(filePath)}`);
+	}
+
+	if (!statSync(filePath).isFile()) {
+		fail(`${label} is not a file at ${relativePath(filePath)}`);
+	}
+
+	if (executable && process.platform !== "win32") {
+		try {
+			accessSync(filePath, constants.X_OK);
+		} catch {
+			fail(`${label} is not executable at ${relativePath(filePath)}`);
+		}
+	}
+
+	console.log(`[packaged-smoke] ${label}: ${relativePath(filePath)}`);
+}
+
+function findDirectoriesByName(rootDir, directoryName, maxDepth = 8) {
+	if (!existsSync(rootDir)) {
+		return [];
+	}
+
+	const matches = [];
+	const queue = [{ dir: rootDir, depth: 0 }];
+
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current || current.depth > maxDepth) {
+			continue;
+		}
+
+		for (const entry of readdirSync(current.dir, { withFileTypes: true })) {
+			if (!entry.isDirectory()) {
+				continue;
+			}
+
+			const childDir = path.join(current.dir, entry.name);
+			if (entry.name === directoryName) {
+				matches.push(childDir);
+				continue;
+			}
+
+			queue.push({ dir: childDir, depth: current.depth + 1 });
+		}
+	}
+
+	return matches;
+}
+
+function findAppBundleDir(startDir) {
+	let current = startDir;
+	while (current !== path.dirname(current)) {
+		if (current.endsWith(".app")) {
+			return current;
+		}
+		current = path.dirname(current);
+	}
+
+	return null;
+}
+
+function findFirstExistingFile(candidates) {
+	return candidates.find((candidate) => existsSync(candidate) && statSync(candidate).isFile());
+}
+
+function assertPackagedAppExecutable(unpackedRoot) {
+	const resourcesDir = path.dirname(unpackedRoot);
+
+	if (process.platform === "darwin") {
+		const appBundleDir = findAppBundleDir(resourcesDir);
+		if (!appBundleDir) {
+			fail(`macOS app bundle not found for ${relativePath(unpackedRoot)}`);
+		}
+
+		const executablePath = findFirstExistingFile([
+			path.join(appBundleDir, "Contents", "MacOS", productName),
+			path.join(appBundleDir, "Contents", "MacOS", packageName),
+		]);
+		assertFile(
+			executablePath ?? path.join(appBundleDir, "Contents", "MacOS", productName),
+			"packaged app executable",
+			{ executable: true },
+		);
+		return;
+	}
+
+	const appDir = path.dirname(resourcesDir);
+	const executableCandidates =
+		process.platform === "win32"
+			? [
+					path.join(appDir, `${productName}.exe`),
+					path.join(appDir, `${packageName}.exe`),
+					path.join(appDir, "Recordly.exe"),
+				]
+			: [
+					path.join(appDir, packageName),
+					path.join(appDir, productName),
+					path.join(appDir, productName.toLowerCase()),
+				];
+
+	const executablePath = findFirstExistingFile(executableCandidates);
+	assertFile(executablePath ?? executableCandidates[0], "packaged app executable", {
+		executable: true,
+	});
+}
+
+function getNativeArchTag(platform = process.platform, arch = process.arch) {
+	if (platform === "darwin") {
+		return arch === "arm64" ? "darwin-arm64" : "darwin-x64";
+	}
+
+	if (platform === "win32") {
+		return arch === "arm64" ? "win32-arm64" : "win32-x64";
+	}
+
+	if (platform === "linux") {
+		return arch === "arm64" ? "linux-arm64" : "linux-x64";
+	}
+
+	return `${platform}-${arch}`;
+}
+
+function getRequiredArchTags() {
+	const configured = process.env.PACKAGED_SMOKE_ARCH_TAGS?.trim();
+	if (!configured) {
+		return [getNativeArchTag()];
+	}
+
+	return [
+		...new Set(
+			configured
+				.split(",")
+				.map((entry) => entry.trim())
+				.filter(Boolean),
+		),
+	];
+}
+
+function getExpectedNativeHelperFiles(archTag) {
+	if (archTag.startsWith("win32-")) {
+		return [
+			{ name: "wgc-capture.exe", label: "Windows capture helper", executable: true },
+			{
+				name: "cursor-monitor.exe",
+				label: "Windows cursor monitor helper",
+				executable: true,
+			},
+			{ name: "helpers-manifest.json", label: "Windows helper manifest" },
+			{ name: "whisper-cli.exe", label: "Whisper CLI runtime", executable: true },
+			{ name: "whisper-runtime.json", label: "Whisper runtime manifest" },
+		];
+	}
+
+	if (archTag.startsWith("darwin-")) {
+		return [
+			{
+				name: "recordly-screencapturekit-helper",
+				label: "ScreenCaptureKit helper",
+				executable: true,
+			},
+			{ name: "recordly-window-list", label: "Window list helper", executable: true },
+			{ name: "recordly-system-cursors", label: "System cursor helper", executable: true },
+			{
+				name: "recordly-native-cursor-monitor",
+				label: "Native cursor monitor helper",
+				executable: true,
+			},
+			{ name: "whisper-cli", label: "Whisper CLI runtime", executable: true },
+			{ name: "whisper-runtime.json", label: "Whisper runtime manifest" },
+		];
+	}
+
+	if (archTag.startsWith("linux-")) {
+		return [
+			{ name: "whisper-cli", label: "Whisper CLI runtime", executable: true },
+			{ name: "whisper-runtime.json", label: "Whisper runtime manifest" },
+		];
+	}
+
+	return [];
+}
+
+function verifyFfmpeg(unpackedRoot) {
+	const binaryName = process.platform === "win32" ? "ffmpeg.exe" : "ffmpeg";
+	const ffmpegPath = path.join(unpackedRoot, "node_modules", "ffmpeg-static", binaryName);
+
+	assertFile(ffmpegPath, "packaged FFmpeg binary", { executable: true });
+
+	const output = execFileSync(ffmpegPath, ["-version"], {
+		encoding: "utf8",
+		timeout: 15000,
+		windowsHide: true,
+	});
+
+	if (!output.startsWith("ffmpeg version")) {
+		fail(`FFmpeg version smoke returned unexpected output from ${relativePath(ffmpegPath)}`);
+	}
+
+	console.log(output.split(/\r?\n/, 1)[0]);
+}
+
+function verifyNativeHelpers(unpackedRoot) {
+	const nativeBinRoot = path.join(unpackedRoot, "electron", "native", "bin");
+	if (!existsSync(nativeBinRoot)) {
+		fail(`native helper bin directory is missing at ${relativePath(nativeBinRoot)}`);
+	}
+
+	for (const archTag of getRequiredArchTags()) {
+		const archDir = path.join(nativeBinRoot, archTag);
+		if (!existsSync(archDir)) {
+			fail(`native helper arch directory is missing at ${relativePath(archDir)}`);
+		}
+
+		const expectedFiles = getExpectedNativeHelperFiles(archTag);
+		if (expectedFiles.length === 0) {
+			fail(`no packaged helper expectations are defined for ${archTag}`);
+		}
+
+		for (const expectedFile of expectedFiles) {
+			assertFile(
+				path.join(archDir, expectedFile.name),
+				`${expectedFile.label} (${archTag})`,
+				{
+					executable: expectedFile.executable,
+				},
+			);
+		}
+	}
+}
+
+const unpackedRoots = findDirectoriesByName(releaseRoot, "app.asar.unpacked");
+
+if (unpackedRoots.length === 0) {
+	fail("no packaged app.asar.unpacked directory found under release/");
+}
+
+console.log(
+	`[packaged-smoke] verifying ${unpackedRoots.length} packaged app root(s) for ${process.platform}/${process.arch}`,
+);
+
+for (const unpackedRoot of unpackedRoots) {
+	console.log(`[packaged-smoke] root: ${relativePath(unpackedRoot)}`);
+	assertPackagedAppExecutable(unpackedRoot);
+	verifyFfmpeg(unpackedRoot);
+	verifyNativeHelpers(unpackedRoot);
+}
+
+console.log("[packaged-smoke] packaged binary path smoke passed");

--- a/scripts/write-release-checksums.mjs
+++ b/scripts/write-release-checksums.mjs
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { createReadStream, existsSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 const projectRoot = process.cwd();
@@ -29,7 +29,13 @@ function isReleaseArtifact(fileName) {
 }
 
 function sha256(filePath) {
-	return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+	return new Promise((resolve, reject) => {
+		const hash = createHash("sha256");
+		createReadStream(filePath)
+			.on("error", reject)
+			.on("data", (chunk) => hash.update(chunk))
+			.on("end", () => resolve(hash.digest("hex")));
+	});
 }
 
 if (!existsSync(releaseRoot)) {
@@ -46,9 +52,10 @@ if (releaseArtifacts.length === 0) {
 	throw new Error("[release-checksums] no release artifacts found");
 }
 
-const checksums = releaseArtifacts.map((filePath) => {
-	return `${sha256(filePath)}  ${artifactSubjectName(filePath)}`;
-});
+const checksums = [];
+for (const filePath of releaseArtifacts) {
+	checksums.push(`${await sha256(filePath)}  ${artifactSubjectName(filePath)}`);
+}
 
 writeFileSync(outputPath, `${checksums.join("\n")}\n`);
 console.log(`[release-checksums] wrote ${relativePath(outputPath)}`);

--- a/scripts/write-release-checksums.mjs
+++ b/scripts/write-release-checksums.mjs
@@ -1,0 +1,57 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const projectRoot = process.cwd();
+const releaseRoot = path.join(projectRoot, "release");
+const outputFileName = process.argv[2] ?? "SHA256SUMS.txt";
+const outputPath = path.join(releaseRoot, outputFileName);
+const releaseArtifactExtensions = new Set([".AppImage", ".blockmap", ".dmg", ".exe", ".zip"]);
+
+function relativePath(filePath) {
+	return path.relative(projectRoot, filePath).replaceAll("\\", "/");
+}
+
+function artifactSubjectName(filePath) {
+	return path.basename(filePath);
+}
+
+function isReleaseArtifact(fileName) {
+	if (fileName.startsWith("SHA256SUMS")) {
+		return false;
+	}
+
+	if (fileName.startsWith("latest") && fileName.endsWith(".yml")) {
+		return true;
+	}
+
+	return releaseArtifactExtensions.has(path.extname(fileName));
+}
+
+function sha256(filePath) {
+	return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+if (!existsSync(releaseRoot)) {
+	throw new Error("[release-checksums] release directory is missing");
+}
+
+const releaseArtifacts = readdirSync(releaseRoot)
+	.map((entry) => path.join(releaseRoot, entry))
+	.filter((filePath) => statSync(filePath).isFile())
+	.filter((filePath) => isReleaseArtifact(path.basename(filePath)))
+	.sort((left, right) => relativePath(left).localeCompare(relativePath(right)));
+
+if (releaseArtifacts.length === 0) {
+	throw new Error("[release-checksums] no release artifacts found");
+}
+
+const checksums = releaseArtifacts.map((filePath) => {
+	return `${sha256(filePath)}  ${artifactSubjectName(filePath)}`;
+});
+
+writeFileSync(outputPath, `${checksums.join("\n")}\n`);
+console.log(`[release-checksums] wrote ${relativePath(outputPath)}`);
+for (const artifact of releaseArtifacts) {
+	console.log(`[release-checksums] ${relativePath(artifact)}`);
+}


### PR DESCRIPTION
﻿## Description
Add packaged-runtime smoke coverage plus release-artifact integrity checks for CI and release builds so packaging regressions are caught before artifacts are uploaded.

## Motivation
The beta-2 investigation surfaced a packaging-path risk around FFmpeg. Dev launches can diverge from packaged Electron output, so CI should verify the packaged app layout directly and publish verifiable artifact metadata for the files users actually download.

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [x] CI / Release Quality

## Related Issue(s)
- Follow-up to the beta-2 FFmpeg packaging path investigation.

## Changes Made
- add `scripts/smoke-packaged-binaries.mjs` to verify packaged `app.asar.unpacked` paths
- execute packaged `ffmpeg -version` from the bundled path
- verify packaged native helper paths for Windows, macOS, and Linux arch tags
- build explicit unpacked `dir` targets before smoke tests in build and release workflows
- split manual macOS CI artifacts into x64 and arm64 jobs so native binaries match the runner architecture
- keep packaged build artifact names aligned with the release workflow artifact names
- generate `SHA256SUMS*.txt` files for packaged artifacts after smoke tests pass
- stream SHA256 calculation so large installers/DMGs/ZIPs are not loaded into memory at once
- add GitHub artifact attestations for per-platform build artifacts and the final release asset set
- stage final release assets into a flat upload directory before publishing
- fail the release job before upload if two artifacts would publish with the same file name
- fail artifact upload when expected files are missing

## Testing Guide
1. Run a packaged build, for example `npx electron-builder --win dir nsis --x64 --publish never` after the normal TypeScript/Vite/native-helper build steps.
2. Run `npm run smoke:packaged-binaries`.
3. Run `npm run checksums:release -- SHA256SUMS-windows.txt`.
4. Verify the smoke check reports the packaged app executable, FFmpeg binary, and native helpers from `app.asar.unpacked`.
5. Verify the checksum file contains only release artifacts such as installers, blockmaps, update metadata, DMGs, ZIPs, or AppImages.

## Checklist
- [x] I have performed a self-review of my changes.
- [x] I have kept the patch scoped to CI/package verification only.
- [x] I have tested the smoke script against a local packaged Windows build from this branch.
- [x] I have tested the checksum script against both a focused fixture and a real local Windows installer output.
- [x] I have tested the release staging logic with unique and duplicate artifact-name fixtures.
- [ ] I have run the full GitHub Actions packaged build matrix before marking ready.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `npm ci --ignore-scripts`
- `node node_modules/ffmpeg-static/install.js`
- `npx electron-builder install-app-deps`
- `npm run build:platform-native-helpers`
- `npx tsc`
- `npx vite build`
- `npx electron-builder --win dir nsis --x64 --publish never`
- `npm run smoke:packaged-binaries`
- `npm run checksums:release -- SHA256SUMS-windows-local.txt`
- focused checksum fixture covering installer, blockmap, `latest.yml`, ignored `builder-debug.yml`, and ignored stale checksum files
- release staging fixture that stages unique artifact names, generates `SHA256SUMS.txt`, and verifies it with `sha256sum -c`
- duplicate release-name fixture that fails before upload when two artifacts share the same basename
- streaming checksum fixture after CodeRabbit review
- `node --check scripts/smoke-packaged-binaries.mjs`
- `node --check scripts/write-release-checksums.mjs`
- `biome check scripts/smoke-packaged-binaries.mjs scripts/write-release-checksums.mjs package.json`
- `git diff --check`
- parsed `.github/workflows/build.yml` and `.github/workflows/release.yml` with PyYAML


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build and release workflows to add artifact attestations and cryptographic integrity checks using generated SHA256 checksum files.
  * Added automated smoke tests that validate packaged application binaries before release.
  * Improved platform-aware packaging and staging, including separate macOS architecture builds and stricter artifact upload validation.
  * Added CLI utilities to run packaged-binary smoke tests and to generate deterministic release checksum manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->