### PR TITLE
perf(export): bypass renderer for source-only MP4 exports

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -258,6 +258,21 @@ interface Window {
 			error?: string;
 			metrics?: RendererFfmpegAudioMuxMetrics;
 		}>;
+		nativeFastVideoExport: (options: {
+			sourcePath: string;
+			width: number;
+			height: number;
+			frameRate: number;
+			bitrate: number;
+			encodingMode: "fast" | "balanced" | "quality";
+			segments?: Array<{ startMs: number; endMs: number }>;
+		}) => Promise<{
+			success: boolean;
+			tempPath?: string;
+			encoderName?: string;
+			error?: string;
+			metrics?: RendererFfmpegAudioMuxMetrics;
+		}>;
 		openExportStream: (options?: { extension?: string }) => Promise<{
 			success: boolean;
 			streamId?: string;

--- a/electron/ipc/export/native-video.ts
+++ b/electron/ipc/export/native-video.ts
@@ -10,17 +10,21 @@ import { app } from "electron";
 import { getFfmpegBinaryPath } from "../ffmpeg/binary";
 import type {
 	NativeExportEncodingMode,
+	NativeFastVideoExportOptions,
 	NativeVideoAudioMuxMetrics,
 	NativeVideoExportFinishOptions,
 } from "../nativeVideoExport";
 import {
 	buildEditedTrackSourceAudioFilter,
+	buildNativeFastVideoExportArgs,
 	buildNativeVideoExportArgs,
 	buildTrimmedSourceAudioFilter,
+	canStreamCopyNativeFastVideoExport,
 	getEditedAudioExtension,
 	getNativeVideoInputByteSize,
 	getPreferredNativeVideoEncoders,
 	parseAvailableFfmpegEncoders,
+	parseNativeFastVideoSourceProbe,
 } from "../nativeVideoExport";
 import { cachedNativeVideoEncoder, setCachedNativeVideoEncoder } from "../state";
 
@@ -370,6 +374,64 @@ export async function resolveNativeVideoEncoder(
 	}
 
 	throw new Error("No usable FFmpeg encoder was available for native export");
+}
+
+async function shouldUseNativeFastVideoStreamCopy(
+	ffmpegPath: string,
+	options: NativeFastVideoExportOptions,
+) {
+	try {
+		await execFileAsync(ffmpegPath, ["-hide_banner", "-i", options.sourcePath], {
+			timeout: 15000,
+			maxBuffer: 20 * 1024 * 1024,
+		});
+		return false;
+	} catch (error) {
+		const output =
+			error && typeof error === "object"
+				? `${"stdout" in error ? String(error.stdout ?? "") : ""}\n${"stderr" in error ? String(error.stderr ?? "") : ""}`
+				: String(error);
+		const probe = parseNativeFastVideoSourceProbe(output);
+		return canStreamCopyNativeFastVideoExport(probe, options);
+	}
+}
+
+export async function exportNativeFastVideo(options: NativeFastVideoExportOptions) {
+	const ffmpegPath = getFfmpegBinaryPath();
+	const useStreamCopy = await shouldUseNativeFastVideoStreamCopy(ffmpegPath, options);
+	const encoderName = useStreamCopy
+		? "copy"
+		: await resolveNativeVideoEncoder(ffmpegPath, options.encodingMode);
+	const outputPath = path.join(
+		app.getPath("temp"),
+		`recordly-fast-export-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.mp4`,
+	);
+	const args = buildNativeFastVideoExportArgs(
+		encoderName,
+		{
+			...options,
+			videoMode: useStreamCopy ? "copy" : "encode",
+		},
+		outputPath,
+	);
+	const metrics: NativeVideoAudioMuxMetrics = {};
+
+	try {
+		const ffmpegExecStartedAt = getNowMs();
+		await execFileAsync(ffmpegPath, args, {
+			timeout: 15 * 60 * 1000,
+			maxBuffer: 20 * 1024 * 1024,
+		});
+		metrics.ffmpegExecMs = getNowMs() - ffmpegExecStartedAt;
+		return {
+			outputPath,
+			encoderName,
+			metrics,
+		};
+	} catch (error) {
+		await removeTemporaryExportFile(outputPath);
+		throw error;
+	}
 }
 
 export async function muxNativeVideoExportAudio(

--- a/electron/ipc/nativeVideoExport.test.ts
+++ b/electron/ipc/nativeVideoExport.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { ATEMPO_FILTER_EPSILON } from "./ffmpeg/filters";
 import {
 	buildEditedTrackSourceAudioFilter,
+	buildNativeFastVideoExportArgs,
 	buildTrimmedSourceAudioFilter,
+	canStreamCopyNativeFastVideoExport,
+	parseNativeFastVideoSourceProbe,
 } from "./nativeVideoExport";
 
 describe("buildTrimmedSourceAudioFilter", () => {
@@ -17,6 +20,120 @@ describe("buildTrimmedSourceAudioFilter", () => {
 				"[1:a]atrim=start=4.000:end=6.000,asetpts=PTS-STARTPTS[trimmed_audio_1];" +
 				"[trimmed_audio_0][trimmed_audio_1]concat=n=2:v=0:a=1[aout]",
 		);
+	});
+});
+
+describe("buildNativeFastVideoExportArgs", () => {
+	it("builds a direct FFmpeg export that maps optional audio and scales in-process", () => {
+		const args = buildNativeFastVideoExportArgs(
+			"libx264",
+			{
+				sourcePath: "C:\\Videos\\source.mp4",
+				width: 1920,
+				height: 1080,
+				frameRate: 30,
+				bitrate: 20_000_000,
+				encodingMode: "fast",
+			},
+			"C:\\Videos\\out.mp4",
+		);
+
+		expect(args).toContain("-map");
+		expect(args).toContain("0:a:0?");
+		expect(args).toContain("scale=1920:1080:flags=lanczos,setsar=1,fps=30,format=yuv420p");
+		expect(args).toContain("libx264");
+		expect(args).toContain("ultrafast");
+	});
+
+	it("uses input seeking for a single contiguous kept segment", () => {
+		const args = buildNativeFastVideoExportArgs(
+			"h264_nvenc",
+			{
+				sourcePath: "C:\\Videos\\source.mp4",
+				width: 1280,
+				height: 720,
+				frameRate: 60,
+				bitrate: 10_000_000,
+				encodingMode: "balanced",
+				segments: [{ startMs: 5_000, endMs: 15_000 }],
+			},
+			"C:\\Videos\\out.mp4",
+		);
+
+		expect(args.slice(0, 10)).toContain("-ss");
+		expect(args).toContain("5.000");
+		expect(args).toContain("-t");
+		expect(args).toContain("10.000");
+		expect(args).toContain("h264_nvenc");
+	});
+
+	it("stream-copies a matching source without scaling or re-encoding", () => {
+		const args = buildNativeFastVideoExportArgs(
+			"copy",
+			{
+				sourcePath: "C:\\Videos\\source.mp4",
+				width: 1280,
+				height: 720,
+				frameRate: 30,
+				bitrate: 10_000_000,
+				encodingMode: "fast",
+				videoMode: "copy",
+			},
+			"C:\\Videos\\out.mp4",
+		);
+
+		expect(args).toContain("copy");
+		expect(args).not.toContain("-vf");
+		expect(args.join(" ")).toContain("-c:v copy -c:a copy");
+	});
+});
+
+describe("native fast video source probing", () => {
+	const ffmpegProbeOutput = `
+Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'source.mp4':
+  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 1280x720 [SAR 1:1 DAR 16:9], 30 fps, 30 tbr, 15360 tbn (default)
+  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 160 kb/s (default)
+`;
+
+	it("parses FFmpeg input stream metadata for guarded stream-copy decisions", () => {
+		expect(parseNativeFastVideoSourceProbe(ffmpegProbeOutput)).toEqual({
+			videoCodecName: "h264",
+			audioCodecName: "aac",
+			pixelFormat: "yuv420p",
+			width: 1280,
+			height: 720,
+			fps: 30,
+		});
+	});
+
+	it("allows stream copy only when codec, dimensions, fps, and timeline match", () => {
+		const options = {
+			sourcePath: "C:\\Videos\\source.mp4",
+			width: 1280,
+			height: 720,
+			frameRate: 30,
+			bitrate: 10_000_000,
+			encodingMode: "fast" as const,
+		};
+		const probe = parseNativeFastVideoSourceProbe(ffmpegProbeOutput);
+
+		expect(canStreamCopyNativeFastVideoExport(probe, options)).toBe(true);
+		expect(
+			canStreamCopyNativeFastVideoExport(probe, {
+				...options,
+				width: 1920,
+				height: 1080,
+			}),
+		).toBe(false);
+		expect(
+			canStreamCopyNativeFastVideoExport(probe, {
+				...options,
+				segments: [{ startMs: 1_000, endMs: 2_000 }],
+			}),
+		).toBe(false);
+		expect(
+			canStreamCopyNativeFastVideoExport({ ...probe, pixelFormat: "yuv444p" }, options),
+		).toBe(false);
 	});
 });
 

--- a/electron/ipc/nativeVideoExport.ts
+++ b/electron/ipc/nativeVideoExport.ts
@@ -40,6 +40,31 @@ export interface NativeVideoExportFinishOptions {
 	editedAudioMimeType?: string | null;
 }
 
+export interface NativeFastVideoExportSegment {
+	startMs: number;
+	endMs: number;
+}
+
+export interface NativeFastVideoExportOptions {
+	sourcePath: string;
+	width: number;
+	height: number;
+	frameRate: number;
+	bitrate: number;
+	encodingMode: NativeExportEncodingMode;
+	videoMode?: "copy" | "encode";
+	segments?: NativeFastVideoExportSegment[];
+}
+
+export interface NativeFastVideoSourceProbe {
+	videoCodecName: string | null;
+	audioCodecName: string | null;
+	pixelFormat: string | null;
+	width: number | null;
+	height: number | null;
+	fps: number | null;
+}
+
 export interface NativeVideoAudioMuxMetrics {
 	tempVideoWriteMs?: number;
 	tempEditedAudioWriteMs?: number;
@@ -145,8 +170,86 @@ export function buildNativeVideoExportArgs(
 	return args;
 }
 
+function getVideoEncodeArgs(
+	encoder: string,
+	options: Pick<NativeFastVideoExportOptions, "bitrate" | "encodingMode">,
+): string[] {
+	const args = ["-c:v", encoder, ...getBitrateArgs(options.bitrate)];
+
+	if (encoder === "libx264") {
+		args.push(...getLibx264ModeArgs(options.encodingMode));
+	}
+
+	return args;
+}
+
 function formatFfmpegSeconds(milliseconds: number): string {
 	return (milliseconds / 1000).toFixed(3);
+}
+
+function normalizeCodecName(codecName: string | null | undefined): string | null {
+	return codecName ? codecName.trim().toLowerCase() : null;
+}
+
+function parseFps(value: string | undefined): number | null {
+	if (!value) {
+		return null;
+	}
+
+	const parsed = Number.parseFloat(value);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function parseNativeFastVideoSourceProbe(ffmpegOutput: string): NativeFastVideoSourceProbe {
+	const videoLine = ffmpegOutput
+		.split(/\r?\n/)
+		.find((line) => /\bVideo:\s*[a-z0-9_]+/i.test(line));
+	const audioLine = ffmpegOutput
+		.split(/\r?\n/)
+		.find((line) => /\bAudio:\s*[a-z0-9_]+/i.test(line));
+	const dimensionsMatch = videoLine?.match(/,\s*(\d{2,5})x(\d{2,5})(?:\s|,|\[)/);
+	const fpsMatch = videoLine?.match(/,\s*([0-9.]+)\s*fps\b/i);
+	const pixelFormatMatch = videoLine?.match(/\bVideo:\s*[a-z0-9_]+[^,]*,\s*([a-z0-9_]+)/i);
+
+	return {
+		videoCodecName: normalizeCodecName(videoLine?.match(/\bVideo:\s*([a-z0-9_]+)/i)?.[1]),
+		audioCodecName: normalizeCodecName(audioLine?.match(/\bAudio:\s*([a-z0-9_]+)/i)?.[1]),
+		pixelFormat: normalizeCodecName(pixelFormatMatch?.[1]),
+		width: dimensionsMatch ? Number.parseInt(dimensionsMatch[1], 10) : null,
+		height: dimensionsMatch ? Number.parseInt(dimensionsMatch[2], 10) : null,
+		fps: parseFps(fpsMatch?.[1]),
+	};
+}
+
+export function canStreamCopyNativeFastVideoExport(
+	probe: NativeFastVideoSourceProbe,
+	options: NativeFastVideoExportOptions,
+): boolean {
+	if ((options.segments?.length ?? 0) > 0) {
+		return false;
+	}
+
+	if (probe.videoCodecName !== "h264") {
+		return false;
+	}
+
+	if (probe.pixelFormat !== "yuv420p" && probe.pixelFormat !== "yuvj420p") {
+		return false;
+	}
+
+	if (probe.audioCodecName && probe.audioCodecName !== "aac" && probe.audioCodecName !== "mp3") {
+		return false;
+	}
+
+	if (
+		probe.width !== Math.round(options.width) ||
+		probe.height !== Math.round(options.height) ||
+		probe.fps === null
+	) {
+		return false;
+	}
+
+	return Math.abs(probe.fps - options.frameRate) <= 0.1;
 }
 
 export function buildTrimmedSourceAudioFilter(
@@ -279,6 +382,52 @@ export function buildNativeH264StreamExportArgs(config: {
 		"+faststart",
 		config.outputPath,
 	];
+}
+
+function buildNativeFastVideoFilter(options: NativeFastVideoExportOptions): string {
+	return [
+		`scale=${Math.round(options.width)}:${Math.round(options.height)}:flags=lanczos`,
+		"setsar=1",
+		`fps=${Math.round(options.frameRate)}`,
+		"format=yuv420p",
+	].join(",");
+}
+
+export function buildNativeFastVideoExportArgs(
+	encoder: string,
+	options: NativeFastVideoExportOptions,
+	outputPath: string,
+): string[] {
+	const segments = (options.segments ?? []).filter(
+		(segment) =>
+			Number.isFinite(segment.startMs) &&
+			Number.isFinite(segment.endMs) &&
+			segment.startMs >= 0 &&
+			segment.endMs - segment.startMs > 0.5,
+	);
+	const args = ["-y", "-hide_banner", "-loglevel", "error"];
+	const singleSegment = segments.length === 1 ? segments[0] : null;
+
+	if (singleSegment && singleSegment.startMs > 0) {
+		args.push("-ss", formatFfmpegSeconds(singleSegment.startMs));
+	}
+
+	if (singleSegment) {
+		args.push("-t", formatFfmpegSeconds(singleSegment.endMs - singleSegment.startMs));
+	}
+
+	args.push("-i", options.sourcePath, "-map", "0:v:0", "-map", "0:a:0?");
+
+	if (options.videoMode === "copy") {
+		args.push("-c:v", "copy", "-c:a", "copy", "-movflags", "+faststart", outputPath);
+		return args;
+	}
+
+	args.push("-vf", buildNativeFastVideoFilter(options));
+	args.push(...getVideoEncodeArgs(encoder, options));
+	args.push("-c:a", "copy", "-shortest", "-movflags", "+faststart", outputPath);
+
+	return args;
 }
 
 export function getEditedAudioExtension(mimeType?: string | null): string {

--- a/electron/ipc/register/export.ts
+++ b/electron/ipc/register/export.ts
@@ -15,6 +15,7 @@ import {
 } from "../export/exportStream";
 import {
 	enqueueNativeVideoExportFrameWrite,
+	exportNativeFastVideo,
 	flushNativeVideoExportPendingWriteRequests,
 	getNativeVideoExportMaxQueuedWriteBytes,
 	getNativeVideoExportSessionError,
@@ -35,6 +36,7 @@ import {
 	buildNativeVideoExportArgs,
 	getNativeVideoInputByteSize,
 	type NativeExportEncodingMode,
+	type NativeFastVideoExportOptions,
 	type NativeVideoExportFinishOptions,
 } from "../nativeVideoExport";
 import { approveUserPath } from "../utils";
@@ -395,6 +397,48 @@ export function registerExportHandlers() {
 			}
 		},
 	);
+
+	ipcMain.handle("native-fast-video-export", async (_, options: NativeFastVideoExportOptions) => {
+		try {
+			if (
+				!options ||
+				typeof options.sourcePath !== "string" ||
+				options.sourcePath.trim().length === 0 ||
+				!Number.isFinite(options.width) ||
+				!Number.isFinite(options.height) ||
+				!Number.isFinite(options.frameRate) ||
+				!Number.isFinite(options.bitrate)
+			) {
+				throw new Error("Invalid native fast export options");
+			}
+
+			if (
+				options.width <= 0 ||
+				options.height <= 0 ||
+				options.width % 2 !== 0 ||
+				options.height % 2 !== 0 ||
+				options.frameRate <= 0 ||
+				options.bitrate <= 0
+			) {
+				throw new Error("Native fast export requires positive even dimensions");
+			}
+
+			const exported = await exportNativeFastVideo(options);
+			registerOwnedExportPath(exported.outputPath);
+			return {
+				success: true,
+				tempPath: exported.outputPath,
+				encoderName: exported.encoderName,
+				metrics: exported.metrics,
+			};
+		} catch (error) {
+			console.error("[native-fast-export] Failed to export video:", error);
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : String(error),
+			};
+		}
+	});
 
 	ipcMain.handle("export-stream-open", async (_event, options?: { extension?: string }) => {
 		try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -219,6 +219,23 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	) => {
 		return ipcRenderer.invoke("mux-exported-video-audio-from-path", videoPath, options);
 	},
+	nativeFastVideoExport: (options: {
+		sourcePath: string;
+		width: number;
+		height: number;
+		frameRate: number;
+		bitrate: number;
+		encodingMode: "fast" | "balanced" | "quality";
+		segments?: Array<{ startMs: number; endMs: number }>;
+	}) => {
+		return ipcRenderer.invoke("native-fast-video-export", options) as Promise<{
+			success: boolean;
+			tempPath?: string;
+			encoderName?: string;
+			error?: string;
+			metrics?: NativeVideoAudioMuxMetrics;
+		}>;
+	},
 	openExportStream: (options?: { extension?: string }) => {
 		return ipcRenderer.invoke("export-stream-open", options);
 	},

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -59,6 +59,9 @@ function getEditorWindowQuery(): Record<string, string> {
 		if (process.env.RECORDLY_SMOKE_EXPORT_USE_NATIVE === "1") {
 			query.smokeUseNativeExport = "1";
 		}
+		if (process.env.RECORDLY_SMOKE_EXPORT_SOURCE_ONLY === "1") {
+			query.smokeSourceOnly = "1";
+		}
 		if (process.env.RECORDLY_SMOKE_EXPORT_ENCODING_MODE) {
 			query.smokeEncodingMode = process.env.RECORDLY_SMOKE_EXPORT_ENCODING_MODE;
 		}

--- a/scripts/benchmark-export-queues.mjs
+++ b/scripts/benchmark-export-queues.mjs
@@ -11,7 +11,10 @@ import ffmpegStatic from "ffmpeg-static";
 const execFileAsync = promisify(execFile);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
-const mainEntry = path.join(repoRoot, "dist-electron", "main.js");
+const mainEntryCandidates = [
+	path.join(repoRoot, "dist-electron", "main.js"),
+	path.join(repoRoot, "dist-electron", "main.cjs"),
+];
 const rendererEntry = path.join(repoRoot, "dist", "index.html");
 
 const width = parseEvenInteger(process.env.RECORDLY_BENCH_EXPORT_WIDTH ?? "1280", "Width");
@@ -28,9 +31,11 @@ const timeoutMs = parsePositiveInteger(
 const runsPerVariant = parsePositiveInteger(process.env.RECORDLY_BENCH_EXPORT_RUNS ?? "2", "Runs");
 const useNativeExport = process.env.RECORDLY_BENCH_EXPORT_USE_NATIVE === "1";
 const useWebcamOverlay = process.env.RECORDLY_BENCH_EXPORT_ENABLE_WEBCAM === "1";
+const useSourceOnlyScene = process.env.RECORDLY_BENCH_EXPORT_SOURCE_ONLY === "1";
 const exportEncodingMode = parseExportEncodingMode(
 	process.env.RECORDLY_BENCH_EXPORT_ENCODING_MODE ?? null,
 );
+const exportQuality = parseExportQuality(process.env.RECORDLY_BENCH_EXPORT_QUALITY ?? "source");
 const exportShadowIntensity = parseExportShadowIntensity(
 	process.env.RECORDLY_BENCH_EXPORT_SHADOW_INTENSITY ?? null,
 );
@@ -177,6 +182,19 @@ function parseExportEncodingMode(rawValue) {
 	throw new Error("RECORDLY_BENCH_EXPORT_ENCODING_MODE must be 'fast', 'balanced', or 'quality'");
 }
 
+function parseExportQuality(rawValue) {
+	if (
+		rawValue === "medium" ||
+		rawValue === "good" ||
+		rawValue === "high" ||
+		rawValue === "source"
+	) {
+		return rawValue;
+	}
+
+	throw new Error("RECORDLY_BENCH_EXPORT_QUALITY must be 'medium', 'good', 'high', or 'source'");
+}
+
 function parseExportShadowIntensity(rawValue) {
 	if (rawValue === null || rawValue === "") {
 		return null;
@@ -244,7 +262,11 @@ function summarizeSmokeProgress(progressSamples) {
 }
 
 async function ensureBuildArtifacts() {
-	await fs.access(mainEntry);
+	await Promise.any(mainEntryCandidates.map((candidate) => fs.access(candidate))).catch(() => {
+		throw new Error(
+			`Missing Electron main build output. Tried: ${mainEntryCandidates.join(", ")}`,
+		);
+	});
 	await fs.access(rendererEntry);
 }
 
@@ -479,7 +501,9 @@ function buildRequestedConfigRows(benchmarkRequests) {
 		{ key: "Requested backends", value: benchmarkRequests.map((request) => request.label) },
 		{ key: "Backend sweep", value: formatBoolean(benchmarkRequests.length > 1) },
 		{ key: "Encoding mode", value: exportEncodingMode ?? "default" },
+		{ key: "Quality", value: exportQuality },
 		{ key: "Shadow intensity", value: exportShadowIntensity ?? "default" },
+		{ key: "Source-only scene", value: formatBoolean(useSourceOnlyScene) },
 		{ key: "Webcam enabled", value: formatBoolean(useWebcamOverlay) },
 		{ key: "Experimental native override", value: formatBoolean(useNativeExport) },
 	];
@@ -662,9 +686,12 @@ async function runVariant(
 			RECORDLY_SMOKE_EXPORT_INPUT: inputPath,
 			RECORDLY_SMOKE_EXPORT_OUTPUT: outputPath,
 			...(useNativeExport ? { RECORDLY_SMOKE_EXPORT_USE_NATIVE: "1" } : {}),
+			...(useSourceOnlyScene ? { RECORDLY_SMOKE_EXPORT_SOURCE_ONLY: "1" } : {}),
 			...(exportEncodingMode
 				? { RECORDLY_SMOKE_EXPORT_ENCODING_MODE: exportEncodingMode }
 				: {}),
+			RECORDLY_SMOKE_EXPORT_QUALITY: exportQuality,
+			RECORDLY_SMOKE_EXPORT_FPS: String(frameRate),
 			...(exportShadowIntensity !== null
 				? { RECORDLY_SMOKE_EXPORT_SHADOW_INTENSITY: String(exportShadowIntensity) }
 				: {}),
@@ -871,6 +898,7 @@ async function main() {
 				requestedBackends: benchmarkRequests.map((request) => request.label),
 				backendSweepEnabled: benchmarkRequests.length > 1,
 				requestedEncodingMode: exportEncodingMode,
+				requestedQuality: exportQuality,
 				requestedShadowIntensity: exportShadowIntensity,
 				webcamEnabled: useWebcamOverlay,
 				requestedWebcamShadowIntensity: webcamShadowIntensity,

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -59,6 +59,7 @@ import {
 	type GifSizePreset,
 	isValidMp4FrameRate,
 	ModernVideoExporter,
+	NativeFastVideoExporter,
 	probeSupportedMp4Dimensions,
 	type SupportedMp4Dimensions,
 	VideoExporter,
@@ -224,6 +225,7 @@ type SmokeExportConfig = {
 	projectPath?: string | null;
 	quality?: ExportQuality;
 	fps?: ExportMp4FrameRate;
+	sourceOnly?: boolean;
 };
 
 async function writeSmokeExportReport(
@@ -361,6 +363,7 @@ function getSmokeExportConfig(search: string): SmokeExportConfig {
 		projectPath: enabled ? params.get("smokeProject") : null,
 		quality: enabled ? parseSmokeExportQuality(params.get("smokeQuality")) : undefined,
 		fps: enabled ? parseSmokeExportFps(params.get("smokeFps")) : undefined,
+		sourceOnly: enabled ? params.get("smokeSourceOnly") === "1" : false,
 	};
 }
 
@@ -522,6 +525,10 @@ export default function VideoEditor() {
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [currentTime, setCurrentTime] = useState(0);
 	const [duration, setDuration] = useState(0);
+	const [sourceVideoDimensions, setSourceVideoDimensions] = useState<{
+		width: number;
+		height: number;
+	} | null>(null);
 	const [wallpaper, setWallpaper] = useState<string>(initialEditorPreferences.wallpaper);
 	const [shadowIntensity, setShadowIntensity] = useState(
 		initialEditorPreferences.shadowIntensity,
@@ -697,6 +704,28 @@ export default function VideoEditor() {
 	const smokeExportStartedRef = useRef(false);
 	const [historyVersion, setHistoryVersion] = useState(0);
 	const timelineRef = useRef<TimelineEditorHandle>(null);
+
+	const updateSourceVideoDimensionsFromRef = useCallback(() => {
+		const video = videoPlaybackRef.current?.video;
+		if (!video || video.videoWidth <= 0 || video.videoHeight <= 0) {
+			return;
+		}
+
+		setSourceVideoDimensions((current) => {
+			if (current?.width === video.videoWidth && current.height === video.videoHeight) {
+				return current;
+			}
+			return { width: video.videoWidth, height: video.videoHeight };
+		});
+	}, []);
+
+	const handleDurationChange = useCallback(
+		(nextDuration: number) => {
+			setDuration(nextDuration);
+			updateSourceVideoDimensionsFromRef();
+		},
+		[updateSourceVideoDimensionsFromRef],
+	);
 
 	function formatTime(seconds: number) {
 		if (!isFinite(seconds) || isNaN(seconds) || seconds < 0) return "0:00";
@@ -1018,22 +1047,26 @@ export default function VideoEditor() {
 	const gifOutputDimensions = useMemo(
 		() =>
 			calculateOutputDimensions(
-				videoPlaybackRef.current?.video?.videoWidth || 1920,
-				videoPlaybackRef.current?.video?.videoHeight || 1080,
+				sourceVideoDimensions?.width || videoPlaybackRef.current?.video?.videoWidth || 1920,
+				sourceVideoDimensions?.height ||
+					videoPlaybackRef.current?.video?.videoHeight ||
+					1080,
 				gifSizePreset,
 				GIF_SIZE_PRESETS,
 			),
-		[gifSizePreset],
+		[gifSizePreset, sourceVideoDimensions?.height, sourceVideoDimensions?.width],
 	);
 
 	const desiredMp4SourceDimensions = useMemo(
 		() =>
 			calculateMp4SourceDimensions(
-				videoPlaybackRef.current?.video?.videoWidth || 1920,
-				videoPlaybackRef.current?.video?.videoHeight || 1080,
+				sourceVideoDimensions?.width || videoPlaybackRef.current?.video?.videoWidth || 1920,
+				sourceVideoDimensions?.height ||
+					videoPlaybackRef.current?.video?.videoHeight ||
+					1080,
 				aspectRatio,
 			),
-		[aspectRatio],
+		[aspectRatio, sourceVideoDimensions?.height, sourceVideoDimensions?.width],
 	);
 
 	const mp4OutputDimensions = useMemo(() => {
@@ -1560,6 +1593,7 @@ export default function VideoEditor() {
 			setIsPlaying(false);
 			setCurrentTime(0);
 			setDuration(0);
+			setSourceVideoDimensions(null);
 
 			setError(null);
 			setVideoSourcePath(sourcePath);
@@ -1845,6 +1879,17 @@ export default function VideoEditor() {
 					setCurrentProjectPath(null);
 					setLastSavedSnapshot(null);
 					pendingFreshRecordingAutoZoomPathRef.current = null;
+					if (smokeExportConfig.sourceOnly) {
+						setShadowIntensity(0);
+						setBackgroundBlur(0);
+						setBorderRadius(0);
+						setPadding({ top: 0, bottom: 0, left: 0, right: 0, linked: true });
+						setFrame(null);
+						setShowCursor(false);
+						setZoomRegions([]);
+						setAnnotationRegions([]);
+						setAutoCaptions([]);
+					}
 					setWebcam((prev) => ({
 						...prev,
 						enabled: !!smokeWebcamSourcePath,
@@ -1950,6 +1995,7 @@ export default function VideoEditor() {
 		smokeExportConfig.webcamInputPath,
 		smokeExportConfig.webcamShadow,
 		smokeExportConfig.webcamSize,
+		smokeExportConfig.sourceOnly,
 	]);
 
 	useEffect(() => {
@@ -3257,22 +3303,25 @@ export default function VideoEditor() {
 		);
 	}, []);
 
-	const handleAudioVolumeChange = useCallback((volume: number) => {
-		if (!selectedAudioId) {
-			return;
-		}
+	const handleAudioVolumeChange = useCallback(
+		(volume: number) => {
+			if (!selectedAudioId) {
+				return;
+			}
 
-		if (!Number.isFinite(volume)) {
-			return;
-		}
+			if (!Number.isFinite(volume)) {
+				return;
+			}
 
-		const nextVolume = Math.max(0, Math.min(1, volume));
-		setAudioRegions((prev) =>
-			prev.map((region) =>
-				region.id === selectedAudioId ? { ...region, volume: nextVolume } : region,
-			),
-		);
-	}, [selectedAudioId]);
+			const nextVolume = Math.max(0, Math.min(1, volume));
+			setAudioRegions((prev) =>
+				prev.map((region) =>
+					region.id === selectedAudioId ? { ...region, volume: nextVolume } : region,
+				),
+			);
+		},
+		[selectedAudioId],
+	);
 
 	const handleAudioDelete = useCallback(
 		(id: string) => {
@@ -4150,16 +4199,32 @@ export default function VideoEditor() {
 						},
 					};
 
+					const nativeFastExporter = new NativeFastVideoExporter({
+						...exporterConfig,
+						sourceWidth:
+							sourceVideoDimensions?.width ||
+							videoPlaybackRef.current?.video?.videoWidth ||
+							supportedSourceDimensions.width,
+						sourceHeight:
+							sourceVideoDimensions?.height ||
+							videoPlaybackRef.current?.video?.videoHeight ||
+							supportedSourceDimensions.height,
+						sourceDurationMs: Math.max(0, Math.round(duration * 1000)),
+					});
+					exporterRef.current = nativeFastExporter;
+					const fastResult = await nativeFastExporter.exportIfEligible();
 					const exporter =
-						pipelineModel === "modern"
-							? new ModernVideoExporter({
-									...exporterConfig,
-									backendPreference,
-								})
-							: new VideoExporter(exporterConfig);
+						fastResult === null
+							? pipelineModel === "modern"
+								? new ModernVideoExporter({
+										...exporterConfig,
+										backendPreference,
+									})
+								: new VideoExporter(exporterConfig)
+							: null;
 
 					exporterRef.current = exporter;
-					const result = await exporter.export();
+					const result = fastResult ?? (await exporter!.export());
 					const smokeExportElapsedMs =
 						smokeExportStartedAt !== null
 							? Math.round(performance.now() - smokeExportStartedAt)
@@ -4415,6 +4480,9 @@ export default function VideoEditor() {
 			smokeExportConfig.encodingMode,
 			smokeExportConfig.fps,
 			smokeExportConfig.quality,
+			duration,
+			sourceVideoDimensions?.height,
+			sourceVideoDimensions?.width,
 		],
 	);
 
@@ -4430,7 +4498,12 @@ export default function VideoEditor() {
 			return;
 		}
 
-		if (!videoPath || loading) {
+		if (
+			!videoPath ||
+			loading ||
+			duration <= 0 ||
+			(smokeExportConfig.sourceOnly && !sourceVideoDimensions)
+		) {
 			return;
 		}
 
@@ -4454,12 +4527,15 @@ export default function VideoEditor() {
 		});
 	}, [
 		cursorTelemetrySourcePath,
+		duration,
 		error,
 		handleExport,
 		loading,
 		smokeExportConfig.enabled,
 		smokeExportConfig.encodingMode,
 		smokeExportConfig.projectPath,
+		smokeExportConfig.sourceOnly,
+		sourceVideoDimensions,
 		videoPath,
 		videoSourcePath,
 	]);
@@ -5409,7 +5485,7 @@ export default function VideoEditor() {
 												aspectRatio={aspectRatio}
 												ref={videoPlaybackRef}
 												videoPath={videoPath || ""}
-												onDurationChange={setDuration}
+												onDurationChange={handleDurationChange}
 												onPreviewReadyChange={setIsPreviewReady}
 												onTimeUpdate={setCurrentTime}
 												currentTime={currentTime}

--- a/src/lib/exporter/index.ts
+++ b/src/lib/exporter/index.ts
@@ -12,6 +12,11 @@ export {
 	resolveSupportedMp4EncoderPath,
 } from "./mp4Support";
 export { VideoMuxer } from "./muxer";
+export type { NativeFastVideoExportPlan } from "./nativeFastVideoExporter";
+export {
+	classifyNativeFastVideoExportPlan,
+	NativeFastVideoExporter,
+} from "./nativeFastVideoExporter";
 export { StreamingVideoDecoder } from "./streamingDecoder";
 export type {
 	ExportBackendPreference,

--- a/src/lib/exporter/nativeFastVideoExporter.test.ts
+++ b/src/lib/exporter/nativeFastVideoExporter.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { classifyNativeFastVideoExportPlan } from "./nativeFastVideoExporter";
+
+const baseConfig = {
+	videoUrl: "file:///C:/Users/meiiie/Videos/source.mp4",
+	sourceWidth: 1920,
+	sourceHeight: 1080,
+	sourceDurationMs: 60_000,
+	width: 1920,
+	height: 1080,
+	frameRate: 30,
+	bitrate: 20_000_000,
+	encodingMode: "balanced" as const,
+	wallpaper: "#000000",
+	zoomRegions: [],
+	trimRegions: [],
+	speedRegions: [],
+	showShadow: false,
+	shadowIntensity: 0,
+	backgroundBlur: 0,
+	borderRadius: 0,
+	padding: 0,
+	cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+	webcam: { enabled: false, sourcePath: null },
+	webcamUrl: null,
+	annotationRegions: [],
+	autoCaptions: [],
+	cursorTelemetry: [],
+	showCursor: false,
+	frame: null,
+	audioRegions: [],
+	sourceAudioFallbackPaths: [],
+};
+
+describe("classifyNativeFastVideoExportPlan", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("allows source-only exports to bypass composed rendering", () => {
+		vi.stubGlobal("window", {
+			electronAPI: { nativeFastVideoExport: vi.fn() },
+		});
+
+		expect(classifyNativeFastVideoExportPlan(baseConfig)).toMatchObject({
+			eligible: true,
+			reason: "source-only timeline can bypass renderer",
+		});
+	});
+
+	it("rejects scene styling that must be rendered by the compositor", () => {
+		vi.stubGlobal("window", {
+			electronAPI: { nativeFastVideoExport: vi.fn() },
+		});
+
+		expect(
+			classifyNativeFastVideoExportPlan({
+				...baseConfig,
+				padding: { top: 20, right: 20, bottom: 20, left: 20 },
+			}),
+		).toMatchObject({
+			eligible: false,
+			reason: "scene styling requires composed rendering",
+		});
+	});
+
+	it("allows one contiguous kept trim segment", () => {
+		vi.stubGlobal("window", {
+			electronAPI: { nativeFastVideoExport: vi.fn() },
+		});
+
+		expect(
+			classifyNativeFastVideoExportPlan({
+				...baseConfig,
+				trimRegions: [{ id: "trim-start", startMs: 0, endMs: 10_000 }],
+			}),
+		).toMatchObject({
+			eligible: true,
+			segments: [{ startMs: 10_000, endMs: 60_000 }],
+		});
+	});
+
+	it("rejects split timelines because they need full timeline composition", () => {
+		vi.stubGlobal("window", {
+			electronAPI: { nativeFastVideoExport: vi.fn() },
+		});
+
+		expect(
+			classifyNativeFastVideoExportPlan({
+				...baseConfig,
+				trimRegions: [{ id: "trim-middle", startMs: 10_000, endMs: 20_000 }],
+			}),
+		).toMatchObject({
+			eligible: false,
+			reason: "multiple kept trim segments need composed export",
+		});
+	});
+});

--- a/src/lib/exporter/nativeFastVideoExporter.ts
+++ b/src/lib/exporter/nativeFastVideoExporter.ts
@@ -1,0 +1,285 @@
+import type {
+	AnnotationRegion,
+	AudioRegion,
+	CaptionCue,
+	CropRegion,
+	CursorTelemetryPoint,
+	Padding,
+	SpeedRegion,
+	TrimRegion,
+	WebcamOverlaySettings,
+	ZoomRegion,
+} from "@/components/video-editor/types";
+import { getLocalFilePath } from "./localMediaSource";
+import type { ExportConfig, ExportMetrics, ExportResult } from "./types";
+
+interface NativeFastVideoExporterConfig extends ExportConfig {
+	videoUrl: string;
+	sourceWidth: number;
+	sourceHeight: number;
+	sourceDurationMs: number;
+	wallpaper: string;
+	zoomRegions?: ZoomRegion[];
+	trimRegions?: TrimRegion[];
+	speedRegions?: SpeedRegion[];
+	showShadow?: boolean;
+	shadowIntensity?: number;
+	backgroundBlur?: number;
+	borderRadius?: number;
+	padding?: Padding | number;
+	cropRegion: CropRegion;
+	webcam?: WebcamOverlaySettings;
+	webcamUrl?: string | null;
+	annotationRegions?: AnnotationRegion[];
+	autoCaptions?: CaptionCue[];
+	cursorTelemetry?: CursorTelemetryPoint[];
+	showCursor?: boolean;
+	frame?: string | null;
+	audioRegions?: AudioRegion[];
+	sourceAudioFallbackPaths?: string[];
+}
+
+export type NativeFastVideoExportPlan =
+	| {
+			eligible: true;
+			sourcePath: string;
+			segments?: Array<{ startMs: number; endMs: number }>;
+			reason: string;
+	  }
+	| {
+			eligible: false;
+			reason: string;
+	  };
+
+const ASPECT_RATIO_TOLERANCE = 0.002;
+
+type NativeFastVideoExportIpcResult = Awaited<
+	ReturnType<Window["electronAPI"]["nativeFastVideoExport"]>
+>;
+
+function isEmpty<T>(items: readonly T[] | null | undefined): boolean {
+	return !items || items.length === 0;
+}
+
+function isZeroPaddingValue(padding: Padding | number | null | undefined): boolean {
+	if (padding === undefined || padding === null) {
+		return true;
+	}
+	if (typeof padding === "number") {
+		return padding === 0;
+	}
+	return padding.top === 0 && padding.bottom === 0 && padding.left === 0 && padding.right === 0;
+}
+
+function isDefaultCrop(cropRegion: CropRegion): boolean {
+	return (
+		cropRegion.x === 0 &&
+		cropRegion.y === 0 &&
+		cropRegion.width === 1 &&
+		cropRegion.height === 1
+	);
+}
+
+function hasMatchingAspectRatio(config: NativeFastVideoExporterConfig): boolean {
+	const sourceAspect = config.sourceWidth / config.sourceHeight;
+	const outputAspect = config.width / config.height;
+	return Math.abs(sourceAspect - outputAspect) <= ASPECT_RATIO_TOLERANCE;
+}
+
+function buildSingleKeptSegment(
+	trimRegions: TrimRegion[] | undefined,
+	sourceDurationMs: number,
+): Array<{ startMs: number; endMs: number }> | null {
+	if (!trimRegions || trimRegions.length === 0) {
+		return [];
+	}
+
+	if (!Number.isFinite(sourceDurationMs) || sourceDurationMs <= 0) {
+		return null;
+	}
+
+	const sorted = [...trimRegions].sort((a, b) => a.startMs - b.startMs);
+	const segments: Array<{ startMs: number; endMs: number }> = [];
+	let cursorMs = 0;
+
+	for (const region of sorted) {
+		const startMs = Math.max(0, Math.min(region.startMs, sourceDurationMs));
+		const endMs = Math.max(startMs, Math.min(region.endMs, sourceDurationMs));
+		if (startMs > cursorMs) {
+			segments.push({ startMs: cursorMs, endMs: startMs });
+		}
+		cursorMs = Math.max(cursorMs, endMs);
+	}
+
+	if (cursorMs < sourceDurationMs) {
+		segments.push({ startMs: cursorMs, endMs: sourceDurationMs });
+	}
+
+	const keptSegments = segments.filter((segment) => segment.endMs - segment.startMs > 0.5);
+	return keptSegments.length <= 1 ? keptSegments : null;
+}
+
+export function classifyNativeFastVideoExportPlan(
+	config: NativeFastVideoExporterConfig,
+): NativeFastVideoExportPlan {
+	if (typeof window === "undefined" || !window.electronAPI?.nativeFastVideoExport) {
+		return { eligible: false, reason: "native fast export IPC is unavailable" };
+	}
+
+	const sourcePath = getLocalFilePath(config.videoUrl);
+	if (!sourcePath) {
+		return { eligible: false, reason: "source is not a local file" };
+	}
+
+	if (
+		!Number.isFinite(config.sourceWidth) ||
+		!Number.isFinite(config.sourceHeight) ||
+		config.sourceWidth <= 0 ||
+		config.sourceHeight <= 0 ||
+		!Number.isFinite(config.width) ||
+		!Number.isFinite(config.height) ||
+		config.width <= 0 ||
+		config.height <= 0
+	) {
+		return { eligible: false, reason: "source or output dimensions are unavailable" };
+	}
+
+	if (!hasMatchingAspectRatio(config)) {
+		return { eligible: false, reason: "output aspect ratio differs from the source" };
+	}
+
+	if (!isEmpty(config.zoomRegions)) {
+		return { eligible: false, reason: "zoom regions require composed rendering" };
+	}
+
+	if (!isEmpty(config.speedRegions)) {
+		return { eligible: false, reason: "speed regions require timeline rendering" };
+	}
+
+	if (!isEmpty(config.annotationRegions) || !isEmpty(config.autoCaptions)) {
+		return { eligible: false, reason: "overlays require composed rendering" };
+	}
+
+	if (config.showCursor && !isEmpty(config.cursorTelemetry)) {
+		return { eligible: false, reason: "cursor telemetry requires composed rendering" };
+	}
+
+	if (config.webcam?.enabled && (config.webcam.sourcePath || config.webcamUrl)) {
+		return { eligible: false, reason: "webcam overlay requires composed rendering" };
+	}
+
+	if (!isEmpty(config.audioRegions) || !isEmpty(config.sourceAudioFallbackPaths)) {
+		return { eligible: false, reason: "external audio regions require audio mixing" };
+	}
+
+	if (
+		config.frame ||
+		(config.showShadow && (config.shadowIntensity ?? 0) > 0) ||
+		(config.backgroundBlur ?? 0) > 0 ||
+		(config.borderRadius ?? 0) > 0 ||
+		!isZeroPaddingValue(config.padding) ||
+		!isDefaultCrop(config.cropRegion)
+	) {
+		return { eligible: false, reason: "scene styling requires composed rendering" };
+	}
+
+	const segments = buildSingleKeptSegment(config.trimRegions, config.sourceDurationMs);
+	if (!segments) {
+		return { eligible: false, reason: "multiple kept trim segments need composed export" };
+	}
+	if ((config.trimRegions?.length ?? 0) > 0 && segments.length === 0) {
+		return { eligible: false, reason: "trim regions remove the whole source" };
+	}
+
+	return {
+		eligible: true,
+		sourcePath,
+		segments: segments.length > 0 ? segments : undefined,
+		reason: "source-only timeline can bypass renderer",
+	};
+}
+
+export class NativeFastVideoExporter {
+	private cancelled = false;
+
+	constructor(private readonly config: NativeFastVideoExporterConfig) {}
+
+	cancel(): void {
+		this.cancelled = true;
+	}
+
+	async exportIfEligible(): Promise<ExportResult | null> {
+		const plan = classifyNativeFastVideoExportPlan(this.config);
+		if (!plan.eligible) {
+			console.log(`[NativeFastVideoExporter] Skipping fast path: ${plan.reason}`);
+			return null;
+		}
+
+		const startedAt = performance.now();
+		console.log(`[NativeFastVideoExporter] Using FFmpeg render-bypass: ${plan.reason}`);
+		const result: NativeFastVideoExportIpcResult = await window.electronAPI
+			.nativeFastVideoExport({
+				sourcePath: plan.sourcePath,
+				width: this.config.width,
+				height: this.config.height,
+				frameRate: this.config.frameRate,
+				bitrate: this.config.bitrate,
+				encodingMode: this.config.encodingMode ?? "balanced",
+				segments: plan.segments,
+			})
+			.catch(
+				(error): NativeFastVideoExportIpcResult => ({
+					success: false,
+					error: error instanceof Error ? error.message : String(error),
+				}),
+			);
+
+		if (this.cancelled) {
+			return {
+				success: false,
+				error: "Export cancelled",
+				metrics: this.buildMetrics(startedAt, result.encoderName, result.metrics),
+			};
+		}
+
+		if (!result.success || !result.tempPath) {
+			console.warn(
+				"[NativeFastVideoExporter] Fast path failed; falling back to composed export:",
+				result.error,
+			);
+			return null;
+		}
+
+		return {
+			success: true,
+			tempFilePath: result.tempPath,
+			metrics: this.buildMetrics(startedAt, result.encoderName, result.metrics),
+		};
+	}
+
+	private buildMetrics(
+		startedAt: number,
+		encoderName?: string,
+		ffmpegMetrics?: { ffmpegExecMs?: number },
+	): ExportMetrics {
+		const totalElapsedMs = performance.now() - startedAt;
+		const ffmpegExecMs = ffmpegMetrics?.ffmpegExecMs;
+
+		return {
+			totalElapsedMs,
+			decodeLoopMs: 0,
+			frameCallbackMs: 0,
+			renderFrameMs: 0,
+			encodeWaitMs: 0,
+			encodeWaitEvents: 0,
+			frameCount: 0,
+			encodeBackend: "ffmpeg",
+			encoderName: encoderName ? `ffmpeg-direct-${encoderName}` : "ffmpeg-direct",
+			finalizationMs: ffmpegExecMs,
+			finalizationStageMs: {
+				nativeExportFinalizeMs: ffmpegExecMs,
+				ffmpegAudioMuxBreakdown: ffmpegMetrics,
+			},
+		};
+	}
+}


### PR DESCRIPTION
﻿## Description
Adds a guarded native FFmpeg fast path for source-only MP4 exports. Eligible timelines bypass the JS/Pixi/WebCodecs frame loop entirely and either stream-copy matching H.264/AAC sources or re-encode directly through FFmpeg. Ineligible timelines continue to use the existing composed exporters.

## Motivation
The current export path still pays per-frame decode, render, and encode costs even when the timeline has no visual composition to apply. For source-only exports, that work is avoidable and becomes the dominant cost on longer recordings.

## Type of Change
- [x] Performance
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other

## Changes Made
- add a renderer-side eligibility classifier for source-only MP4 timelines
- add a main-process FFmpeg direct export IPC path
- stream-copy H.264/AAC/MP3 sources when codec, pixel format, dimensions, FPS, and timeline constraints match
- fall back to FFmpeg re-encode or the existing composed exporter when constraints are not met
- make export benchmark smoke runs deterministic for source-only mode, quality, and FPS
- wait for source metadata before source-only smoke export so benchmarks do not use stale fallback dimensions
- add focused unit coverage for fast-path eligibility, FFmpeg args, probe parsing, and stream-copy guards

## Testing Guide
1. Export a plain MP4 without zoom, cursor, webcam, captions, annotations, audio regions, trim splits, or scene styling.
2. Verify export succeeds and metrics show `encoderName: "ffmpeg-direct-copy"` or `ffmpeg-direct-<encoder>`.
3. Export a styled or edited project and verify it falls back to the existing composed exporter.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the new behavior.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `npx biome check electron/electron-env.d.ts electron/ipc/export/native-video.ts electron/ipc/nativeVideoExport.ts electron/ipc/nativeVideoExport.test.ts electron/ipc/register/export.ts electron/preload.ts electron/windows.ts scripts/benchmark-export-queues.mjs src/components/video-editor/VideoEditor.tsx src/lib/exporter/index.ts src/lib/exporter/nativeFastVideoExporter.ts src/lib/exporter/nativeFastVideoExporter.test.ts`
- `npx tsc --noEmit`
- `npm run test -- electron/ipc/nativeVideoExport.test.ts src/lib/exporter/nativeFastVideoExporter.test.ts`
- `npx vite build --config vite.config.ts`

E2E benchmark:
- 720p, 20s, source-only, H.264/AAC fixture: export elapsed `363ms`, `ffmpegExecMs 105ms`, `encoderName: ffmpeg-direct-copy`, `decodeLoopMs/renderFrameMs/encodeWaitMs: 0`.
- Earlier source-only WebCodecs smoke on the same class of export was about `15.2s`; the FFmpeg transcode fast path was about `6.4s`.

Notes:
- This intentionally does not claim to speed up composed exports with scene styling, cursor, zoom, webcam, captions, annotations, audio edits, or split trims.
- Draft because this is a broader export-path optimization and should get maintainer review before it becomes ready for merge.
