### PR TITLE
perf(export): default MP4 exports to modern pipeline

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,6 +55,45 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const IS_SMOKE_EXPORT = process.env.RECORDLY_SMOKE_EXPORT === "1";
 
+function isBrokenPipeError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		(error as NodeJS.ErrnoException).code === "EPIPE"
+	);
+}
+
+function configureSmokeExportPipeGuards() {
+	if (!IS_SMOKE_EXPORT) {
+		return;
+	}
+
+	const ignoreBrokenPipe = (error: Error) => {
+		if (!isBrokenPipeError(error)) {
+			throw error;
+		}
+	};
+
+	process.stdout.on("error", ignoreBrokenPipe);
+	process.stderr.on("error", ignoreBrokenPipe);
+
+	for (const method of ["log", "warn", "error"] as const) {
+		const original = console[method].bind(console);
+		console[method] = (...args: unknown[]) => {
+			try {
+				original(...args);
+			} catch (error) {
+				if (!isBrokenPipeError(error)) {
+					throw error;
+				}
+			}
+		};
+	}
+}
+
+configureSmokeExportPipeGuards();
+
 app.commandLine.appendSwitch("ignore-gpu-blocklist");
 app.commandLine.appendSwitch("enable-unsafe-webgpu");
 app.commandLine.appendSwitch("enable-gpu-rasterization");

--- a/scripts/benchmark-export-queues.mjs
+++ b/scripts/benchmark-export-queues.mjs
@@ -11,7 +11,7 @@ import ffmpegStatic from "ffmpeg-static";
 const execFileAsync = promisify(execFile);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
-const mainEntry = path.join(repoRoot, "dist-electron", "main.js");
+const mainEntry = path.join(repoRoot, "dist-electron", "main.cjs");
 const rendererEntry = path.join(repoRoot, "dist", "index.html");
 
 const width = parseEvenInteger(process.env.RECORDLY_BENCH_EXPORT_WIDTH ?? "1280", "Width");

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -519,6 +519,7 @@ export default function VideoEditor() {
 	const [isSavingProjectName, setIsSavingProjectName] = useState(false);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [smokeExportReadinessTick, setSmokeExportReadinessTick] = useState(0);
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [currentTime, setCurrentTime] = useState(0);
 	const [duration, setDuration] = useState(0);
@@ -4042,7 +4043,7 @@ export default function VideoEditor() {
 						: (settings.mp4FrameRate ?? mp4FrameRate);
 					const pipelineModel = smokeExportConfig.enabled
 						? (smokeExportConfig.pipelineModel ??
-							(smokeExportConfig.useNativeExport ? "modern" : "legacy"))
+							(smokeExportConfig.useNativeExport ? "modern" : exportPipelineModel))
 						: (settings.pipelineModel ?? exportPipelineModel);
 					const backendPreference =
 						pipelineModel === "legacy"
@@ -4423,14 +4424,65 @@ export default function VideoEditor() {
 			return;
 		}
 
-		if (error) {
+		const writeSmokeStartupFailure = (reason: string, detail: Record<string, unknown> = {}) => {
 			smokeExportStartedRef.current = true;
-			console.error(`[smoke-export] ${error}`);
-			window.close();
+			void writeSmokeExportReport(smokeExportConfig.outputPath, {
+				success: false,
+				phase: "startup",
+				reason,
+				...detail,
+			}).finally(() => window.close());
+		};
+
+		if (error) {
+			writeSmokeStartupFailure("editor-error", { error });
 			return;
 		}
 
 		if (!videoPath || loading) {
+			if (smokeExportReadinessTick >= 80) {
+				writeSmokeStartupFailure("video-not-loaded", {
+					videoPath,
+					loading,
+					duration,
+				});
+				return;
+			}
+
+			const retryTimeout = window.setTimeout(() => {
+				setSmokeExportReadinessTick((tick) => tick + 1);
+			}, 100);
+			return () => window.clearTimeout(retryTimeout);
+		}
+
+		const videoElement = videoPlaybackRef.current?.video;
+		if (!videoElement || videoElement.readyState < 1 || duration <= 0) {
+			if (smokeExportReadinessTick >= 80) {
+				writeSmokeStartupFailure("video-metadata-not-ready", {
+					hasVideoElement: Boolean(videoElement),
+					readyState: videoElement?.readyState ?? null,
+					duration,
+					videoPath,
+				});
+				return;
+			}
+
+			const retryTimeout = window.setTimeout(() => {
+				setSmokeExportReadinessTick((tick) => tick + 1);
+			}, 100);
+			return () => window.clearTimeout(retryTimeout);
+		}
+
+		if (
+			smokeExportConfig.projectPath &&
+			videoSourcePath &&
+			cursorTelemetrySourcePath !== videoSourcePath &&
+			smokeExportReadinessTick >= 80
+		) {
+			writeSmokeStartupFailure("cursor-telemetry-not-ready", {
+				videoSourcePath,
+				cursorTelemetrySourcePath,
+			});
 			return;
 		}
 
@@ -4457,9 +4509,12 @@ export default function VideoEditor() {
 		error,
 		handleExport,
 		loading,
+		duration,
 		smokeExportConfig.enabled,
 		smokeExportConfig.encodingMode,
+		smokeExportConfig.outputPath,
 		smokeExportConfig.projectPath,
+		smokeExportReadinessTick,
 		videoPath,
 		videoSourcePath,
 	]);

--- a/src/components/video-editor/editorPreferences.test.ts
+++ b/src/components/video-editor/editorPreferences.test.ts
@@ -56,6 +56,10 @@ describe("editorPreferences", () => {
 		expect(DEFAULT_EDITOR_PREFERENCES.exportQuality).toBe("source");
 	});
 
+	it("defaults MP4 exports to the modern pipeline", () => {
+		expect(DEFAULT_EDITOR_PREFERENCES.exportPipelineModel).toBe("modern");
+	});
+
 	it("loads stored editor control preferences", () => {
 		vi.stubGlobal(
 			"localStorage",
@@ -282,7 +286,13 @@ describe("editorPreferences", () => {
 			cursorClickBounceDuration: 350,
 			cursorSway: 1.5,
 			borderRadius: 18,
-			padding: 30,
+			padding: {
+				top: 30,
+				bottom: 30,
+				left: 30,
+				right: 30,
+				linked: true,
+			},
 			frame: DEFAULT_EDITOR_PREFERENCES.frame,
 			aspectRatio: "4:5",
 			exportEncodingMode: "quality",

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -156,7 +156,7 @@ export function normalizeExportPipelineModel(value: unknown): ExportPipelineMode
 		return value;
 	}
 
-	return "legacy";
+	return "modern";
 }
 
 export function normalizeExportMp4FrameRate(value: unknown): ExportMp4FrameRate {


### PR DESCRIPTION
## Description
Switch new/default MP4 exports from the legacy renderer pipeline to the modern pipeline while preserving explicit legacy selections in saved projects and preferences.

This also hardens the export smoke harness so benchmark runs exercise the real editor default when no pipeline override is passed, wait for video metadata before exporting, write startup failure reports, and avoid EPIPE dialogs when an interrupted smoke run closes stdout/stderr.

## Motivation
A real 60-second slice from a 22:47 Recordly recording showed the legacy default path spending most of the export time in the frame pipeline. The modern path is already available and produced the same MP4 export flow substantially faster on the same input.

Measured locally on Windows, source quality, balanced encoding, 1080p/30fps:
- legacy + WebCodecs: 142.43s total, 12.67 export FPS, 33.86 MB output
- modern + WebCodecs: 82.10s total, 21.97 export FPS, 24.76 MB output
- modern + Breeze/native: 78.80s total, 22.89 export FPS, 33.87 MB output
- modern + WebCodecs + fast: 76.16s total, 23.69 export FPS, 16.04 MB output

I kept the default encoding mode at balanced. The fast preset was faster, but it is a quality/bitrate tradeoff rather than a safe default.

## Type of Change
- [x] Performance
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Changes Made
- default missing/invalid MP4 pipeline settings to `modern` instead of `legacy`
- keep explicit `legacy` project/preference selections intact
- align smoke export fallback behavior with the real editor default when no smoke pipeline override is provided
- wait for smoke export video metadata before starting the export
- write structured smoke startup failure reports instead of silently closing
- fix the export benchmark script entrypoint from `dist-electron/main.js` to `dist-electron/main.cjs`
- suppress smoke-only EPIPE console pipe failures after interrupted benchmark runs
- update editor preference coverage for the new default and current normalized padding shape

## Testing Guide
1. Start from a clean/new editor preference state or a project without `exportPipelineModel`.
2. Open an MP4 recording and export with default MP4 settings.
3. Confirm the export uses the modern pipeline and completes successfully.
4. Open a project that explicitly stores `exportPipelineModel: "legacy"` and confirm it still exports through legacy.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the new default.
- [ ] I have linked screenshots or videos where helpful.

Local checks run:
- `npx tsc --noEmit`
- `npx vitest run src/components/video-editor/editorPreferences.test.ts src/components/video-editor/audio.test.ts src/components/video-editor/types.test.ts src/lib/exporter/exportTuning.test.ts src/lib/exporter/backendPolicy.test.ts`
- `npx vite build --config vite.config.ts`

Smoke/benchmark runs:
- real 60s slice, legacy + WebCodecs balanced: 142.43s
- real 60s slice, modern + WebCodecs balanced: 82.10s
- real 60s slice, modern + Breeze balanced: 78.80s
- real 60s slice, modern + WebCodecs fast: 76.16s
- no-pipeline smoke project after patch: reported `pipelineModel: modern`, `backendPreference: webcodecs`, and completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export process stability by adding error handling for broken-pipe scenarios.

* **New Features**
  * Enhanced export readiness detection with automatic retry logic and diagnostic reporting for startup failures.
  * Updated default MP4 export format to modern pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->