### PR TITLE
feat: increase frame corner radius max from 50 to 200

### DIFF
--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -1886,7 +1886,7 @@ export function SettingsPanel({
 					value={borderRadius}
 					defaultValue={initialEditorPreferences.borderRadius}
 					min={0}
-					max={50}
+					max={200}
 					step={0.5}
 					onChange={(v) => onBorderRadiusChange?.(v)}
 					formatValue={(v) => `${v}px`}


### PR DESCRIPTION
Increases the maximum value of the frame border radius slider from `50px` to `200px`, giving users more flexibility to create heavily rounded or pill-shaped video frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum border radius limit in the video editor from 50 to 200, enabling users to apply more dramatic rounded corner effects to video frames with enhanced customization and greater creative control over visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->