### PR TITLE
[codex] Fix cursor sync after recording pause

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -151,12 +151,12 @@ interface Window {
 			message?: string;
 			error?: string;
 		}>;
-		pauseCursorCapture: () => Promise<{
+		pauseCursorCapture: (boundaryMs?: number) => Promise<{
 			success: boolean;
 			message?: string;
 			error?: string;
 		}>;
-		resumeCursorCapture: () => Promise<{
+		resumeCursorCapture: (boundaryMs?: number) => Promise<{
 			success: boolean;
 			message?: string;
 			error?: string;

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -151,6 +151,16 @@ interface Window {
 			message?: string;
 			error?: string;
 		}>;
+		pauseCursorCapture: () => Promise<{
+			success: boolean;
+			message?: string;
+			error?: string;
+		}>;
+		resumeCursorCapture: () => Promise<{
+			success: boolean;
+			message?: string;
+			error?: string;
+		}>;
 		startFfmpegRecording: (
 			source: ProcessedDesktopSource,
 		) => Promise<{ success: boolean; path?: string; message?: string; error?: string }>;

--- a/electron/ipc/cursor/interaction.ts
+++ b/electron/ipc/cursor/interaction.ts
@@ -2,7 +2,6 @@ import { createRequire } from "node:module";
 import type { HookMouseEvent, UiohookLike, UiohookModuleNamespace, CursorInteractionType } from "../types";
 import {
 	isCursorCaptureActive,
-	cursorCaptureStartTimeMs,
 	interactionCaptureCleanup,
 	setInteractionCaptureCleanup,
 	hasLoggedInteractionHookFailure,
@@ -13,7 +12,9 @@ import {
 } from "../state";
 import {
 	getNormalizedCursorPoint,
+	getCursorCaptureElapsedMs,
 	getHookCursorScreenPoint,
+	isCursorCapturePaused,
 	pushCursorSample,
 } from "./telemetry";
 
@@ -119,7 +120,7 @@ export async function startInteractionCapture() {
 		}
 
 		const onMouseDown = (event: HookMouseEvent) => {
-			if (!isCursorCaptureActive) {
+			if (!isCursorCaptureActive || isCursorCapturePaused()) {
 				return;
 			}
 
@@ -128,7 +129,7 @@ export async function startInteractionCapture() {
 				return;
 			}
 
-			const timeMs = Date.now() - cursorCaptureStartTimeMs;
+			const timeMs = getCursorCaptureElapsedMs();
 			const button = getHookMouseButton(event);
 			let interactionType: CursorInteractionType = "click";
 
@@ -157,7 +158,7 @@ export async function startInteractionCapture() {
 		};
 
 		const onMouseUp = () => {
-			if (!isCursorCaptureActive) {
+			if (!isCursorCaptureActive || isCursorCapturePaused()) {
 				return;
 			}
 
@@ -166,12 +167,16 @@ export async function startInteractionCapture() {
 				return;
 			}
 
-			const timeMs = Date.now() - cursorCaptureStartTimeMs;
+			const timeMs = getCursorCaptureElapsedMs();
 			pushCursorSample(point.cx, point.cy, timeMs, "mouseup");
 		};
 
 		const onMouseMove = (event: HookMouseEvent) => {
-			if (process.platform !== "linux" || !isCursorCaptureActive) {
+			if (
+				process.platform !== "linux" ||
+				!isCursorCaptureActive ||
+				isCursorCapturePaused()
+			) {
 				return;
 			}
 

--- a/electron/ipc/cursor/telemetry.test.ts
+++ b/electron/ipc/cursor/telemetry.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+	app: {
+		getPath: vi.fn(() => "/tmp"),
+	},
+}));
+
+vi.mock("../utils", () => ({
+	getTelemetryPathForVideo: vi.fn(() => "/tmp/recording.cursor.json"),
+	getScreen: vi.fn(() => ({
+		getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+		getPrimaryDisplay: () => ({ scaleFactor: 1 }),
+		getDisplayNearestPoint: () => ({ bounds: { x: 0, y: 0, width: 1, height: 1 } }),
+		getAllDisplays: () => [],
+	})),
+}));
+
+import {
+	getCursorCaptureElapsedMs,
+	pauseCursorCapture,
+	resetCursorCaptureClock,
+	resumeCursorCapture,
+} from "./telemetry";
+import { setCursorCaptureStartTimeMs } from "../state";
+
+describe("cursor telemetry pause clock", () => {
+	beforeEach(() => {
+		setCursorCaptureStartTimeMs(1_000);
+		resetCursorCaptureClock();
+	});
+
+	it("subtracts paused time from elapsed cursor timestamps", () => {
+		expect(getCursorCaptureElapsedMs(1_120)).toBe(120);
+
+		pauseCursorCapture(1_200);
+		expect(getCursorCaptureElapsedMs(1_450)).toBe(200);
+
+		resumeCursorCapture(1_700);
+		expect(getCursorCaptureElapsedMs(1_900)).toBe(400);
+	});
+
+	it("ignores duplicate pause or resume transitions", () => {
+		pauseCursorCapture(1_150);
+		pauseCursorCapture(1_250);
+		resumeCursorCapture(1_500);
+		resumeCursorCapture(1_650);
+
+		expect(getCursorCaptureElapsedMs(1_900)).toBe(550);
+	});
+});

--- a/electron/ipc/cursor/telemetry.ts
+++ b/electron/ipc/cursor/telemetry.ts
@@ -168,9 +168,9 @@ export function pushCursorSample(
 	}
 }
 
-export function sampleCursorPoint() {
+export function sampleCursorPoint(sampledAtMs = Date.now()) {
 	const point = getNormalizedCursorPoint();
-	pushCursorSample(point.cx, point.cy, getCursorCaptureElapsedMs(), "move");
+	pushCursorSample(point.cx, point.cy, getCursorCaptureElapsedMs(sampledAtMs), "move");
 }
 
 export async function persistPendingCursorTelemetry(videoPath: string) {

--- a/electron/ipc/cursor/telemetry.ts
+++ b/electron/ipc/cursor/telemetry.ts
@@ -9,6 +9,8 @@ import type { CursorVisualType, CursorInteractionType, CursorTelemetryPoint } fr
 import {
 	cursorCaptureInterval,
 	setCursorCaptureInterval,
+	cursorCaptureAccumulatedPausedMs,
+	cursorCapturePauseStartedAtMs,
 	cursorCaptureStartTimeMs,
 	activeCursorSamples,
 	pendingCursorSamples,
@@ -18,6 +20,8 @@ import {
 	linuxCursorScreenPoint,
 	selectedSource,
 	selectedWindowBounds,
+	setCursorCaptureAccumulatedPausedMs,
+	setCursorCapturePauseStartedAtMs,
 } from "../state";
 
 export function clamp(value: number, min: number, max: number) {
@@ -29,6 +33,55 @@ export function stopCursorCapture() {
 		clearTimeout(cursorCaptureInterval);
 		setCursorCaptureInterval(null);
 	}
+}
+
+export function resetCursorCaptureClock() {
+	setCursorCaptureAccumulatedPausedMs(0);
+	setCursorCapturePauseStartedAtMs(null);
+}
+
+export function isCursorCapturePaused() {
+	return cursorCapturePauseStartedAtMs !== null;
+}
+
+export function pauseCursorCapture(pausedAtMs: number) {
+	if (cursorCapturePauseStartedAtMs !== null) {
+		return;
+	}
+
+	setCursorCapturePauseStartedAtMs(pausedAtMs);
+}
+
+export function resumeCursorCapture(resumedAtMs: number) {
+	if (cursorCapturePauseStartedAtMs === null) {
+		return;
+	}
+
+	const pauseDurationMs = Math.max(0, resumedAtMs - cursorCapturePauseStartedAtMs);
+	setCursorCaptureAccumulatedPausedMs(
+		cursorCaptureAccumulatedPausedMs + pauseDurationMs,
+	);
+	setCursorCapturePauseStartedAtMs(null);
+}
+
+export function getCursorCaptureElapsedMs(nowMs = Date.now()) {
+	if (!Number.isFinite(cursorCaptureStartTimeMs) || cursorCaptureStartTimeMs <= 0) {
+		return 0;
+	}
+
+	const safeNowMs = Math.max(cursorCaptureStartTimeMs, nowMs);
+	const activePauseDurationMs =
+		cursorCapturePauseStartedAtMs === null
+			? 0
+			: Math.max(0, safeNowMs - cursorCapturePauseStartedAtMs);
+
+	return Math.max(
+		0,
+		safeNowMs -
+			cursorCaptureStartTimeMs -
+			Math.max(0, cursorCaptureAccumulatedPausedMs) -
+			activePauseDurationMs,
+	);
 }
 
 export function getNormalizedCursorPoint() {
@@ -117,7 +170,7 @@ export function pushCursorSample(
 
 export function sampleCursorPoint() {
 	const point = getNormalizedCursorPoint();
-	pushCursorSample(point.cx, point.cy, Date.now() - cursorCaptureStartTimeMs, "move");
+	pushCursorSample(point.cx, point.cy, getCursorCaptureElapsedMs(), "move");
 }
 
 export async function persistPendingCursorTelemetry(videoPath: string) {
@@ -163,7 +216,7 @@ export function startCursorSampling() {
 	let nextExpectedMs = Date.now() + CURSOR_SAMPLE_INTERVAL_MS;
 
 	const tick = () => {
-		if (isCursorCaptureActive) {
+		if (isCursorCaptureActive && !isCursorCapturePaused()) {
 			sampleCursorPoint();
 		}
 

--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -1312,15 +1312,23 @@ export function registerRecordingHandlers(
 		}
 	});
 
-	ipcMain.handle("pause-cursor-capture", () => {
-		sampleCursorPoint();
-		pauseCursorCapture(Date.now());
+	ipcMain.handle("pause-cursor-capture", (_event, boundaryMs?: number) => {
+		const timestamp =
+			typeof boundaryMs === "number" && Number.isFinite(boundaryMs)
+				? boundaryMs
+				: Date.now();
+		sampleCursorPoint(timestamp);
+		pauseCursorCapture(timestamp);
 		return { success: true };
 	});
 
-	ipcMain.handle("resume-cursor-capture", () => {
-		resumeCursorCapture(Date.now());
-		sampleCursorPoint();
+	ipcMain.handle("resume-cursor-capture", (_event, boundaryMs?: number) => {
+		const timestamp =
+			typeof boundaryMs === "number" && Number.isFinite(boundaryMs)
+				? boundaryMs
+				: Date.now();
+		resumeCursorCapture(timestamp);
+		sampleCursorPoint(timestamp);
 		return { success: true };
 	});
 

--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -19,6 +19,9 @@ import { startInteractionCapture, stopInteractionCapture } from "../cursor/inter
 import { startNativeCursorMonitor, stopNativeCursorMonitor } from "../cursor/monitor";
 import {
 	clamp,
+	pauseCursorCapture,
+	resumeCursorCapture,
+	resetCursorCaptureClock,
 	sampleCursorPoint,
 	snapshotCursorTelemetryForPersistence,
 	startCursorSampling,
@@ -1275,6 +1278,7 @@ export function registerRecordingHandlers(
 			setActiveCursorSamples([]);
 			setPendingCursorSamples([]);
 			setCursorCaptureStartTimeMs(Date.now());
+			resetCursorCaptureClock();
 			setLinuxCursorScreenPoint(null);
 			setLastLeftClick(null);
 			sampleCursorPoint();
@@ -1288,6 +1292,7 @@ export function registerRecordingHandlers(
 			stopNativeCursorMonitor();
 			showCursor();
 			setLinuxCursorScreenPoint(null);
+			resetCursorCaptureClock();
 			snapshotCursorTelemetryForPersistence();
 			setActiveCursorSamples([]);
 		}
@@ -1305,6 +1310,18 @@ export function registerRecordingHandlers(
 		if (onRecordingStateChange) {
 			onRecordingStateChange(recording, source.name);
 		}
+	});
+
+	ipcMain.handle("pause-cursor-capture", () => {
+		sampleCursorPoint();
+		pauseCursorCapture(Date.now());
+		return { success: true };
+	});
+
+	ipcMain.handle("resume-cursor-capture", () => {
+		resumeCursorCapture(Date.now());
+		sampleCursorPoint();
+		return { success: true };
 	});
 
 	ipcMain.handle("get-cursor-telemetry", async (_, videoPath?: string) => {

--- a/electron/ipc/state.ts
+++ b/electron/ipc/state.ts
@@ -76,6 +76,8 @@ export let currentCursorVisualType: CursorVisualType | undefined = undefined;
 // ── Cursor telemetry ──────────────────────────────────────────────────────────
 export let cursorCaptureInterval: NodeJS.Timeout | null = null;
 export let cursorCaptureStartTimeMs = 0;
+export let cursorCaptureAccumulatedPausedMs = 0;
+export let cursorCapturePauseStartedAtMs: number | null = null;
 export let activeCursorSamples: CursorTelemetryPoint[] = [];
 export let pendingCursorSamples: CursorTelemetryPoint[] = [];
 export let isCursorCaptureActive = false;
@@ -236,6 +238,12 @@ export function setCursorCaptureInterval(v: NodeJS.Timeout | null) {
 }
 export function setCursorCaptureStartTimeMs(v: number) {
 	cursorCaptureStartTimeMs = v;
+}
+export function setCursorCaptureAccumulatedPausedMs(v: number) {
+	cursorCaptureAccumulatedPausedMs = v;
+}
+export function setCursorCapturePauseStartedAtMs(v: number | null) {
+	cursorCapturePauseStartedAtMs = v;
 }
 export function setActiveCursorSamples(v: CursorTelemetryPoint[]) {
 	activeCursorSamples = v;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -293,11 +293,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	resumeNativeScreenRecording: () => {
 		return ipcRenderer.invoke("resume-native-screen-recording");
 	},
-	pauseCursorCapture: () => {
-		return ipcRenderer.invoke("pause-cursor-capture");
+	pauseCursorCapture: (boundaryMs?: number) => {
+		return ipcRenderer.invoke("pause-cursor-capture", boundaryMs);
 	},
-	resumeCursorCapture: () => {
-		return ipcRenderer.invoke("resume-cursor-capture");
+	resumeCursorCapture: (boundaryMs?: number) => {
+		return ipcRenderer.invoke("resume-cursor-capture", boundaryMs);
 	},
 	startFfmpegRecording: (source: ProcessedDesktopSource) => {
 		return ipcRenderer.invoke("start-ffmpeg-recording", source);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -293,6 +293,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	resumeNativeScreenRecording: () => {
 		return ipcRenderer.invoke("resume-native-screen-recording");
 	},
+	pauseCursorCapture: () => {
+		return ipcRenderer.invoke("pause-cursor-capture");
+	},
+	resumeCursorCapture: () => {
+		return ipcRenderer.invoke("resume-cursor-capture");
+	},
 	startFfmpegRecording: (source: ProcessedDesktopSource) => {
 		return ipcRenderer.invoke("start-ffmpeg-recording", source);
 	},

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1440,12 +1440,32 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				if (webcamRecorder.current?.state === "recording") {
 					webcamRecorder.current.pause();
 				}
+				const boundaryMs = Date.now();
 				try {
-					await window.electronAPI.pauseCursorCapture();
+					await window.electronAPI.pauseCursorCapture(boundaryMs);
 				} catch (error) {
 					console.warn("Failed to pause cursor capture:", error);
+					try {
+						const rollbackResult =
+							await window.electronAPI.resumeNativeScreenRecording();
+						if (!rollbackResult.success) {
+							console.warn(
+								"Failed to roll back native pause after cursor pause failure:",
+								rollbackResult.error ?? rollbackResult.message,
+							);
+						}
+					} catch (rollbackError) {
+						console.warn(
+							"Failed to roll back native pause after cursor pause failure:",
+							rollbackError,
+						);
+					}
+					if (webcamRecorder.current?.state === "paused") {
+						webcamRecorder.current.resume();
+					}
+					return;
 				}
-				markRecordingPaused(Date.now());
+				markRecordingPaused(boundaryMs);
 				setPaused(true);
 			})();
 			return;
@@ -1455,13 +1475,21 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			if (webcamRecorder.current?.state === "recording") {
 				webcamRecorder.current.pause();
 			}
+			const boundaryMs = Date.now();
 			void (async () => {
 				try {
-					await window.electronAPI.pauseCursorCapture();
+					await window.electronAPI.pauseCursorCapture(boundaryMs);
 				} catch (error) {
 					console.warn("Failed to pause cursor capture:", error);
+					if (mediaRecorder.current?.state === "paused") {
+						mediaRecorder.current.resume();
+					}
+					if (webcamRecorder.current?.state === "paused") {
+						webcamRecorder.current.resume();
+					}
+					return;
 				}
-				markRecordingPaused(Date.now());
+				markRecordingPaused(boundaryMs);
 				setPaused(true);
 			})();
 		}
@@ -1483,12 +1511,32 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				if (webcamRecorder.current?.state === "paused") {
 					webcamRecorder.current.resume();
 				}
+				const boundaryMs = Date.now();
 				try {
-					await window.electronAPI.resumeCursorCapture();
+					await window.electronAPI.resumeCursorCapture(boundaryMs);
 				} catch (error) {
 					console.warn("Failed to resume cursor capture:", error);
+					try {
+						const rollbackResult =
+							await window.electronAPI.pauseNativeScreenRecording();
+						if (!rollbackResult.success) {
+							console.warn(
+								"Failed to roll back native resume after cursor resume failure:",
+								rollbackResult.error ?? rollbackResult.message,
+							);
+						}
+					} catch (rollbackError) {
+						console.warn(
+							"Failed to roll back native resume after cursor resume failure:",
+							rollbackError,
+						);
+					}
+					if (webcamRecorder.current?.state === "recording") {
+						webcamRecorder.current.pause();
+					}
+					return;
 				}
-				markRecordingResumed(Date.now());
+				markRecordingResumed(boundaryMs);
 				setPaused(false);
 			})();
 			return;
@@ -1498,13 +1546,21 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			if (webcamRecorder.current?.state === "paused") {
 				webcamRecorder.current.resume();
 			}
+			const boundaryMs = Date.now();
 			void (async () => {
 				try {
-					await window.electronAPI.resumeCursorCapture();
+					await window.electronAPI.resumeCursorCapture(boundaryMs);
 				} catch (error) {
 					console.warn("Failed to resume cursor capture:", error);
+					if (mediaRecorder.current?.state === "recording") {
+						mediaRecorder.current.pause();
+					}
+					if (webcamRecorder.current?.state === "recording") {
+						webcamRecorder.current.pause();
+					}
+					return;
 				}
-				markRecordingResumed(Date.now());
+				markRecordingResumed(boundaryMs);
 				setPaused(false);
 			})();
 		}

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1094,7 +1094,6 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				}
 			}
 
-			const wantsAudioCapture = microphoneEnabled || systemAudioEnabled;
 			const browserCaptureSource = await resolveBrowserCaptureSource(selectedSource);
 
 			if (
@@ -1441,6 +1440,11 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				if (webcamRecorder.current?.state === "recording") {
 					webcamRecorder.current.pause();
 				}
+				try {
+					await window.electronAPI.pauseCursorCapture();
+				} catch (error) {
+					console.warn("Failed to pause cursor capture:", error);
+				}
 				markRecordingPaused(Date.now());
 				setPaused(true);
 			})();
@@ -1451,8 +1455,15 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			if (webcamRecorder.current?.state === "recording") {
 				webcamRecorder.current.pause();
 			}
-			markRecordingPaused(Date.now());
-			setPaused(true);
+			void (async () => {
+				try {
+					await window.electronAPI.pauseCursorCapture();
+				} catch (error) {
+					console.warn("Failed to pause cursor capture:", error);
+				}
+				markRecordingPaused(Date.now());
+				setPaused(true);
+			})();
 		}
 	}, [markRecordingPaused, paused, recording]);
 
@@ -1472,6 +1483,11 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				if (webcamRecorder.current?.state === "paused") {
 					webcamRecorder.current.resume();
 				}
+				try {
+					await window.electronAPI.resumeCursorCapture();
+				} catch (error) {
+					console.warn("Failed to resume cursor capture:", error);
+				}
 				markRecordingResumed(Date.now());
 				setPaused(false);
 			})();
@@ -1482,8 +1498,15 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			if (webcamRecorder.current?.state === "paused") {
 				webcamRecorder.current.resume();
 			}
-			markRecordingResumed(Date.now());
-			setPaused(false);
+			void (async () => {
+				try {
+					await window.electronAPI.resumeCursorCapture();
+				} catch (error) {
+					console.warn("Failed to resume cursor capture:", error);
+				}
+				markRecordingResumed(Date.now());
+				setPaused(false);
+			})();
 		}
 	}, [markRecordingResumed, paused, recording]);
 


### PR DESCRIPTION
## What changed
Fix cursor telemetry timing so pausing and resuming a recording no longer desynchronizes the cursor in the editor.

## Why
The video timeline already removes paused time, but cursor telemetry was still being timestamped against wall-clock elapsed time. After a pause/resume boundary, cursor events drifted later than the recorded video.

## Root cause
Cursor sampling and cursor interaction events continued to measure elapsed time from the original recording start without subtracting paused duration.

## Implementation
- add a pause-aware cursor capture clock in the Electron recording state
- stop advancing cursor sampling and interaction timestamps while recording is paused
- wire pause/resume from the recorder hook into cursor capture IPC
- add a regression test covering paused elapsed-time accounting
- remove an unused local in `useScreenRecorder` so the branch typechecks cleanly

## Impact
Recordings that include pauses should keep cursor motion and click effects aligned with the video timeline in the editor after resume.

## Validation
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest --run electron/ipc/cursor/telemetry.test.ts src/hooks/useScreenRecorder.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pause and resume controls for cursor capture during recording sessions; paused time is excluded from the recording timeline.
* **Bug Fixes / Reliability**
  * Improved pause/resume coordination so recording state and cursor sampling stay in sync; failures now roll back to preserve recorder state.
* **Tests**
  * Added tests to validate pause/resume timing and prevent duplicate state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->