### PR TITLE
fix(export): return temp path from buffer-mode FFmpeg muxer (>2 GiB) (#380)

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -246,7 +246,7 @@ interface Window {
 			},
 		) => Promise<{
 			success: boolean;
-			data?: Uint8Array;
+			tempPath?: string;
 			error?: string;
 			metrics?: RendererFfmpegAudioMuxMetrics;
 		}>;

--- a/electron/ipc/export/native-video.test.ts
+++ b/electron/ipc/export/native-video.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+	app: {
+		getPath: vi.fn(() => "/tmp"),
+	},
+}));
+
+vi.mock("../ffmpeg/binary", () => ({
+	getFfmpegBinaryPath: vi.fn(() => "/usr/bin/ffmpeg"),
+}));
+
+vi.mock("../state", () => ({
+	cachedNativeVideoEncoder: null,
+	setCachedNativeVideoEncoder: vi.fn(),
+}));
+
+const fsMocks = vi.hoisted(() => ({
+	writeFile: vi.fn(async () => undefined),
+	readFile: vi.fn(),
+	stat: vi.fn(async () => ({ size: 5_000_000_000 })),
+	unlink: vi.fn(async () => undefined),
+}));
+
+vi.mock("node:fs/promises", () => ({
+	default: fsMocks,
+	...fsMocks,
+}));
+
+const execFileMock = vi.hoisted(() =>
+	vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null) => void) => {
+		cb(null);
+		return { stdout: "", stderr: "" } as unknown;
+	}),
+);
+
+vi.mock("node:child_process", () => ({
+	execFile: execFileMock,
+	spawn: vi.fn(),
+}));
+
+import { muxExportedVideoAudioBuffer } from "./native-video";
+
+describe("muxExportedVideoAudioBuffer", () => {
+	it("returns the muxed output path without reading the muxed file into memory", async () => {
+		const videoData = new ArrayBuffer(64);
+		const result = await muxExportedVideoAudioBuffer(videoData, { audioMode: "none" });
+
+		// Path-based contract: caller (IPC handler) registers ownership and
+		// hands the path to the renderer's finalize-exported-video flow.
+		expect(typeof result.outputPath).toBe("string");
+		expect(result.outputPath.length).toBeGreaterThan(0);
+		// The 2 GiB bug was a fs.readFile of the muxed output. The fix relies on
+		// stat-only metric collection — readFile must stay unused.
+		expect(fsMocks.readFile).not.toHaveBeenCalled();
+		// We still record byte size so export metrics survive the change.
+		expect(result.metrics.muxedVideoBytes).toBe(5_000_000_000);
+	});
+
+	it("preserves the input temp path when audioMode='none' (no re-mux)", async () => {
+		const videoData = new ArrayBuffer(32);
+		const result = await muxExportedVideoAudioBuffer(videoData, { audioMode: "none" });
+
+		// muxNativeVideoExportAudio short-circuits when audioMode === "none" and
+		// returns the input path unchanged. We surface that so the renderer can
+		// finalize the same temp file the buffer was written to.
+		expect(result.outputPath).toMatch(/recordly-export-video-/);
+	});
+});

--- a/electron/ipc/export/native-video.ts
+++ b/electron/ipc/export/native-video.ts
@@ -492,6 +492,8 @@ export async function muxExportedVideoAudioBuffer(
 		`recordly-export-video-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.mp4`,
 	);
 	const metrics: NativeVideoAudioMuxMetrics = {};
+	let succeeded = false;
+	let outputPath = tempVideoPath;
 
 	try {
 		const tempVideoWriteStartedAt = getNowMs();
@@ -500,23 +502,35 @@ export async function muxExportedVideoAudioBuffer(
 		metrics.tempVideoBytes = videoData.byteLength;
 		const finalized = await muxNativeVideoExportAudio(tempVideoPath, options);
 		Object.assign(metrics, finalized.metrics);
-		const muxedVideoReadStartedAt = getNowMs();
-		const muxedData = await fs.readFile(finalized.outputPath);
-		metrics.muxedVideoReadMs = getNowMs() - muxedVideoReadStartedAt;
-		metrics.muxedVideoBytes = muxedData.byteLength;
+		outputPath = finalized.outputPath;
+		// Record byte size via stat instead of reading the whole file into a
+		// Buffer — fs.readFile throws ERR_FS_FILE_TOO_LARGE on >2 GiB outputs.
+		try {
+			const stat = await fs.stat(outputPath);
+			metrics.muxedVideoBytes = stat.size;
+		} catch {
+			// Stat failures are non-fatal; size is purely metric data.
+		}
+		succeeded = true;
 		return {
-			data: new Uint8Array(muxedData),
+			outputPath,
 			metrics,
 		};
 	} finally {
-		await Promise.allSettled([
-			removeTemporaryExportFile(tempVideoPath),
-			removeTemporaryExportFile(
-				path.join(
-					path.dirname(tempVideoPath),
-					`${path.basename(tempVideoPath, path.extname(tempVideoPath))}-final.mp4`,
-				),
-			),
-		]);
+		// Always remove the unmuxed intermediate when the muxer wrote a separate
+		// file. Only remove the muxed output on failure — on success the caller
+		// owns it and is responsible for moving/deleting it.
+		const cleanupTargets: string[] = [];
+		if (outputPath !== tempVideoPath) {
+			cleanupTargets.push(tempVideoPath);
+		}
+		if (!succeeded) {
+			cleanupTargets.push(outputPath);
+		}
+		if (cleanupTargets.length > 0) {
+			await Promise.allSettled(
+				cleanupTargets.map((target) => removeTemporaryExportFile(target)),
+			);
+		}
 	}
 }

--- a/electron/ipc/register/export.ts
+++ b/electron/ipc/register/export.ts
@@ -382,9 +382,14 @@ export function registerExportHandlers() {
 		async (_, videoData: ArrayBuffer, options?: NativeVideoExportFinishOptions) => {
 			try {
 				const result = await muxExportedVideoAudioBuffer(videoData, options ?? {});
+				// Register the muxed output so finalize-exported-video / discard-
+				// exported-temp accept it. Returning a temp path (instead of the
+				// muxed bytes) keeps us off Node's >2 GiB fs.readFile cap and
+				// avoids a redundant copy through the renderer.
+				registerOwnedExportPath(result.outputPath);
 				return {
 					success: true,
-					data: result.data,
+					tempPath: result.outputPath,
 					metrics: result.metrics,
 				};
 			} catch (error) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -202,7 +202,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	) => {
 		return ipcRenderer.invoke("mux-exported-video-audio", videoData, options) as Promise<{
 			success: boolean;
-			data?: Uint8Array;
+			tempPath?: string;
 			error?: string;
 			metrics?: NativeVideoAudioMuxMetrics;
 		}>;

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -1244,17 +1244,18 @@ export class ModernVideoExporter {
 			this.finalizationStageMs.ffmpegAudioMuxBreakdown = result.metrics;
 		}
 
-		if (!result.success || !result.data) {
+		if (!result.success || !result.tempPath) {
 			return {
 				success: false,
 				error: result.error || "Failed to mux exported audio with FFmpeg",
 			};
 		}
 
-		const videoBytes = result.data.slice();
+		// Returning a temp path (instead of buffering the muxed bytes back into
+		// the renderer) is what keeps >2 GiB exports off Node's fs.readFile cap.
 		return {
 			success: true,
-			blob: new Blob([videoBytes.buffer], { type: "video/mp4" }),
+			tempFilePath: result.tempPath,
 		};
 	}
 

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -981,7 +981,7 @@ export class VideoExporter {
 			this.finalizationStageMs.ffmpegAudioMuxBreakdown = result.metrics;
 		}
 
-		if (!result.success || !result.data) {
+		if (!result.success || !result.tempPath) {
 			return {
 				success: false,
 				error: result.error || "Failed to mux exported audio with FFmpeg",
@@ -989,11 +989,11 @@ export class VideoExporter {
 			};
 		}
 
-		const blobData = new Uint8Array(result.data.byteLength);
-		blobData.set(result.data);
+		// Returning a temp path (instead of buffering the muxed bytes back into
+		// the renderer) is what keeps >2 GiB exports off Node's fs.readFile cap.
 		return {
 			success: true,
-			blob: new Blob([blobData.buffer], { type: "video/mp4" }),
+			tempFilePath: result.tempPath,
 			metrics: this.buildExportMetrics(),
 		};
 	}


### PR DESCRIPTION
## Summary

Fixes #380 — \`RangeError [ERR_FS_FILE_TOO_LARGE]: File size is greater than 2 GiB\` when exporting large recordings through the legacy (non-streaming) FFmpeg audio-mux pipeline.

## Root cause

\`muxExportedVideoAudioBuffer\` in \`electron/ipc/export/native-video.ts\` writes the renderer-supplied \`ArrayBuffer\` to a temp file, runs FFmpeg to mux audio in, then ships the result back to the renderer. The shipping step was:

\`\`\`ts
const muxedData = await fs.readFile(finalized.outputPath);
...
return { data: new Uint8Array(muxedData), metrics };
\`\`\`

Node's \`fs.readFile\` throws \`ERR_FS_FILE_TOO_LARGE\` when the file exceeds \`kIoMaxLength\` (\`2 ** 31 - 1\` bytes ≈ 2 GiB). Anyone exporting a recording whose muxed output crosses 2 GiB hits this, killing the export.

## Fix

Mirror the existing path-based contract used by \`mux-exported-video-audio-from-path\`. The renderer already prefers the temp-path flow for MP4 saves (\`VideoEditor.tsx\` has the comment "avoids ever allocating a multi-GiB ArrayBuffer in the renderer"); this PR routes the buffer-mode fallback through the same flow.

- \`muxExportedVideoAudioBuffer\` returns \`{ outputPath, metrics }\`. Byte-size metric is collected via \`fs.stat\`, not \`fs.readFile\`. The unmuxed intermediate is still cleaned up; the muxed output is preserved for the caller.
- IPC handler \`mux-exported-video-audio\` registers the muxed output via \`registerOwnedExportPath\` and returns \`{ success, tempPath, metrics }\`.
- \`preload.ts\` and \`electron-env.d.ts\` updated: \`data?: Uint8Array\` → \`tempPath?: string\`.
- \`videoExporter.ts\` and \`modernVideoExporter.ts\` (\`finalizeExportWithFfmpegAudio\` fallback) return \`{ tempFilePath }\`, the same shape as stream mode. The downstream \`VideoEditor.tsx\` saving flow already handles \`tempFilePath\` by calling \`finalize-exported-video\`, which uses \`fs.rename\` / \`fs.copyFile\` (both 2 GiB-safe).

The blob-construction round-trip in the renderer (allocate Uint8Array, copy, wrap in Blob) is also gone — it was never going to work for large exports.

## Tests

Adds \`electron/ipc/export/native-video.test.ts\` (2 tests) asserting:

- \`muxExportedVideoAudioBuffer\` returns a non-empty \`outputPath\`
- it does **not** call \`fs.readFile\` (the original bug)
- it still records \`muxedVideoBytes\` via \`fs.stat\`
- when \`audioMode === \"none\"\`, the output path is the same temp the buffer was written to (no orphaned intermediate)

## Test plan

- [x] \`npx vitest run\` — 326 tests pass (45 files), including 2 new ones
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx biome check\` clean on changed files (the 2 pre-existing \`setCurrentRecordingSession\` formatter notes in \`preload.ts\` / \`electron-env.d.ts\` exist on \`main\` and are untouched here)
- [ ] Maintainer: please verify with a recording whose muxed output exceeds 2 GiB on the legacy pipeline (e.g. a long high-bitrate session with audio enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated video and audio muxing export mechanism to optimize handling of large media files. The system now manages intermediate output files more efficiently while maintaining export functionality and metrics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->