### PR TITLE
[codex] clean up clip-first timeline editing

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -150,7 +150,6 @@ import {
 	DEFAULT_PLAYBACK_SPEED,
 	DEFAULT_WEBCAM_OVERLAY,
 	DEFAULT_WEBCAM_TIME_OFFSET_MS,
-	DEFAULT_ZOOM_DEPTH,
 	DEFAULT_ZOOM_IN_DURATION_MS,
 	DEFAULT_ZOOM_IN_EASING,
 	DEFAULT_ZOOM_IN_OVERLAP_MS,
@@ -2940,13 +2939,14 @@ export default function VideoEditor() {
 	const handleZoomAdded = useCallback(
 		(span: Span) => {
 			const id = `zoom-${nextZoomIdRef.current++}`;
+			const defaultDepth: ZoomDepth = 2;
 			const newRegion: ZoomRegion = {
 				id,
 				startMs: Math.round(span.start),
 				endMs: Math.round(span.end),
-				depth: DEFAULT_ZOOM_DEPTH,
-				focus: { cx: 0.5, cy: 0.5 },
-				mode: "manual",
+				depth: defaultDepth,
+				focus: clampFocusToDepth({ cx: 0.5, cy: 0.5 }, defaultDepth),
+				mode: "auto",
 			};
 			if (videoPath && pendingFreshRecordingAutoZoomPathRef.current === videoPath) {
 				autoSuggestedVideoPathRef.current = videoPath;

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -2772,7 +2772,12 @@ export default function VideoEditor() {
 				autoFullTrackClipIdRef.current = id;
 				autoFullTrackClipEndMsRef.current = totalMs;
 				if (trimRegions.length > 0) {
-					setClipRegions(trimsToClips(trimRegions, totalMs));
+					const migratedClips = trimsToClips(trimRegions, totalMs);
+					nextClipIdRef.current = deriveNextId(
+						"clip",
+						migratedClips.map((clip) => clip.id),
+					);
+					setClipRegions(migratedClips);
 					clipInitializedRef.current = true;
 					return;
 				}

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -147,7 +147,6 @@ import {
 	DEFAULT_CROP_REGION,
 	DEFAULT_CURSOR_STYLE,
 	DEFAULT_FIGURE_DATA,
-	DEFAULT_PLAYBACK_SPEED,
 	DEFAULT_WEBCAM_OVERLAY,
 	DEFAULT_WEBCAM_TIME_OFFSET_MS,
 	DEFAULT_ZOOM_IN_DURATION_MS,
@@ -159,10 +158,12 @@ import {
 	extendAutoFullTrackClip,
 	type FigureData,
 	getClipSourceEndMs,
+	mapSourceTimeToTimelineTime as resolveSourceTimeToTimelineTime,
+	mapTimelineTimeToSourceTime as resolveTimelineTimeToSourceTime,
 	type Padding,
-	type PlaybackSpeed,
 	type SpeedRegion,
 	type TrimRegion,
+	trimsToClips,
 	type WebcamOverlaySettings,
 	type ZoomDepth,
 	type ZoomFocus,
@@ -184,9 +185,7 @@ type EditorHistorySnapshot = {
 	audioRegions: AudioRegion[];
 	autoCaptions: CaptionCue[];
 	selectedZoomId: string | null;
-	selectedTrimId: string | null;
 	selectedClipId: string | null;
-	selectedSpeedId: string | null;
 	selectedAnnotationId: string | null;
 	selectedAudioId: string | null;
 };
@@ -653,11 +652,9 @@ export default function VideoEditor() {
 	const [cursorTelemetrySourcePath, setCursorTelemetrySourcePath] = useState<string | null>(null);
 	const [selectedZoomId, setSelectedZoomId] = useState<string | null>(null);
 	const [trimRegions, setTrimRegions] = useState<TrimRegion[]>([]);
-	const [selectedTrimId, setSelectedTrimId] = useState<string | null>(null);
 	const [clipRegions, setClipRegions] = useState<ClipRegion[]>([]);
 	const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
 	const [speedRegions, setSpeedRegions] = useState<SpeedRegion[]>([]);
-	const [selectedSpeedId, setSelectedSpeedId] = useState<string | null>(null);
 	const [annotationRegions, setAnnotationRegions] = useState<AnnotationRegion[]>([]);
 	const [selectedAnnotationId, setSelectedAnnotationId] = useState<string | null>(null);
 	const [audioRegions, setAudioRegions] = useState<AudioRegion[]>([]);
@@ -731,9 +728,7 @@ export default function VideoEditor() {
 	const projectBrowserFallbackTriggerRef = useRef<HTMLButtonElement | null>(null);
 	const projectNameInputRef = useRef<HTMLInputElement | null>(null);
 	const nextZoomIdRef = useRef(1);
-	const nextTrimIdRef = useRef(1);
 	const nextClipIdRef = useRef(1);
-	const nextSpeedIdRef = useRef(1);
 	const nextAudioIdRef = useRef(1);
 
 	const { shortcuts, isMac } = useShortcuts();
@@ -1567,9 +1562,7 @@ export default function VideoEditor() {
 			audioRegions,
 			autoCaptions,
 			selectedZoomId,
-			selectedTrimId,
 			selectedClipId,
-			selectedSpeedId,
 			selectedAnnotationId,
 			selectedAudioId,
 		};
@@ -1581,9 +1574,7 @@ export default function VideoEditor() {
 		audioRegions,
 		autoCaptions,
 		selectedZoomId,
-		selectedTrimId,
 		selectedClipId,
-		selectedSpeedId,
 		selectedAnnotationId,
 		selectedAudioId,
 	]);
@@ -1599,9 +1590,7 @@ export default function VideoEditor() {
 			setAudioRegions(cloned.audioRegions);
 			setAutoCaptions(cloned.autoCaptions);
 			setSelectedZoomId(cloned.selectedZoomId);
-			setSelectedTrimId(cloned.selectedTrimId);
 			setSelectedClipId(cloned.selectedClipId);
-			setSelectedSpeedId(cloned.selectedSpeedId);
 			setSelectedAnnotationId(cloned.selectedAnnotationId);
 			setSelectedAudioId(cloned.selectedAudioId);
 
@@ -1612,10 +1601,6 @@ export default function VideoEditor() {
 			nextClipIdRef.current = deriveNextId(
 				"clip",
 				cloned.clipRegions.map((region) => region.id),
-			);
-			nextSpeedIdRef.current = deriveNextId(
-				"speed",
-				cloned.speedRegions.map((region) => region.id),
 			);
 			nextAnnotationIdRef.current = deriveNextId(
 				"annotation",
@@ -1748,9 +1733,7 @@ export default function VideoEditor() {
 			setGifSizePreset(normalizedEditor.gifSizePreset);
 
 			setSelectedZoomId(null);
-			setSelectedTrimId(null);
 			setSelectedClipId(null);
-			setSelectedSpeedId(null);
 			setSelectedAnnotationId(null);
 			setSelectedAudioId(null);
 
@@ -1758,17 +1741,9 @@ export default function VideoEditor() {
 				"zoom",
 				normalizedEditor.zoomRegions.map((region) => region.id),
 			);
-			nextTrimIdRef.current = deriveNextId(
-				"trim",
-				normalizedEditor.trimRegions.map((region) => region.id),
-			);
 			nextClipIdRef.current = deriveNextId(
 				"clip",
 				normalizedEditor.clipRegions.map((region: ClipRegion) => region.id),
-			);
-			nextSpeedIdRef.current = deriveNextId(
-				"speed",
-				normalizedEditor.speedRegions.map((region) => region.id),
 			);
 			nextAudioIdRef.current = deriveNextId(
 				"audio",
@@ -2796,6 +2771,11 @@ export default function VideoEditor() {
 				const id = `clip-${nextClipIdRef.current++}`;
 				autoFullTrackClipIdRef.current = id;
 				autoFullTrackClipEndMsRef.current = totalMs;
+				if (trimRegions.length > 0) {
+					setClipRegions(trimsToClips(trimRegions, totalMs));
+					clipInitializedRef.current = true;
+					return;
+				}
 				setClipRegions([{ id, startMs: 0, endMs: totalMs, speed: 1 }]);
 			}
 			clipInitializedRef.current = true;
@@ -2812,7 +2792,7 @@ export default function VideoEditor() {
 
 		autoFullTrackClipEndMsRef.current = totalMs;
 		setClipRegions(extendedClipRegions);
-	}, [duration, clipRegions]);
+	}, [duration, clipRegions, trimRegions]);
 
 	// Derive trimRegions from clipRegions so export/playback pipelines stay unchanged
 	useEffect(() => {
@@ -2822,27 +2802,12 @@ export default function VideoEditor() {
 	}, [clipRegions, duration]);
 
 	const mapTimelineTimeToSourceTime = useCallback(
-		(timeMs: number) => {
-			for (const clip of clipRegions) {
-				if (timeMs < clip.startMs || timeMs > clip.endMs) continue;
-				const speed = Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
-				return Math.round(clip.startMs + (timeMs - clip.startMs) * speed);
-			}
-			return Math.round(timeMs);
-		},
+		(timeMs: number) => resolveTimelineTimeToSourceTime(timeMs, clipRegions),
 		[clipRegions],
 	);
 
 	const mapSourceTimeToTimelineTime = useCallback(
-		(timeMs: number) => {
-			for (const clip of clipRegions) {
-				const sourceEndMs = getClipSourceEndMs(clip);
-				if (timeMs < clip.startMs || timeMs > sourceEndMs) continue;
-				const speed = Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
-				return Math.round(clip.startMs + (timeMs - clip.startMs) / speed);
-			}
-			return Math.round(timeMs);
-		},
+		(timeMs: number) => resolveSourceTimeToTimelineTime(timeMs, clipRegions),
 		[clipRegions],
 	);
 
@@ -2910,7 +2875,6 @@ export default function VideoEditor() {
 		setSelectedZoomId(id);
 		if (id) {
 			setActiveEffectSection("zoom");
-			setSelectedTrimId(null);
 			setSelectedAnnotationId(null);
 			setSelectedAudioId(null);
 		} else {
@@ -2918,20 +2882,10 @@ export default function VideoEditor() {
 		}
 	}, []);
 
-	const handleSelectTrim = useCallback((id: string | null) => {
-		setSelectedTrimId(id);
-		if (id) {
-			setSelectedZoomId(null);
-			setSelectedAnnotationId(null);
-			setSelectedAudioId(null);
-		}
-	}, []);
-
 	const handleSelectAnnotation = useCallback((id: string | null) => {
 		setSelectedAnnotationId(id);
 		if (id) {
 			setSelectedZoomId(null);
-			setSelectedTrimId(null);
 			setSelectedAudioId(null);
 		}
 	}, []);
@@ -2954,7 +2908,6 @@ export default function VideoEditor() {
 			}
 			setZoomRegions((prev) => [...prev, newRegion]);
 			setSelectedZoomId(id);
-			setSelectedTrimId(null);
 			setSelectedAnnotationId(null);
 			extensionHost.emitEvent({
 				type: "timeline:region-added",
@@ -3048,19 +3001,6 @@ export default function VideoEditor() {
 		zoomRegions,
 	]);
 
-	const handleTrimAdded = useCallback((span: Span) => {
-		const id = `trim-${nextTrimIdRef.current++}`;
-		const newRegion: TrimRegion = {
-			id,
-			startMs: Math.round(span.start),
-			endMs: Math.round(span.end),
-		};
-		setTrimRegions((prev) => [...prev, newRegion]);
-		setSelectedTrimId(id);
-		setSelectedZoomId(null);
-		setSelectedAnnotationId(null);
-	}, []);
-
 	const handleZoomSpanChange = useCallback((id: string, span: Span) => {
 		setZoomRegions((prev) =>
 			prev.map((region) =>
@@ -3071,21 +3011,7 @@ export default function VideoEditor() {
 							endMs: Math.round(span.end),
 						}
 					: region,
-			),
-		);
-	}, []);
-
-	const handleTrimSpanChange = useCallback((id: string, span: Span) => {
-		setTrimRegions((prev) =>
-			prev.map((region) =>
-				region.id === id
-					? {
-							...region,
-							startMs: Math.round(span.start),
-							endMs: Math.round(span.end),
-						}
-					: region,
-			),
+				),
 		);
 	}, []);
 
@@ -3139,16 +3065,6 @@ export default function VideoEditor() {
 			extensionHost.emitEvent({ type: "timeline:region-removed", data: { id } });
 		},
 		[selectedZoomId],
-	);
-
-	const handleTrimDelete = useCallback(
-		(id: string) => {
-			setTrimRegions((prev) => prev.filter((region) => region.id !== id));
-			if (selectedTrimId === id) {
-				setSelectedTrimId(null);
-			}
-		},
-		[selectedTrimId],
 	);
 
 	const handleSelectClip = useCallback((id: string | null) => {
@@ -3329,62 +3245,11 @@ export default function VideoEditor() {
 		[clipRegions, selectedClipId],
 	);
 
-	const handleSelectSpeed = useCallback((id: string | null) => {
-		setSelectedSpeedId(id);
-		if (id) {
-			setSelectedZoomId(null);
-			setSelectedTrimId(null);
-			setSelectedAnnotationId(null);
-			setSelectedAudioId(null);
-		}
-	}, []);
-
-	const handleSpeedAdded = useCallback((span: Span) => {
-		const id = `speed-${nextSpeedIdRef.current++}`;
-		const newRegion: SpeedRegion = {
-			id,
-			startMs: Math.round(span.start),
-			endMs: Math.round(span.end),
-			speed: DEFAULT_PLAYBACK_SPEED,
-		};
-		setSpeedRegions((prev) => [...prev, newRegion]);
-		setSelectedSpeedId(id);
-		setSelectedZoomId(null);
-		setSelectedTrimId(null);
-		setSelectedAnnotationId(null);
-	}, []);
-
-	const handleSpeedSpanChange = useCallback((id: string, span: Span) => {
-		setSpeedRegions((prev) =>
-			prev.map((region) =>
-				region.id === id
-					? {
-							...region,
-							startMs: Math.round(span.start),
-							endMs: Math.round(span.end),
-						}
-					: region,
-			),
-		);
-	}, []);
-
-	const handleSpeedDelete = useCallback(
-		(id: string) => {
-			setSpeedRegions((prev) => prev.filter((region) => region.id !== id));
-			if (selectedSpeedId === id) {
-				setSelectedSpeedId(null);
-			}
-		},
-		[selectedSpeedId],
-	);
-
 	const handleSelectAudio = useCallback((id: string | null) => {
 		setSelectedAudioId(id);
 		if (id) {
 			setSelectedZoomId(null);
-			setSelectedTrimId(null);
 			setSelectedAnnotationId(null);
-			setSelectedSpeedId(null);
 		}
 	}, []);
 
@@ -3401,9 +3266,7 @@ export default function VideoEditor() {
 		setAudioRegions((prev) => [...prev, newRegion]);
 		setSelectedAudioId(id);
 		setSelectedZoomId(null);
-		setSelectedTrimId(null);
 		setSelectedAnnotationId(null);
-		setSelectedSpeedId(null);
 	}, []);
 
 	const handleAudioSpanChange = useCallback((id: string, span: Span, trackIndex?: number) => {
@@ -3455,18 +3318,6 @@ export default function VideoEditor() {
 		[selectedAudioId],
 	);
 
-	const handleSpeedChange = useCallback(
-		(speed: PlaybackSpeed) => {
-			if (!selectedSpeedId) return;
-			setSpeedRegions((prev) =>
-				prev.map((region) =>
-					region.id === selectedSpeedId ? { ...region, speed } : region,
-				),
-			);
-		},
-		[selectedSpeedId],
-	);
-
 	const handleAnnotationAdded = useCallback((span: Span, trackIndex = 0) => {
 		const id = `annotation-${nextAnnotationIdRef.current++}`;
 		const zIndex = nextAnnotationZIndexRef.current++; // Assign z-index based on creation order
@@ -3485,7 +3336,6 @@ export default function VideoEditor() {
 		setAnnotationRegions((prev) => [...prev, newRegion]);
 		setSelectedAnnotationId(id);
 		setSelectedZoomId(null);
-		setSelectedTrimId(null);
 	}, []);
 
 	const handleAnnotationSpanChange = useCallback(
@@ -3687,12 +3537,6 @@ export default function VideoEditor() {
 	}, [selectedZoomId, zoomRegions]);
 
 	useEffect(() => {
-		if (selectedTrimId && !trimRegions.some((region) => region.id === selectedTrimId)) {
-			setSelectedTrimId(null);
-		}
-	}, [selectedTrimId, trimRegions]);
-
-	useEffect(() => {
 		if (
 			selectedAnnotationId &&
 			!annotationRegions.some((region) => region.id === selectedAnnotationId)
@@ -3700,12 +3544,6 @@ export default function VideoEditor() {
 			setSelectedAnnotationId(null);
 		}
 	}, [selectedAnnotationId, annotationRegions]);
-
-	useEffect(() => {
-		if (selectedSpeedId && !speedRegions.some((region) => region.id === selectedSpeedId)) {
-			setSelectedSpeedId(null);
-		}
-	}, [selectedSpeedId, speedRegions]);
 
 	useEffect(() => {
 		if (selectedAudioId && !audioRegions.some((region) => region.id === selectedAudioId)) {
@@ -3891,7 +3729,7 @@ export default function VideoEditor() {
 	// Sync audio playback with video currentTime and isPlaying state
 	useEffect(() => {
 		const currentTimeMs = currentTime * 1000;
-		const activeSpeedRegion = speedRegions.find(
+		const activeSpeedRegion = effectiveSpeedRegions.find(
 			(region) => currentTimeMs >= region.startMs && currentTimeMs < region.endMs,
 		);
 		const targetPlaybackRate = activeSpeedRegion ? activeSpeedRegion.speed : 1;
@@ -3925,7 +3763,7 @@ export default function VideoEditor() {
 				}
 			}
 		}
-	}, [isPlaying, currentTime, audioRegions, speedRegions]);
+	}, [isPlaying, currentTime, audioRegions, effectiveSpeedRegions]);
 
 	useEffect(() => {
 		if (previewSourceAudioFallbackPaths.length === 0) {
@@ -3933,7 +3771,7 @@ export default function VideoEditor() {
 			return;
 		}
 
-		const activeSpeedRegion = speedRegions.find(
+		const activeSpeedRegion = effectiveSpeedRegions.find(
 			(region) => currentTime * 1000 >= region.startMs && currentTime * 1000 < region.endMs,
 		);
 		const targetPlaybackRate = activeSpeedRegion ? activeSpeedRegion.speed : 1;
@@ -3987,8 +3825,8 @@ export default function VideoEditor() {
 		isPlaying,
 		previewSourceAudioFallbackPaths,
 		sourceAudioFallbackStartDelayMsByPath,
-		speedRegions,
-	]);
+			effectiveSpeedRegions,
+		]);
 
 	const showExportSuccessToast = useCallback((filePath: string) => {
 		toast.success(`Exported successfully to ${filePath}`, {
@@ -5349,8 +5187,6 @@ export default function VideoEditor() {
 									selectedZoomId && handleZoomModeChange(mode)
 								}
 								onZoomDelete={handleZoomDelete}
-								selectedTrimId={selectedTrimId}
-								onTrimDelete={handleTrimDelete}
 								selectedClipId={selectedClipId}
 								selectedClipSpeed={
 									selectedClipId
@@ -5469,15 +5305,6 @@ export default function VideoEditor() {
 								}
 								onAnnotationBlurColorChange={handleAnnotationBlurColorChange}
 								onAnnotationDelete={handleAnnotationDelete}
-								selectedSpeedId={selectedSpeedId}
-								selectedSpeedValue={
-									selectedSpeedId
-										? (speedRegions.find((r) => r.id === selectedSpeedId)
-												?.speed ?? null)
-										: null
-								}
-								onSpeedChange={handleSpeedChange}
-								onSpeedDelete={handleSpeedDelete}
 							/>
 						)}
 					</div>
@@ -5885,22 +5712,11 @@ export default function VideoEditor() {
 						selectedZoomId={selectedZoomId}
 						onSelectZoom={handleSelectZoom}
 						trimRegions={trimRegions}
-						onTrimAdded={handleTrimAdded}
-						onTrimSpanChange={handleTrimSpanChange}
-						onTrimDelete={handleTrimDelete}
-						selectedTrimId={selectedTrimId}
-						onSelectTrim={handleSelectTrim}
 						clipRegions={clipRegions}
 						onClipSplit={handleClipSplit}
 						onClipSpanChange={handleClipSpanChange}
 						selectedClipId={selectedClipId}
 						onSelectClip={handleSelectClip}
-						speedRegions={speedRegions}
-						onSpeedAdded={handleSpeedAdded}
-						onSpeedSpanChange={handleSpeedSpanChange}
-						onSpeedDelete={handleSpeedDelete}
-						selectedSpeedId={selectedSpeedId}
-						onSelectSpeed={handleSelectSpeed}
 						audioRegions={audioRegions}
 						onAudioAdded={handleAudioAdded}
 						onAudioSpanChange={handleAudioSpanChange}

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -226,6 +226,57 @@ type SmokeExportConfig = {
 	fps?: ExportMp4FrameRate;
 };
 
+const EXPORT_BLOB_STREAM_CHUNK_BYTES = 16 * 1024 * 1024;
+
+async function streamExportBlobToTempFile(blob: Blob, extension: string): Promise<string | null> {
+	if (
+		typeof window === "undefined" ||
+		!window.electronAPI?.openExportStream ||
+		!window.electronAPI?.writeExportStreamChunk ||
+		!window.electronAPI?.closeExportStream
+	) {
+		return null;
+	}
+
+	const openResult = await window.electronAPI.openExportStream({ extension });
+	if (!openResult.success || !openResult.streamId || !openResult.tempPath) {
+		throw new Error(openResult.error || "Failed to open export stream");
+	}
+
+	const { streamId } = openResult;
+	let position = 0;
+
+	try {
+		while (position < blob.size) {
+			const chunk = blob.slice(position, position + EXPORT_BLOB_STREAM_CHUNK_BYTES);
+			const chunkBuffer = await chunk.arrayBuffer();
+			const writeResult = await window.electronAPI.writeExportStreamChunk(
+				streamId,
+				position,
+				new Uint8Array(chunkBuffer),
+			);
+			if (!writeResult.success) {
+				throw new Error(writeResult.error || "Failed to write export stream chunk");
+			}
+			position += chunkBuffer.byteLength;
+		}
+
+		const closeResult = await window.electronAPI.closeExportStream(streamId);
+		if (!closeResult.success || !closeResult.tempPath) {
+			throw new Error(closeResult.error || "Failed to close export stream");
+		}
+
+		return closeResult.tempPath;
+	} catch (error) {
+		try {
+			await window.electronAPI.closeExportStream(streamId, { abort: true });
+		} catch {
+			// Best-effort cleanup; preserve the original error below.
+		}
+		throw error;
+	}
+}
+
 type SaveProjectOptions = {
 	silent?: boolean;
 	remountPreviewAfterSave?: boolean;
@@ -1005,6 +1056,43 @@ export default function VideoEditor() {
 		return run;
 	}, []);
 
+	const saveBlobExport = useCallback(
+		async (blob: Blob, fileName: string, outputPath: string | null = null) => {
+			const extension = fileName.split(".").pop()?.toLowerCase() || "bin";
+
+			try {
+				const tempFilePath = await streamExportBlobToTempFile(blob, extension);
+				if (tempFilePath) {
+					return {
+						saveResult: await window.electronAPI.finalizeExportedVideo({
+							tempPath: tempFilePath,
+							fileName,
+							outputPath,
+						}),
+						pendingSave: {
+							fileName,
+							tempFilePath,
+						} satisfies PendingExportSave,
+					};
+				}
+			} catch (error) {
+				console.warn("[export] Falling back to in-memory blob save", error);
+			}
+
+			const arrayBuffer = await blob.arrayBuffer();
+			return {
+				saveResult: outputPath
+					? await window.electronAPI.writeExportedVideoToPath(arrayBuffer, outputPath)
+					: await window.electronAPI.saveExportedVideo(arrayBuffer, fileName),
+				pendingSave: {
+					fileName,
+					arrayBuffer,
+				} satisfies PendingExportSave,
+			};
+		},
+		[],
+	);
+
 	useEffect(() => {
 		return () => {
 			exporterRef.current?.cancel();
@@ -1398,6 +1486,7 @@ export default function VideoEditor() {
 				borderRadius,
 				padding,
 				frame,
+				cropRegion,
 				webcam,
 				zoomRegions,
 				trimRegions,
@@ -1446,6 +1535,7 @@ export default function VideoEditor() {
 			cursorSway,
 			borderRadius,
 			padding,
+			cropRegion,
 			webcam,
 			zoomRegions,
 			trimRegions,
@@ -4059,21 +4149,18 @@ export default function VideoEditor() {
 					const result = await gifExporter.export();
 
 					if (result.success && result.blob) {
-						const arrayBuffer = await result.blob.arrayBuffer();
 						const timestamp = Date.now();
 						const fileName = `export-${timestamp}.gif`;
 						markExportAsSaving();
 
-						const saveResult =
-							smokeExportConfig.enabled && smokeExportConfig.outputPath
-								? await window.electronAPI.writeExportedVideoToPath(
-										arrayBuffer,
-										smokeExportConfig.outputPath,
-									)
-								: await window.electronAPI.saveExportedVideo(arrayBuffer, fileName);
+						const { saveResult, pendingSave } = await saveBlobExport(
+							result.blob,
+							fileName,
+							smokeExportConfig.enabled ? smokeExportConfig.outputPath : null,
+						);
 
 						if (saveResult.canceled) {
-							pendingExportSaveRef.current = { arrayBuffer, fileName };
+							pendingExportSaveRef.current = pendingSave;
 							setHasPendingExportSave(true);
 							setExportError(
 								"Save dialog canceled. Click Save Again to save without re-rendering.",
@@ -4273,20 +4360,16 @@ export default function VideoEditor() {
 							});
 							pendingOnCancel = { fileName, tempFilePath: result.tempFilePath };
 						} else if (result.blob) {
-							// Legacy fallback: small exports may still surface a Blob (GIF,
-							// smoke tests in non-Electron environments, etc.).
-							const arrayBuffer = await result.blob.arrayBuffer();
-							saveResult =
-								smokeExportConfig.enabled && smokeExportConfig.outputPath
-									? await window.electronAPI.writeExportedVideoToPath(
-											arrayBuffer,
-											smokeExportConfig.outputPath,
-										)
-									: await window.electronAPI.saveExportedVideo(
-											arrayBuffer,
-											fileName,
-										);
-							pendingOnCancel = { fileName, arrayBuffer };
+							// Legacy fallback: some export paths still surface a Blob, but in
+							// Electron we stream it into a temp file first so save/finalize
+							// never requires a giant renderer ArrayBuffer.
+							const blobSave = await saveBlobExport(
+								result.blob,
+								fileName,
+								smokeExportConfig.enabled ? smokeExportConfig.outputPath : null,
+							);
+							saveResult = blobSave.saveResult;
+							pendingOnCancel = blobSave.pendingSave;
 						} else {
 							saveResult = { success: false, message: "Export produced no output" };
 							pendingOnCancel = { fileName };

--- a/src/components/video-editor/timeline/Row.tsx
+++ b/src/components/video-editor/timeline/Row.tsx
@@ -7,9 +7,24 @@ interface RowProps extends RowDefinition {
 	hint?: string;
 	isEmpty?: boolean;
 	labelColor?: string;
+	onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
+	onMouseMove?: React.MouseEventHandler<HTMLDivElement>;
+	onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
+	onClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 
-export default function Row({ id, children, label, hint, isEmpty, labelColor = "#666" }: RowProps) {
+export default function Row({
+	id,
+	children,
+	label,
+	hint,
+	isEmpty,
+	labelColor = "#666",
+	onMouseEnter,
+	onMouseMove,
+	onMouseLeave,
+	onClick,
+}: RowProps) {
 	const { setNodeRef, rowWrapperStyle, rowStyle } = useRow({ id });
 
 	return (
@@ -34,6 +49,10 @@ export default function Row({ id, children, label, hint, isEmpty, labelColor = "
 				ref={setNodeRef}
 				className="relative h-full min-h-[26px] overflow-hidden"
 				style={rowStyle}
+				onMouseEnter={onMouseEnter}
+				onMouseMove={onMouseMove}
+				onMouseLeave={onMouseLeave}
+				onClick={onClick}
 			>
 				{children}
 			</div>

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -1048,11 +1048,11 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			selectedZoomId,
 			onSelectZoom,
 			trimRegions = [],
-			onTrimAdded,
+			onTrimAdded: _onTrimAdded,
 			onTrimSpanChange,
-			onTrimDelete,
-			selectedTrimId,
-			onSelectTrim,
+			onTrimDelete: _onTrimDelete,
+			selectedTrimId: _selectedTrimId,
+			onSelectTrim: _onSelectTrim,
 			clipRegions = [],
 			onClipSplit,
 			onClipSpanChange,
@@ -1066,11 +1066,11 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			selectedAnnotationId,
 			onSelectAnnotation,
 			speedRegions = [],
-			onSpeedAdded,
+			onSpeedAdded: _onSpeedAdded,
 			onSpeedSpanChange,
-			onSpeedDelete,
-			selectedSpeedId,
-			onSelectSpeed,
+			onSpeedDelete: _onSpeedDelete,
+			selectedSpeedId: _selectedSpeedId,
+			onSelectSpeed: _onSelectSpeed,
 			audioRegions = [],
 			onAudioAdded,
 			onAudioSpanChange,
@@ -1212,13 +1212,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			onSelectZoom(null);
 		}, [selectedZoomId, onZoomDelete, onSelectZoom]);
 
-		// Delete selected trim item
-		const deleteSelectedTrim = useCallback(() => {
-			if (!selectedTrimId || !onTrimDelete || !onSelectTrim) return;
-			onTrimDelete(selectedTrimId);
-			onSelectTrim(null);
-		}, [selectedTrimId, onTrimDelete, onSelectTrim]);
-
 		const deleteSelectedClip = useCallback(() => {
 			if (!selectedClipId || !onClipDelete || !onSelectClip) return;
 			onClipDelete(selectedClipId);
@@ -1231,12 +1224,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			onSelectAnnotation(null);
 		}, [selectedAnnotationId, onAnnotationDelete, onSelectAnnotation]);
 
-		const deleteSelectedSpeed = useCallback(() => {
-			if (!selectedSpeedId || !onSpeedDelete || !onSelectSpeed) return;
-			onSpeedDelete(selectedSpeedId);
-			onSelectSpeed(null);
-		}, [selectedSpeedId, onSpeedDelete, onSelectSpeed]);
-
 		const deleteSelectedAudio = useCallback(() => {
 			if (!selectedAudioId || !onAudioDelete || !onSelectAudio) return;
 			onAudioDelete(selectedAudioId);
@@ -1245,42 +1232,32 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 
 		const clearSelectedBlocks = useCallback(() => {
 			onSelectZoom(null);
-			onSelectTrim?.(null);
 			onSelectClip?.(null);
 			onSelectAnnotation?.(null);
-			onSelectSpeed?.(null);
 			onSelectAudio?.(null);
 			setSelectAllBlocksActive(false);
 		}, [
 			onSelectAnnotation,
 			onSelectAudio,
 			onSelectClip,
-			onSelectSpeed,
-			onSelectTrim,
 			onSelectZoom,
 		]);
 
 		const hasAnyTimelineBlocks =
 			zoomRegions.length > 0 ||
-			trimRegions.length > 0 ||
 			clipRegions.length > 0 ||
 			annotationRegions.length > 0 ||
-			speedRegions.length > 0 ||
 			audioRegions.length > 0;
 
 		const deleteAllBlocks = useCallback(() => {
 			const zoomIds = zoomRegions.map((region) => region.id);
-			const trimIds = trimRegions.map((region) => region.id);
 			const clipIds = clipRegions.map((region) => region.id);
 			const annotationIds = annotationRegions.map((region) => region.id);
-			const speedIds = speedRegions.map((region) => region.id);
 			const audioIds = audioRegions.map((region) => region.id);
 
 			zoomIds.forEach((id) => onZoomDelete(id));
-			trimIds.forEach((id) => onTrimDelete?.(id));
 			clipIds.forEach((id) => onClipDelete?.(id));
 			annotationIds.forEach((id) => onAnnotationDelete?.(id));
-			speedIds.forEach((id) => onSpeedDelete?.(id));
 			audioIds.forEach((id) => onAudioDelete?.(id));
 
 			clearSelectedBlocks();
@@ -1293,11 +1270,7 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			onAnnotationDelete,
 			onAudioDelete,
 			onClipDelete,
-			onSpeedDelete,
-			onTrimDelete,
 			onZoomDelete,
-			speedRegions,
-			trimRegions,
 			zoomRegions,
 		]);
 
@@ -1307,14 +1280,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				onSelectZoom(id);
 			},
 			[onSelectZoom],
-		);
-
-		const handleSelectTrim = useCallback(
-			(id: string | null) => {
-				setSelectAllBlocksActive(false);
-				onSelectTrim?.(id);
-			},
-			[onSelectTrim],
 		);
 
 		const handleSelectClip = useCallback(
@@ -1331,14 +1296,6 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				onSelectAnnotation?.(id);
 			},
 			[onSelectAnnotation],
-		);
-
-		const handleSelectSpeed = useCallback(
-			(id: string | null) => {
-				setSelectAllBlocksActive(false);
-				onSelectSpeed?.(id);
-			},
-			[onSelectSpeed],
 		);
 
 		const handleSelectAudio = useCallback(
@@ -1519,17 +1476,26 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				}
 
 				const startPos = Math.max(0, Math.min(startMs, totalMs));
+				const activeClip = clipRegions.find(
+					(clip) => startPos >= clip.startMs && startPos < clip.endMs,
+				);
+				if (!activeClip) {
+					return false;
+				}
+
 				const sorted = [...zoomRegions].sort((a, b) => a.startMs - b.startMs);
 				const nextRegion = sorted.find((region) => region.startMs > startPos);
-				const gapToNext = nextRegion ? nextRegion.startMs - startPos : totalMs - startPos;
+				const gapToNextClipEdge = activeClip.endMs - startPos;
+				const gapToNextRegion = nextRegion ? nextRegion.startMs - startPos : gapToNextClipEdge;
+				const availableDuration = Math.min(gapToNextClipEdge, gapToNextRegion);
 
 				const isOverlapping = sorted.some(
 					(region) => startPos >= region.startMs && startPos < region.endMs,
 				);
 
-				return !isOverlapping && gapToNext >= defaultDuration;
+				return !isOverlapping && availableDuration >= defaultDuration;
 			},
-			[videoDuration, totalMs, zoomRegions, defaultRegionDurationMs],
+			[videoDuration, totalMs, zoomRegions, defaultRegionDurationMs, clipRegions],
 		);
 
 		const addZoomAtMs = useCallback(
@@ -1547,7 +1513,7 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				if (!canPlaceZoomAtMs(startPos)) {
 					toast.error("Cannot place zoom here", {
 						description:
-							"Zoom already exists at this location or not enough space available.",
+							"Place zooms inside a kept clip and leave enough room before the clip ends.",
 					});
 					return;
 				}
@@ -1649,92 +1615,12 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			handleSuggestZooms();
 		}, [autoSuggestZoomsTrigger, handleSuggestZooms, onAutoSuggestZoomsConsumed]);
 
-		const handleAddTrim = useCallback(() => {
-			if (!videoDuration || videoDuration === 0 || totalMs === 0 || !onTrimAdded) {
-				return;
-			}
-
-			const defaultDuration = Math.min(defaultRegionDurationMs, totalMs);
-			if (defaultDuration <= 0) {
-				return;
-			}
-
-			// Always place trim at playhead
-			const startPos = Math.max(0, Math.min(currentTimeMs, totalMs));
-			// Find the next trim region after the playhead
-			const sorted = [...trimRegions].sort((a, b) => a.startMs - b.startMs);
-			const nextRegion = sorted.find((region) => region.startMs > startPos);
-			const gapToNext = nextRegion ? nextRegion.startMs - startPos : totalMs - startPos;
-
-			// Check if playhead is inside any trim region
-			const isOverlapping = sorted.some(
-				(region) => startPos >= region.startMs && startPos < region.endMs,
-			);
-			if (isOverlapping || gapToNext <= 0) {
-				toast.error("Cannot place trim here", {
-					description:
-						"Trim already exists at this location or not enough space available.",
-				});
-				return;
-			}
-
-			const actualDuration = Math.min(defaultRegionDurationMs, gapToNext);
-			onTrimAdded({ start: startPos, end: startPos + actualDuration });
-		}, [
-			videoDuration,
-			totalMs,
-			currentTimeMs,
-			trimRegions,
-			onTrimAdded,
-			defaultRegionDurationMs,
-		]);
-
 		const handleSplitClip = useCallback(() => {
 			if (!videoDuration || videoDuration === 0 || totalMs === 0 || !onClipSplit) {
 				return;
 			}
 			onClipSplit(currentTimeMs);
 		}, [videoDuration, totalMs, currentTimeMs, onClipSplit]);
-
-		const handleAddSpeed = useCallback(() => {
-			if (!videoDuration || videoDuration === 0 || totalMs === 0 || !onSpeedAdded) {
-				return;
-			}
-
-			const defaultDuration = Math.min(defaultRegionDurationMs, totalMs);
-			if (defaultDuration <= 0) {
-				return;
-			}
-
-			// Always place speed region at playhead
-			const startPos = Math.max(0, Math.min(currentTimeMs, totalMs));
-			// Find the next speed region after the playhead
-			const sorted = [...speedRegions].sort((a, b) => a.startMs - b.startMs);
-			const nextRegion = sorted.find((region) => region.startMs > startPos);
-			const gapToNext = nextRegion ? nextRegion.startMs - startPos : totalMs - startPos;
-
-			// Check if playhead is inside any speed region
-			const isOverlapping = sorted.some(
-				(region) => startPos >= region.startMs && startPos < region.endMs,
-			);
-			if (isOverlapping || gapToNext <= 0) {
-				toast.error("Cannot place speed here", {
-					description:
-						"Speed region already exists at this location or not enough space available.",
-				});
-				return;
-			}
-
-			const actualDuration = Math.min(defaultRegionDurationMs, gapToNext);
-			onSpeedAdded({ start: startPos, end: startPos + actualDuration });
-		}, [
-			videoDuration,
-			totalMs,
-			currentTimeMs,
-			speedRegions,
-			onSpeedAdded,
-			defaultRegionDurationMs,
-		]);
 
 		const handleAddAudio = useCallback(
 			async (preferredTrackIndex?: number) => {
@@ -1918,17 +1804,11 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 				if (matchesShortcut(e, keyShortcuts.addZoom, isMac)) {
 					handleAddZoom();
 				}
-				if (matchesShortcut(e, keyShortcuts.addTrim, isMac)) {
-					handleAddTrim();
-				}
 				if (matchesShortcut(e, keyShortcuts.splitClip, isMac)) {
 					handleSplitClip();
 				}
 				if (matchesShortcut(e, keyShortcuts.addAnnotation, isMac)) {
 					handleAddAnnotation();
-				}
-				if (matchesShortcut(e, keyShortcuts.addSpeed, isMac)) {
-					handleAddSpeed();
 				}
 
 				// Tab: Cycle through overlapping annotations at current time
@@ -1970,14 +1850,10 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 						deleteSelectedKeyframe();
 					} else if (selectedZoomId) {
 						deleteSelectedZoom();
-					} else if (selectedTrimId) {
-						deleteSelectedTrim();
 					} else if (selectedClipId) {
 						deleteSelectedClip();
 					} else if (selectedAnnotationId) {
 						deleteSelectedAnnotation();
-					} else if (selectedSpeedId) {
-						deleteSelectedSpeed();
 					} else if (selectedAudioId) {
 						deleteSelectedAudio();
 					}
@@ -1988,24 +1864,18 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 		}, [
 			addKeyframe,
 			handleAddZoom,
-			handleAddTrim,
 			handleSplitClip,
 			handleAddAnnotation,
-			handleAddSpeed,
 			deleteAllBlocks,
 			deleteSelectedKeyframe,
 			deleteSelectedZoom,
-			deleteSelectedTrim,
 			deleteSelectedClip,
 			deleteSelectedAnnotation,
-			deleteSelectedSpeed,
 			deleteSelectedAudio,
 			selectedKeyframeId,
 			selectedZoomId,
-			selectedTrimId,
 			selectedClipId,
 			selectedAnnotationId,
-			selectedSpeedId,
 			selectedAudioId,
 			annotationRegions,
 			currentTimeMs,
@@ -2479,16 +2349,12 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 							onAddZoomAtMs={addZoomAtMs}
 							canPlaceZoomAtMs={canPlaceZoomAtMs}
 							onSelectZoom={handleSelectZoom}
-							onSelectTrim={handleSelectTrim}
 							onSelectClip={handleSelectClip}
 							onSelectAnnotation={handleSelectAnnotation}
-							onSelectSpeed={handleSelectSpeed}
 							onSelectAudio={handleSelectAudio}
 							selectedZoomId={selectedZoomId}
-							selectedTrimId={selectedTrimId}
 							selectedClipId={selectedClipId}
 							selectedAnnotationId={selectedAnnotationId}
-							selectedSpeedId={selectedSpeedId}
 							selectedAudioId={selectedAudioId}
 							selectAllBlocksActive={selectAllBlocksActive}
 							onClearBlockSelection={clearSelectedBlocks}

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -57,6 +57,7 @@ import type {
 } from "../types";
 import AudioWaveform from "./AudioWaveform";
 import Item from "./Item";
+import glassStyles from "./ItemGlass.module.css";
 import KeyframeMarkers from "./KeyframeMarkers";
 import Row from "./Row";
 import TimelineWrapper from "./TimelineWrapper";
@@ -410,11 +411,14 @@ function PlaybackCursor({
 				>
 					<div className="w-3 h-3 mx-auto mt-[2px] bg-[#2563EB] rotate-45 rounded-sm shadow-lg border border-foreground/20" />
 				</div>
-				{isDragging && (
-					<div className="absolute -top-6 left-1/2 -translate-x-1/2 px-1.5 py-0.5 rounded bg-black/80 text-[10px] text-white/90 font-medium tabular-nums whitespace-nowrap border border-foreground/10 shadow-lg pointer-events-none">
-						{formatPlayheadTime(clampedTime)}
-					</div>
-				)}
+				<div
+					className={cn(
+						"absolute -top-6 left-1/2 -translate-x-1/2 px-1.5 py-0.5 rounded bg-black/80 text-[10px] text-white/90 font-medium tabular-nums whitespace-nowrap border border-foreground/10 shadow-lg pointer-events-none",
+						isDragging ? "opacity-100" : "opacity-0",
+					)}
+				>
+					<span className="leading-5">{formatPlayheadTime(clampedTime)}</span>
+				</div>
 			</div>
 		</div>
 	);
@@ -594,6 +598,8 @@ function Timeline({
 	videoDurationMs,
 	currentTimeMs,
 	onSeek,
+	onAddZoomAtMs,
+	canPlaceZoomAtMs,
 	onSelectZoom,
 	onSelectTrim,
 	onSelectClip,
@@ -615,12 +621,14 @@ function Timeline({
 	videoDurationMs: number;
 	currentTimeMs: number;
 	onSeek?: (time: number) => void;
+	canPlaceZoomAtMs?: (startMs: number) => boolean;
 	onSelectZoom?: (id: string | null) => void;
 	onSelectTrim?: (id: string | null) => void;
 	onSelectClip?: (id: string | null) => void;
 	onSelectAnnotation?: (id: string | null) => void;
 	onSelectSpeed?: (id: string | null) => void;
 	onSelectAudio?: (id: string | null) => void;
+	onAddZoomAtMs?: (startMs: number) => void;
 	selectedZoomId: string | null;
 	selectedTrimId?: string | null;
 	selectedClipId?: string | null;
@@ -632,8 +640,13 @@ function Timeline({
 	keyframes?: { id: string; time: number }[];
 	audioPeaks?: AudioPeaksData | null;
 }) {
-	const { setTimelineRef, style, sidebarWidth, range, pixelsToValue } = useTimelineContext();
+	const { setTimelineRef, style, sidebarWidth, direction, range, valueToPixels, pixelsToValue } =
+		useTimelineContext();
 	const localTimelineRef = useRef<HTMLDivElement | null>(null);
+	const [isTimelineHovered, setIsTimelineHovered] = useState(false);
+	const [timelineHoverMs, setTimelineHoverMs] = useState<number | null>(null);
+	const [isZoomRowHovered, setIsZoomRowHovered] = useState(false);
+	const [zoomRowHoverMs, setZoomRowHoverMs] = useState<number | null>(null);
 
 	const setRefs = useCallback(
 		(node: HTMLDivElement | null) => {
@@ -712,6 +725,125 @@ function Timeline({
 	const timelineRowsMinHeightPx = getTimelineRowsMinHeightPx(timelineRowCount);
 	const timelineContentMinHeightPx = getTimelineContentMinHeightPx(timelineRowCount);
 	const timelineViewportStretchFactor = getTimelineViewportStretchFactor(timelineRowCount);
+	const sideProperty = direction === "rtl" ? "right" : "left";
+	const visibleDurationMs = Math.max(1, range.end - range.start);
+	const ghostStartMs =
+		zoomRowHoverMs === null ? null : Math.max(0, Math.min(zoomRowHoverMs, videoDurationMs));
+	const ghostDurationMs = Math.min(1000, videoDurationMs);
+	const ghostEndMs =
+		ghostStartMs === null
+			? null
+			: Math.max(ghostStartMs, Math.min(videoDurationMs, ghostStartMs + ghostDurationMs));
+	const ghostStartOffsetPx =
+		ghostStartMs === null ? 0 : valueToPixels(Math.max(0, ghostStartMs - range.start));
+	const ghostEndOffsetPx =
+		ghostEndMs === null ? 0 : valueToPixels(Math.max(0, ghostEndMs - range.start));
+	const ghostWidthPx = Math.max(18, ghostEndOffsetPx - ghostStartOffsetPx);
+	const timelineGhostOffsetPx =
+		timelineHoverMs === null ? 0 : valueToPixels(Math.max(0, timelineHoverMs - range.start));
+	const canShowGhostPlayhead = isTimelineHovered && timelineHoverMs !== null;
+	const canShowGhostZoom =
+		isZoomRowHovered &&
+		ghostStartMs !== null &&
+		(onAddZoomAtMs ? (canPlaceZoomAtMs?.(ghostStartMs) ?? true) : false);
+
+	const updateTimelineHoverTime = useCallback(
+		(clientX: number, rect: DOMRect) => {
+			const contentWidth = Math.max(1, rect.width - sidebarWidth);
+
+			const contentX =
+				direction === "rtl"
+					? rect.right - sidebarWidth - clientX
+					: clientX - rect.left - sidebarWidth;
+			const clampedX = Math.max(0, Math.min(contentX, contentWidth));
+			const ratio = clampedX / contentWidth;
+			const nextMs = range.start + ratio * visibleDurationMs;
+			setTimelineHoverMs(Math.max(0, Math.min(nextMs, videoDurationMs)));
+		},
+		[direction, range.start, sidebarWidth, videoDurationMs, visibleDurationMs],
+	);
+
+	const handleTimelineMouseEnter = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>) => {
+			setIsTimelineHovered(true);
+			updateTimelineHoverTime(event.clientX, event.currentTarget.getBoundingClientRect());
+		},
+		[updateTimelineHoverTime],
+	);
+
+	const handleTimelineMouseMove = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>) => {
+			if (!isTimelineHovered) {
+				setIsTimelineHovered(true);
+			}
+			updateTimelineHoverTime(event.clientX, event.currentTarget.getBoundingClientRect());
+		},
+		[isTimelineHovered, updateTimelineHoverTime],
+	);
+
+	const handleTimelineMouseLeave = useCallback(() => {
+		setIsTimelineHovered(false);
+		setTimelineHoverMs(null);
+		setIsZoomRowHovered(false);
+		setZoomRowHoverMs(null);
+	}, []);
+
+	const updateZoomRowHoverTime = useCallback(
+		(clientX: number, rect: DOMRect) => {
+			if (rect.width <= 0) {
+				return;
+			}
+
+			const position =
+				direction === "rtl"
+					? Math.max(0, Math.min(rect.right - clientX, rect.width))
+					: Math.max(0, Math.min(clientX - rect.left, rect.width));
+			const ratio = position / rect.width;
+			const nextMs = range.start + ratio * visibleDurationMs;
+			setZoomRowHoverMs(Math.max(0, Math.min(nextMs, videoDurationMs)));
+		},
+		[direction, range.start, videoDurationMs, visibleDurationMs],
+	);
+
+	const handleZoomRowMouseEnter = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>) => {
+			setIsZoomRowHovered(true);
+			updateZoomRowHoverTime(event.clientX, event.currentTarget.getBoundingClientRect());
+		},
+		[updateZoomRowHoverTime],
+	);
+
+	const handleZoomRowMouseMove = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>) => {
+			if (!isZoomRowHovered) {
+				setIsZoomRowHovered(true);
+			}
+			updateZoomRowHoverTime(event.clientX, event.currentTarget.getBoundingClientRect());
+		},
+		[isZoomRowHovered, updateZoomRowHoverTime],
+	);
+
+	const handleZoomRowMouseLeave = useCallback(() => {
+		setIsZoomRowHovered(false);
+		setZoomRowHoverMs(null);
+	}, []);
+
+	const handleZoomRowClick = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>) => {
+			event.stopPropagation();
+			if (!onAddZoomAtMs || zoomRowHoverMs === null) {
+				return;
+			}
+
+			const startMs = Math.max(0, Math.min(zoomRowHoverMs, videoDurationMs));
+			if (canPlaceZoomAtMs && !canPlaceZoomAtMs(startMs)) {
+				return;
+			}
+
+			onAddZoomAtMs(startMs);
+		},
+		[canPlaceZoomAtMs, onAddZoomAtMs, videoDurationMs, zoomRowHoverMs],
+	);
 
 	return (
 		<div
@@ -722,6 +854,9 @@ function Timeline({
 			}}
 			className="select-none bg-editor-bg relative cursor-pointer group flex flex-col"
 			onClick={handleTimelineClick}
+			onMouseEnter={handleTimelineMouseEnter}
+			onMouseMove={handleTimelineMouseMove}
+			onMouseLeave={handleTimelineMouseLeave}
 		>
 			<div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--foreground)/0.03)_1px,transparent_1px)] bg-[length:20px_100%] pointer-events-none" />
 			<TimelineAxis videoDurationMs={videoDurationMs} currentTimeMs={currentTimeMs} />
@@ -732,6 +867,20 @@ function Timeline({
 				timelineRef={localTimelineRef}
 				keyframes={keyframes}
 			/>
+			{canShowGhostPlayhead && (
+				<div
+					className="absolute top-0 bottom-0 z-[45] pointer-events-none"
+					style={{
+						[sideProperty === "right" ? "marginRight" : "marginLeft"]:
+							`${sidebarWidth - 1}px`,
+					}}
+				>
+					<div
+						className="absolute top-0 bottom-0 w-px bg-foreground/35"
+						style={{ [sideProperty]: `${timelineGhostOffsetPx}px` }}
+					/>
+				</div>
+			)}
 
 			<div
 				className="relative z-10 flex flex-1 min-h-0 flex-col"
@@ -755,7 +904,47 @@ function Timeline({
 					))}
 				</Row>
 
-				<Row id={ZOOM_ROW_ID} isEmpty={zoomItems.length === 0} hint="Press Z to add zoom">
+				<Row
+					id={ZOOM_ROW_ID}
+					isEmpty={zoomItems.length === 0}
+					onMouseEnter={handleZoomRowMouseEnter}
+					onMouseMove={handleZoomRowMouseMove}
+					onMouseLeave={handleZoomRowMouseLeave}
+					onClick={handleZoomRowClick}
+				>
+					{canShowGhostZoom && ghostStartMs !== null && (
+						<div className="absolute inset-0 z-[3] pointer-events-none">
+							<div
+								className="absolute top-1/2 -translate-y-1/2 h-[85%] min-h-[22px]"
+								style={
+									direction === "rtl"
+										? {
+												right: `${ghostStartOffsetPx}px`,
+												width: `${ghostWidthPx}px`,
+											}
+										: {
+												left: `${ghostStartOffsetPx}px`,
+												width: `${ghostWidthPx}px`,
+											}
+								}
+							>
+								<div
+									className={cn(
+										glassStyles.glassPurple,
+										"w-full h-full overflow-hidden flex items-center justify-center cursor-default relative opacity-80",
+									)}
+								>
+									<div className={cn(glassStyles.zoomEndCap, glassStyles.left)} />
+									<div
+										className={cn(glassStyles.zoomEndCap, glassStyles.right)}
+									/>
+									<div className="relative z-10 inline-flex h-4 w-4 items-center justify-center rounded-full border border-white/45 bg-white/15 text-white">
+										<Plus className="h-2.5 w-2.5" />
+									</div>
+								</div>
+							</div>
+						</div>
+					)}
 					{zoomItems.map((item) => (
 						<Item
 							id={item.id}
@@ -1318,45 +1507,63 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 		// scaling them with the full recording length.
 		const defaultRegionDurationMs = useMemo(() => Math.min(1000, totalMs), [totalMs]);
 
+		const canPlaceZoomAtMs = useCallback(
+			(startMs: number) => {
+				if (!videoDuration || videoDuration === 0 || totalMs === 0) {
+					return false;
+				}
+
+				const defaultDuration = Math.min(defaultRegionDurationMs, totalMs);
+				if (defaultDuration <= 0) {
+					return false;
+				}
+
+				const startPos = Math.max(0, Math.min(startMs, totalMs));
+				const sorted = [...zoomRegions].sort((a, b) => a.startMs - b.startMs);
+				const nextRegion = sorted.find((region) => region.startMs > startPos);
+				const gapToNext = nextRegion ? nextRegion.startMs - startPos : totalMs - startPos;
+
+				const isOverlapping = sorted.some(
+					(region) => startPos >= region.startMs && startPos < region.endMs,
+				);
+
+				return !isOverlapping && gapToNext >= defaultDuration;
+			},
+			[videoDuration, totalMs, zoomRegions, defaultRegionDurationMs],
+		);
+
+		const addZoomAtMs = useCallback(
+			(startMs: number) => {
+				if (!videoDuration || videoDuration === 0 || totalMs === 0) {
+					return;
+				}
+
+				const defaultDuration = Math.min(defaultRegionDurationMs, totalMs);
+				if (defaultDuration <= 0) {
+					return;
+				}
+
+				const startPos = Math.max(0, Math.min(startMs, totalMs));
+				if (!canPlaceZoomAtMs(startPos)) {
+					toast.error("Cannot place zoom here", {
+						description:
+							"Zoom already exists at this location or not enough space available.",
+					});
+					return;
+				}
+
+				onZoomAdded({ start: startPos, end: startPos + defaultDuration });
+			},
+			[videoDuration, totalMs, onZoomAdded, defaultRegionDurationMs, canPlaceZoomAtMs],
+		);
+
 		const handleAddZoom = useCallback(() => {
 			if (!videoDuration || videoDuration === 0 || totalMs === 0) {
 				return;
 			}
 
-			const defaultDuration = Math.min(defaultRegionDurationMs, totalMs);
-			if (defaultDuration <= 0) {
-				return;
-			}
-
-			// Always place zoom at playhead
-			const startPos = Math.max(0, Math.min(currentTimeMs, totalMs));
-			// Find the next zoom region after the playhead
-			const sorted = [...zoomRegions].sort((a, b) => a.startMs - b.startMs);
-			const nextRegion = sorted.find((region) => region.startMs > startPos);
-			const gapToNext = nextRegion ? nextRegion.startMs - startPos : totalMs - startPos;
-
-			// Check if playhead is inside any zoom region
-			const isOverlapping = sorted.some(
-				(region) => startPos >= region.startMs && startPos < region.endMs,
-			);
-			if (isOverlapping || gapToNext <= 0) {
-				toast.error("Cannot place zoom here", {
-					description:
-						"Zoom already exists at this location or not enough space available.",
-				});
-				return;
-			}
-
-			const actualDuration = Math.min(defaultRegionDurationMs, gapToNext);
-			onZoomAdded({ start: startPos, end: startPos + actualDuration });
-		}, [
-			videoDuration,
-			totalMs,
-			currentTimeMs,
-			zoomRegions,
-			onZoomAdded,
-			defaultRegionDurationMs,
-		]);
+			addZoomAtMs(currentTimeMs);
+		}, [addZoomAtMs, currentTimeMs, totalMs, videoDuration]);
 
 		const handleSuggestZooms = useCallback(() => {
 			if (!videoDuration || videoDuration === 0 || totalMs === 0) {
@@ -2269,6 +2476,8 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 							videoDurationMs={totalMs}
 							currentTimeMs={currentTimeMs}
 							onSeek={onSeek}
+							onAddZoomAtMs={addZoomAtMs}
+							canPlaceZoomAtMs={canPlaceZoomAtMs}
 							onSelectZoom={handleSelectZoom}
 							onSelectTrim={handleSelectTrim}
 							onSelectClip={handleSelectClip}

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -836,13 +836,9 @@ function Timeline({
 			}
 
 			const startMs = Math.max(0, Math.min(zoomRowHoverMs, videoDurationMs));
-			if (canPlaceZoomAtMs && !canPlaceZoomAtMs(startMs)) {
-				return;
-			}
-
 			onAddZoomAtMs(startMs);
 		},
-		[canPlaceZoomAtMs, onAddZoomAtMs, videoDurationMs, zoomRowHoverMs],
+		[onAddZoomAtMs, videoDurationMs, zoomRowHoverMs],
 	);
 
 	return (

--- a/src/components/video-editor/types.test.ts
+++ b/src/components/video-editor/types.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { extendAutoFullTrackClip } from "./types";
+import {
+	extendAutoFullTrackClip,
+	findClipAtTimelineTime,
+	mapSourceTimeToTimelineTime,
+	mapTimelineTimeToSourceTime,
+} from "./types";
 
 describe("extendAutoFullTrackClip", () => {
 	it("extends the default full-track clip when metadata duration grows", () => {
@@ -103,5 +108,37 @@ describe("extendAutoFullTrackClip", () => {
 				8_000,
 			),
 		).toBeNull();
+	});
+});
+
+describe("clip timeline mapping", () => {
+	const clips = [
+		{ id: "clip-1", startMs: 0, endMs: 4_000, speed: 1 },
+		{ id: "clip-2", startMs: 6_000, endMs: 8_000, speed: 2 },
+	];
+
+	it("maps kept timeline time into source time", () => {
+		expect(mapTimelineTimeToSourceTime(1_500, clips)).toBe(1_500);
+		expect(mapTimelineTimeToSourceTime(7_000, clips)).toBe(8_000);
+	});
+
+	it("snaps timeline gaps to the nearest clip edge", () => {
+		expect(mapTimelineTimeToSourceTime(4_300, clips)).toBe(4_000);
+		expect(mapTimelineTimeToSourceTime(5_700, clips)).toBe(6_000);
+	});
+
+	it("maps kept source time back into timeline time", () => {
+		expect(mapSourceTimeToTimelineTime(1_500, clips)).toBe(1_500);
+		expect(mapSourceTimeToTimelineTime(8_000, clips)).toBe(7_000);
+	});
+
+	it("snaps removed source gaps to the nearest kept boundary", () => {
+		expect(mapSourceTimeToTimelineTime(4_200, clips)).toBe(4_000);
+		expect(mapSourceTimeToTimelineTime(5_900, clips)).toBe(6_000);
+	});
+
+	it("finds clips only inside visible kept spans", () => {
+		expect(findClipAtTimelineTime(500, clips)?.id).toBe("clip-1");
+		expect(findClipAtTimelineTime(5_000, clips)).toBeNull();
 	});
 });

--- a/src/components/video-editor/types.test.ts
+++ b/src/components/video-editor/types.test.ts
@@ -122,6 +122,12 @@ describe("clip timeline mapping", () => {
 		expect(mapTimelineTimeToSourceTime(7_000, clips)).toBe(8_000);
 	});
 
+	it("treats clip ends as exclusive at cut boundaries", () => {
+		expect(mapTimelineTimeToSourceTime(4_000, clips)).toBe(4_000);
+		expect(mapSourceTimeToTimelineTime(4_000, clips)).toBe(4_000);
+		expect(findClipAtTimelineTime(4_000, clips)).toBeNull();
+	});
+
 	it("snaps timeline gaps to the nearest clip edge", () => {
 		expect(mapTimelineTimeToSourceTime(4_300, clips)).toBe(4_000);
 		expect(mapTimelineTimeToSourceTime(5_700, clips)).toBe(6_000);

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -194,7 +194,7 @@ export function mapTimelineTimeToSourceTime(timeMs: number, clips: ClipRegion[])
 	const sortedClips = sortClipRegions(clips);
 
 	for (const clip of sortedClips) {
-		if (roundedTimeMs < clip.startMs || roundedTimeMs > clip.endMs) {
+		if (roundedTimeMs < clip.startMs || roundedTimeMs >= clip.endMs) {
 			continue;
 		}
 
@@ -216,7 +216,7 @@ export function mapSourceTimeToTimelineTime(timeMs: number, clips: ClipRegion[])
 
 	for (const clip of sortedClips) {
 		const sourceEndMs = getClipSourceEndMs(clip);
-		if (roundedTimeMs < clip.startMs || roundedTimeMs > sourceEndMs) {
+		if (roundedTimeMs < clip.startMs || roundedTimeMs >= sourceEndMs) {
 			continue;
 		}
 

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -155,6 +155,92 @@ export function getClipSourceEndMs(clip: ClipRegion): number {
 	return Math.round(clip.startMs + displayDurationMs * speed);
 }
 
+export function sortClipRegions(clips: ClipRegion[]): ClipRegion[] {
+	return [...clips].sort((left, right) => left.startMs - right.startMs);
+}
+
+function getSafeClipSpeed(clip: ClipRegion) {
+	return Number.isFinite(clip.speed) && clip.speed > 0 ? clip.speed : 1;
+}
+
+function clampToNearestClipBoundary(
+	timeMs: number,
+	clips: ClipRegion[],
+	kind: "timeline" | "source",
+) {
+	let nearestTimeMs = Math.round(timeMs);
+	let nearestDistance = Number.POSITIVE_INFINITY;
+
+	for (const clip of clips) {
+		const boundaries =
+			kind === "timeline"
+				? [clip.startMs, clip.endMs]
+				: [clip.startMs, getClipSourceEndMs(clip)];
+
+		for (const boundary of boundaries) {
+			const distance = Math.abs(timeMs - boundary);
+			if (distance < nearestDistance) {
+				nearestDistance = distance;
+				nearestTimeMs = Math.round(boundary);
+			}
+		}
+	}
+
+	return nearestTimeMs;
+}
+
+export function mapTimelineTimeToSourceTime(timeMs: number, clips: ClipRegion[]): number {
+	const roundedTimeMs = Math.round(timeMs);
+	const sortedClips = sortClipRegions(clips);
+
+	for (const clip of sortedClips) {
+		if (roundedTimeMs < clip.startMs || roundedTimeMs > clip.endMs) {
+			continue;
+		}
+
+		return Math.round(
+			clip.startMs + (roundedTimeMs - clip.startMs) * getSafeClipSpeed(clip),
+		);
+	}
+
+	if (sortedClips.length === 0) {
+		return roundedTimeMs;
+	}
+
+	return clampToNearestClipBoundary(roundedTimeMs, sortedClips, "timeline");
+}
+
+export function mapSourceTimeToTimelineTime(timeMs: number, clips: ClipRegion[]): number {
+	const roundedTimeMs = Math.round(timeMs);
+	const sortedClips = sortClipRegions(clips);
+
+	for (const clip of sortedClips) {
+		const sourceEndMs = getClipSourceEndMs(clip);
+		if (roundedTimeMs < clip.startMs || roundedTimeMs > sourceEndMs) {
+			continue;
+		}
+
+		return Math.round(
+			clip.startMs + (roundedTimeMs - clip.startMs) / getSafeClipSpeed(clip),
+		);
+	}
+
+	if (sortedClips.length === 0) {
+		return roundedTimeMs;
+	}
+
+	return clampToNearestClipBoundary(roundedTimeMs, sortedClips, "source");
+}
+
+export function findClipAtTimelineTime(timeMs: number, clips: ClipRegion[]): ClipRegion | null {
+	const roundedTimeMs = Math.round(timeMs);
+	return (
+		sortClipRegions(clips).find(
+			(clip) => roundedTimeMs >= clip.startMs && roundedTimeMs < clip.endMs,
+		) ?? null
+	);
+}
+
 export function extendAutoFullTrackClip(
 	clips: ClipRegion[],
 	autoClipId: string | null,

--- a/src/components/video-editor/videoPlayback/videoEventHandlers.test.ts
+++ b/src/components/video-editor/videoPlayback/videoEventHandlers.test.ts
@@ -151,4 +151,29 @@ describe("createVideoEventHandlers", () => {
 		handlers.dispose();
 		expect(cancelVideoFrameCallback).toHaveBeenCalledWith(23);
 	});
+
+	it("skips removed footage after a paused seek", () => {
+		const video = createMockVideo({
+			currentTime: 1.25,
+			paused: true,
+		});
+		const onTimeUpdate = vi.fn();
+		const handlers = createVideoEventHandlers({
+			video,
+			isSeekingRef: createMutableRef(true),
+			isPlayingRef: createMutableRef(false),
+			allowPlaybackRef: createMutableRef(true),
+			currentTimeRef: createMutableRef(0),
+			timeUpdateAnimationRef: createMutableRef<number | null>(null),
+			onPlayStateChange: vi.fn(),
+			onTimeUpdate,
+			trimRegionsRef: createMutableRef([{ id: "trim-1", startMs: 1000, endMs: 2000 }]),
+			speedRegionsRef: createMutableRef([]),
+		});
+
+		handlers.handleSeeked();
+
+		expect(video.currentTime).toBe(2);
+		expect(onTimeUpdate).toHaveBeenLastCalledWith(2);
+	});
 });

--- a/src/components/video-editor/videoPlayback/videoEventHandlers.ts
+++ b/src/components/video-editor/videoPlayback/videoEventHandlers.ts
@@ -167,8 +167,8 @@ export function createVideoEventHandlers(params: VideoEventHandlersParams) {
 		const currentTimeMs = video.currentTime * 1000;
 		const activeTrimRegion = findActiveTrimRegion(currentTimeMs);
 
-		// If we seeked into a trim region while playing, skip to the end
-		if (activeTrimRegion && isPlayingRef.current && !video.paused) {
+		// Never leave the preview parked on removed footage after a seek.
+		if (activeTrimRegion) {
 			skipPastTrimRegion(activeTrimRegion);
 		} else {
 			emitTime(video.currentTime);

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,8 +1,6 @@
 export const SHORTCUT_ACTIONS = [
 	"addZoom",
-	"addTrim",
 	"splitClip",
-	"addSpeed",
 	"addAnnotation",
 	"addKeyframe",
 	"deleteSelected",
@@ -76,9 +74,7 @@ export function findConflict(
 
 export const DEFAULT_SHORTCUTS: ShortcutsConfig = {
 	addZoom: { key: "z" },
-	addTrim: { key: "t" },
 	splitClip: { key: "c" },
-	addSpeed: { key: "s" },
 	addAnnotation: { key: "a" },
 	addKeyframe: { key: "f" },
 	deleteSelected: { key: "d", ctrl: true },
@@ -87,9 +83,7 @@ export const DEFAULT_SHORTCUTS: ShortcutsConfig = {
 
 export const SHORTCUT_LABELS: Record<ShortcutAction, string> = {
 	addZoom: "Add Zoom",
-	addTrim: "Add Trim",
 	splitClip: "Split Clip",
-	addSpeed: "Add Speed",
 	addAnnotation: "Add Annotation",
 	addKeyframe: "Add Keyframe",
 	deleteSelected: "Delete Selected",


### PR DESCRIPTION
## Summary
This PR removes the most confusing clip/trim split-brain paths so the editor behaves more consistently as a clip-first workflow.

## What changed
- centralized clip timeline/source time mapping helpers and used them for scrubbing and timeline conversions
- migrated trim-only legacy projects into clip regions when duration becomes available
- removed trim and speed-region authoring shortcuts plus the hidden timeline actions that still created them
- made zoom placement require a kept clip span with enough room before the clip ends
- made seek handling skip removed footage even when playback is paused
- added focused tests for the new mapping helpers and paused seek behavior

## Why
The clip feature still exposed legacy trim and speed-region behaviors in shortcuts, playback, and timeline interactions. That made the product feel unpredictable: users could land in removed space, trigger hidden edit modes, or work with timeline semantics that did not match what the UI emphasized.

## Impact
This keeps the existing clip cleanup behavior you wanted, while reducing the unintuitive parts around seeking, gap handling, and hidden legacy editing paths.

## Validation
- `npx vitest run src/components/video-editor/types.test.ts src/components/video-editor/videoPlayback/videoEventHandlers.test.ts`
- `npx tsc --noEmit`

## Notes
The local worktree had unrelated in-flight changes, so this PR is intentionally scoped to the staged clip/timeline files only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory-optimized video export streaming with a fallback for legacy saves
  * Visual ghost playhead and ghost zoom preview; improved zoom placement validation and error feedback
  * Row-level mouse interaction handlers for timeline rows

* **Bug Fixes**
  * Audio stays in sync with clip speed changes
  * Playback now skips removed footage after paused seeks

* **Refactor**
  * Timeline selection and clip/time mapping reworked for more accurate undo/restore

* **Tests**
  * Added mapping and playback unit tests

* **Chores**
  * Updated keyboard shortcuts (added clip split; removed trim/speed actions)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->