### PR TITLE
fix(windows): honor selected window in native capture

### DIFF
--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -236,23 +236,36 @@ export function registerRecordingHandlers(
 					let systemAudioPath: string | null = null;
 					let microphonePath: string | null = null;
 					let orphanedMicAudioPath: string | null = null;
-					const resolvedDisplay = resolveWindowsCaptureDisplay(
-						source,
-						getScreen().getAllDisplays(),
-						getScreen().getPrimaryDisplay(),
-					);
-					const displayBounds = resolvedDisplay.bounds;
+					const isWindowSource = Boolean(source?.id?.startsWith("window:"));
+					const parsedWindowHandle = isWindowSource ? parseWindowId(source?.id) : null;
+					let resolvedDisplay: ReturnType<typeof resolveWindowsCaptureDisplay> | null = null;
+					const displayBounds =
+						parsedWindowHandle && parsedWindowHandle > 0
+							? null
+							: (() => {
+								resolvedDisplay = resolveWindowsCaptureDisplay(
+									source,
+									getScreen().getAllDisplays(),
+									getScreen().getPrimaryDisplay(),
+								);
+								return resolvedDisplay.bounds;
+							})();
 					setWindowsOrphanedMicAudioPath(null);
 
 					const config: Record<string, unknown> = {
 						outputPath,
 						fps: 60,
-						displayId: resolvedDisplay.displayId,
-						displayX: Math.round(resolvedDisplay.bounds.x),
-						displayY: Math.round(resolvedDisplay.bounds.y),
-						displayW: Math.round(resolvedDisplay.bounds.width),
-						displayH: Math.round(resolvedDisplay.bounds.height),
 					};
+
+					if (parsedWindowHandle && parsedWindowHandle > 0) {
+						config.windowHandle = parsedWindowHandle;
+					} else if (resolvedDisplay) {
+						config.displayId = resolvedDisplay.displayId;
+						config.displayX = Math.round(resolvedDisplay.bounds.x);
+						config.displayY = Math.round(resolvedDisplay.bounds.y);
+						config.displayW = Math.round(resolvedDisplay.bounds.width);
+						config.displayH = Math.round(resolvedDisplay.bounds.height);
+					}
 
 					if (options?.capturesSystemAudio) {
 						systemAudioPath = path.join(


### PR DESCRIPTION
## Description
Fixes Windows native capture so selecting a `window:*` source records that window instead of falling back to full-display capture.

## Motivation
The native WGC helper supports window capture via `windowHandle`, but the Windows start path was always building display-target config. This caused selected window sources to record the monitor.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Closes #420

## Testing Guide
1. Build and run Windows x64 package.
2. In source selector, pick a `window:*` source and start recording.
3. Confirm output captures only that window.
4. Pick a `screen:*` source and confirm full-display capture still works.

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows screen recording to correctly handle both window and display capture sources with accurate geometry information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->