### PR TITLE
fix(export): preserve duration with short video-stream metadata

### DIFF
--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -14,6 +14,7 @@ import type {
 	ZoomTransitionEasing,
 } from "@/components/video-editor/types";
 import { extensionHost } from "@/lib/extensions";
+import { getEffectiveVideoStreamDurationSeconds } from "@/lib/mediaTiming";
 import { AudioProcessor, isAacAudioEncodingSupported } from "./audioEncoder";
 import { normalizeLightningRuntimePlatform } from "./backendPolicy";
 import { buildEditedTrackSourceSegments, classifyEditedTrackStrategy } from "./editedTrackStrategy";
@@ -787,7 +788,12 @@ export class ModernVideoExporter {
 		) {
 			const sourceDurationMs = Math.max(
 				0,
-				Math.round((videoInfo.streamDuration ?? videoInfo.duration) * 1000),
+				Math.round(
+					getEffectiveVideoStreamDurationSeconds({
+						duration: videoInfo.duration,
+						streamDuration: videoInfo.streamDuration,
+					}) * 1000,
+				),
 			);
 			const trimRegions = this.config.trimRegions ?? [];
 			const strategy =
@@ -846,7 +852,12 @@ export class ModernVideoExporter {
 		if ((this.config.trimRegions ?? []).length > 0) {
 			const sourceDurationMs = Math.max(
 				0,
-				Math.round((videoInfo.streamDuration ?? videoInfo.duration) * 1000),
+				Math.round(
+					getEffectiveVideoStreamDurationSeconds({
+						duration: videoInfo.duration,
+						streamDuration: videoInfo.streamDuration,
+					}) * 1000,
+				),
 			);
 			const trimSegments = this.buildNativeTrimSegments(sourceDurationMs);
 			if (trimSegments.length === 0) {

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -13,6 +13,7 @@ import type {
 	ZoomRegion,
 	ZoomTransitionEasing,
 } from "@/components/video-editor/types";
+import { getEffectiveVideoStreamDurationSeconds } from "@/lib/mediaTiming";
 import { AudioProcessor, isAacAudioEncodingSupported } from "./audioEncoder";
 import { buildEditedTrackSourceSegments, classifyEditedTrackStrategy } from "./editedTrackStrategy";
 import {
@@ -544,7 +545,12 @@ export class VideoExporter {
 		) {
 			const sourceDurationMs = Math.max(
 				0,
-				Math.round((videoInfo.streamDuration ?? videoInfo.duration) * 1000),
+				Math.round(
+					getEffectiveVideoStreamDurationSeconds({
+						duration: videoInfo.duration,
+						streamDuration: videoInfo.streamDuration,
+					}) * 1000,
+				),
 			);
 			const trimRegions = this.config.trimRegions ?? [];
 			const strategy =
@@ -603,7 +609,12 @@ export class VideoExporter {
 		if ((this.config.trimRegions ?? []).length > 0) {
 			const sourceDurationMs = Math.max(
 				0,
-				Math.round((videoInfo.streamDuration ?? videoInfo.duration) * 1000),
+				Math.round(
+					getEffectiveVideoStreamDurationSeconds({
+						duration: videoInfo.duration,
+						streamDuration: videoInfo.streamDuration,
+					}) * 1000,
+				),
 			);
 			const trimSegments = this.buildNativeTrimSegments(sourceDurationMs);
 			if (trimSegments.length === 0) {

--- a/src/lib/mediaTiming.test.ts
+++ b/src/lib/mediaTiming.test.ts
@@ -111,6 +111,15 @@ describe("getEffectiveVideoStreamDurationSeconds", () => {
 		).toBe(11.2);
 	});
 
+	it("uses the container duration when the video stream is much shorter", () => {
+		expect(
+			getEffectiveVideoStreamDurationSeconds({
+				duration: 60,
+				streamDuration: 40,
+			}),
+		).toBe(60);
+	});
+
 	it("falls back to the container duration when stream duration is missing", () => {
 		expect(
 			getEffectiveVideoStreamDurationSeconds({

--- a/src/lib/mediaTiming.ts
+++ b/src/lib/mediaTiming.ts
@@ -81,12 +81,29 @@ export function getEffectiveVideoStreamDurationSeconds({
 	duration?: number | null;
 	streamDuration?: number | null;
 }): number {
-	if (Number.isFinite(streamDuration) && (streamDuration ?? 0) > 0) {
-		return Math.max(0, streamDuration ?? 0);
+	const safeDuration =
+		Number.isFinite(duration) && (duration ?? 0) > 0 ? Math.max(0, duration ?? 0) : 0;
+	const safeStreamDuration =
+		Number.isFinite(streamDuration) && (streamDuration ?? 0) > 0
+			? Math.max(0, streamDuration ?? 0)
+			: 0;
+
+	if (safeDuration > 0 && safeStreamDuration > 0) {
+		const gapSeconds = safeDuration - safeStreamDuration;
+		const largeMismatchThresholdSeconds = Math.max(2, safeDuration * 0.1);
+		if (gapSeconds > largeMismatchThresholdSeconds) {
+			return safeDuration;
+		}
+
+		return safeStreamDuration;
 	}
 
-	if (Number.isFinite(duration) && (duration ?? 0) > 0) {
-		return Math.max(0, duration ?? 0);
+	if (safeStreamDuration > 0) {
+		return safeStreamDuration;
+	}
+
+	if (safeDuration > 0) {
+		return safeDuration;
 	}
 
 	return 0;


### PR DESCRIPTION
## Description
Fix export duration planning when the source media reports a much shorter video-stream duration than the overall container duration.

The exporter should not cut a source that presents as `60s` overall down to `40s` only because the video stream metadata is shorter. This keeps the existing stream-duration behavior for small metadata differences, but falls back to the container duration when the mismatch is large enough to indicate an export-truncation risk.

## Motivation
Issue #400 reports Windows system-audio recordings where the raw recording is full length, but the editor export is much shorter, for example raw `60s` and exported MP4 `40s`.

The local repro pass found a matching exporter-side metadata shape: an MP4 with container duration `60s`, video stream duration `40s`, and audio stream duration `60s`. Recordly's browser demuxer reports the same `60/40/60` split, and the existing duration helper would plan the export from the `40s` video stream duration.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
- #400

## Changes Made
- preserve the container duration when the video stream duration is materially shorter than the overall media duration
- keep the current video-stream duration preference for small stream/container differences
- use the same effective duration helper for modern and legacy exporter audio/trim planning
- add focused regression coverage for a `60s` container / `40s` video-stream duration mismatch

## Scope Note
This only targets editor/export duration planning for large container-vs-video-stream metadata mismatches. It does not change native Windows capture, WGC finalization, audio capture, frame scheduling, or the separate native GPU export work in #410.

## Testing Guide
1. Open a project whose source MP4 presents as full length overall but has a much shorter video stream duration.
2. Export without adding trims or speed regions.
3. Verify the exported MP4 duration follows the source container duration rather than the shorter video stream metadata.
4. Re-test a normal MP4 with only small stream/container duration differences and verify export duration behavior remains unchanged.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] I have added focused regression coverage for the changed duration helper.
- [x] I have completed a local metadata repro pass.
- [ ] I have completed a reporter/raw-file retest for #400.

Local checks run:
- `npm exec -- biome check src/lib/mediaTiming.ts src/lib/mediaTiming.test.ts src/lib/exporter/modernVideoExporter.ts src/lib/exporter/videoExporter.ts`
- `npm test -- src/lib/mediaTiming.test.ts`
- `npm test -- src/lib/exporter/streamingDecoder.test.ts`
- `npm exec tsc -- --noEmit`

Metadata repro:
- synthetic source: MP4 with container duration `60s`, video stream duration `40s`, audio stream duration `60s`
- browser demux: Recordly's `web-demuxer` reports the same `60/40/60` split in Chromium
- previous behavior: `getEffectiveVideoStreamDurationSeconds({ duration: 60, streamDuration: 40 })` returned `40`
- patched behavior: the same metadata shape returns `60`

Native capture check:
- ran local Windows WGC + system-audio captures from a clean worktree
- short muxed sample: matching container/video/audio duration around `7.57s`
- longer sample: raw video around `58.71s`, loopback WAV around `45.11s`, app-equivalent mux padded audio back to matching duration around `58.71s`
- this did not reproduce the exact raw-`60s` / export-`40s` split locally, so this PR should stay draft until a failing raw file or current build retest confirms #400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video duration calculation during export to better handle cases where stream duration differs from container duration, ensuring more accurate duration-based segmentation and consistent native audio planning.

* **Tests**
  * Added test coverage for updated duration calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->