### PR TITLE
fix(export): harden post-merge file handling

### DIFF
--- a/electron/ipc/register/export.test.ts
+++ b/electron/ipc/register/export.test.ts
@@ -40,6 +40,7 @@ async function makeTempDir() {
 }
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	await Promise.allSettled(
 		tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })),
 	);
@@ -57,6 +58,31 @@ describe("moveExportedTempFile", () => {
 		await expect(fs.readFile(destinationPath, "utf8")).resolves.toBe(
 			"recordly-export",
 		);
+		await expect(fs.access(tempPath)).rejects.toThrow();
+	});
+
+	it("falls back when Windows reports the destination already exists during initial rename", async () => {
+		const dir = await makeTempDir();
+		const tempPath = path.join(dir, "export-temp.mp4");
+		const destinationPath = path.join(dir, "export-final.mp4");
+		await fs.writeFile(tempPath, "new-export");
+		await fs.writeFile(destinationPath, "previous-export");
+
+		const originalRename = fs.rename.bind(fs);
+		const renameSpy = vi.spyOn(fs, "rename");
+		renameSpy.mockImplementation(async (from, to) => {
+			if (from === tempPath && to === destinationPath) {
+				const error = new Error("destination exists") as NodeJS.ErrnoException;
+				error.code = "EEXIST";
+				throw error;
+			}
+
+			return originalRename(from, to);
+		});
+
+		await moveExportedTempFile(tempPath, destinationPath);
+
+		await expect(fs.readFile(destinationPath, "utf8")).resolves.toBe("new-export");
 		await expect(fs.access(tempPath)).rejects.toThrow();
 	});
 });

--- a/electron/ipc/register/export.ts
+++ b/electron/ipc/register/export.ts
@@ -58,7 +58,12 @@ export async function moveExportedTempFile(tempPath: string, destinationPath: st
 		return;
 	} catch (error) {
 		const code = (error as NodeJS.ErrnoException).code;
-		if (code !== "EXDEV" && code !== "EPERM" && code !== "ENOTEMPTY") {
+		if (
+			code !== "EXDEV" &&
+			code !== "EPERM" &&
+			code !== "ENOTEMPTY" &&
+			code !== "EEXIST"
+		) {
 			throw error;
 		}
 		// Cross-device or Windows permission quirks — fall back to copy + unlink so
@@ -143,6 +148,10 @@ async function resolveAllowedReadableFilePath(
 	}
 
 	const resolvedPath = path.resolve(filePath);
+	if (!isAllowedLocalReadPath(resolvedPath)) {
+		throw new Error(`${label} is not approved for local reads`);
+	}
+
 	const realPath = await fs.realpath(resolvedPath).catch(() => null);
 	if (!realPath) {
 		throw new Error(`${label} does not exist`);


### PR DESCRIPTION
## Description
Follow-up to #410 for two final CodeRabbit export hardening comments that were left after the merge.

## Changes Made
- Treat `EEXIST` from the first `fs.rename(tempPath, destinationPath)` as recoverable so the safe copy/replace fallback can run on Windows overwrite cases.
- Check the normalized path with `isAllowedLocalReadPath()` before `realpath` / `stat` for non-media local read paths, then keep the realpath re-check for symlink protection.
- Add a regression test for the initial `EEXIST` fallback path.

## Validation
- `npm test -- electron/ipc/register/export.test.ts electron/ipc/export/native-video.test.ts` (`67` tests)
- `npx biome check --formatter-enabled=false electron/ipc/register/export.ts electron/ipc/register/export.test.ts`
- `npx tsc --noEmit`
- `git diff --check`

## Notes
This does not change CUDA/D3D11 routing, browser mic behavior, or exporter feature gates from #410.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export logic to reliably handle destination conflicts (including Windows-specific cases) by using a safer fallback when a rename can't be trusted.
  * Added earlier permission validation for export paths to fail fast on disallowed locations.

* **Tests**
  * Added tests for export edge cases and ensured test mocks are cleaned up after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->