### PR TITLE
fix(electron): avoid CJS dirname binding collision

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -52,7 +52,7 @@ import {
 	showUpdateToastWindow,
 } from "./windows";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const electronMainDir = path.dirname(fileURLToPath(import.meta.url));
 const IS_SMOKE_EXPORT = process.env.RECORDLY_SMOKE_EXPORT === "1";
 
 function ignoreBrokenConsolePipe(stream: NodeJS.WritableStream | undefined) {
@@ -118,7 +118,7 @@ async function ensureRecordingsDir() {
 // │ │ ├── main.js
 // │ │ └── preload.mjs
 // │
-process.env.APP_ROOT = path.join(__dirname, "..");
+process.env.APP_ROOT = path.join(electronMainDir, "..");
 
 // Use ['ENV_NAME'] avoid vite:define plugin - Vite@2.x
 export const VITE_DEV_SERVER_URL = process.env["VITE_DEV_SERVER_URL"];

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -7,10 +7,10 @@ import { app, BrowserWindow, ipcMain } from "electron";
 import { USER_DATA_PATH } from "./appPaths";
 import { getPackagedRendererBaseUrl } from "./rendererServer";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const electronWindowsDir = path.dirname(fileURLToPath(import.meta.url));
 const nodeRequire = createRequire(import.meta.url);
 
-const APP_ROOT = path.join(__dirname, "..");
+const APP_ROOT = path.join(electronWindowsDir, "..");
 const VITE_DEV_SERVER_URL = process.env["VITE_DEV_SERVER_URL"];
 const RENDERER_DIST = path.join(APP_ROOT, "dist");
 const WINDOW_ICON_PATH = path.join(
@@ -374,7 +374,7 @@ export function createHudOverlayWindow(): BrowserWindow {
 		hasShadow: false,
 		show: false,
 		webPreferences: {
-			preload: path.join(__dirname, "preload.mjs"),
+			preload: path.join(electronWindowsDir, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
 			webSecurity: false,
@@ -537,7 +537,7 @@ export function createUpdateToastWindow(): BrowserWindow {
 		...(parentWindow ? { parent: parentWindow } : {}),
 		backgroundColor: useTransparentToastWindow ? "#00000000" : "#101418",
 		webPreferences: {
-			preload: path.join(__dirname, "preload.mjs"),
+			preload: path.join(electronWindowsDir, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
 			backgroundThrottling: false,
@@ -726,7 +726,7 @@ export function createEditorWindow(): BrowserWindow {
 		show: false,
 		backgroundColor: "#000000",
 		webPreferences: {
-			preload: path.join(__dirname, "preload.mjs"),
+			preload: path.join(electronWindowsDir, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
 			webSecurity: false,
@@ -799,7 +799,7 @@ export function createSourceSelectorWindow(): BrowserWindow {
 		}),
 		backgroundColor: "#00000000",
 		webPreferences: {
-			preload: path.join(__dirname, "preload.mjs"),
+			preload: path.join(electronWindowsDir, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
 		},
@@ -846,7 +846,7 @@ export function createCountdownWindow(): BrowserWindow {
 		focusable: true,
 		show: false,
 		webPreferences: {
-			preload: path.join(__dirname, "preload.mjs"),
+			preload: path.join(electronWindowsDir, "preload.mjs"),
 			nodeIntegration: false,
 			contextIsolation: true,
 		},


### PR DESCRIPTION
﻿## Description

Avoid declaring `__dirname` in Electron main-process source that is bundled into `dist-electron/main.cjs`.

## Motivation

A tester reported intermittent `npm run dev` failures where the generated Electron main bundle failed the CommonJS smoke guard with:

```text
SyntaxError: Identifier '__dirname' has already been declared
```

The bundle is CommonJS, so Node already provides `__dirname` in the CJS wrapper scope. If Rollup preserves a top-level source variable named `__dirname`, the generated bundle can fail to parse. Renaming the source-side ESM directory helpers makes the output deterministic instead of depending on minifier/name-collision behavior.

## Type of Change

- Bug fix
- Build/dev reliability

## Related Issues

Reporter feedback from the v1.3 beta/dev branch: intermittent `dist-electron/main.cjs does not parse as CommonJS` during `npm run dev`.

## Changes Made

- Renamed the Electron main entry directory helper from `__dirname` to `electronMainDir`.
- Renamed the Electron window module directory helper from `__dirname` to `electronWindowsDir`.
- Kept the existing `APP_ROOT` and preload path behavior unchanged.

## Scope Note

This only changes internal variable names used before bundling. It does not alter runtime paths, renderer behavior, export logic, native helpers, or packaged assets.

## Testing Guide

Run:

```bash
npm run dev
```

Expected result: the Electron main CJS guard should pass on first run; it should not require rerunning `npm run dev` multiple times.

## Local Checks

```bash
npx tsc --noEmit
npx biome check electron/main.ts electron/windows.ts
git diff --check
npx vite build --config vite.config.ts
npm run smoke:electron-main-cjs
node --check dist-electron/main.cjs
rg -n "\b(const|let|var)\s+__dirname\b|\b(const|let|var)\s+__filename\b" dist-electron/main.cjs
```

The final `rg` returned no reserved CommonJS dirname/filename declarations.

## Checklist

- [x] Root cause identified
- [x] Minimal source fix
- [x] CJS smoke guard passes
- [x] Typecheck passes
- [x] Scoped Biome check passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal path resolution in Electron application initialization and window management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->