### PR TITLE
fix(export): recover video background fallback and smooth preview audio

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -2140,13 +2140,14 @@ export default function VideoEditor() {
 						preserveProjectPath: Boolean(path),
 					},
 				);
+				const sessionResult = await window.electronAPI.getCurrentRecordingSession?.();
+				applySessionPresentation(sessionResult?.success ? sessionResult.session : null);
 			} else {
 				await window.electronAPI.setCurrentVideoPath(sourcePath, {
 					preserveProjectPath: Boolean(path),
 				});
+				applySessionPresentation(null);
 			}
-			const sessionResult = await window.electronAPI.getCurrentRecordingSession?.();
-			applySessionPresentation(sessionResult?.success ? sessionResult.session : null);
 
 			setWallpaper(normalizedEditor.wallpaper);
 			setShadowIntensity(normalizedEditor.shadowIntensity);
@@ -4629,13 +4630,11 @@ export default function VideoEditor() {
 					const backendPreference =
 						pipelineModel === "legacy"
 							? "webcodecs"
-							: useExperimentalNativeExport
-								? "auto"
-								: smokeExportConfig.enabled
-									? (smokeExportConfig.backendPreference ??
-										(smokeExportConfig.useNativeExport
-											? "breeze"
-											: "webcodecs"))
+							: smokeExportConfig.enabled
+								? (smokeExportConfig.backendPreference ??
+									(smokeExportConfig.useNativeExport ? "breeze" : "webcodecs"))
+								: useExperimentalNativeExport
+									? "auto"
 									: (settings.backendPreference ?? exportBackendPreference);
 					const supportedSourceDimensions =
 						await ensureSupportedMp4SourceDimensions(selectedMp4FrameRate);

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -339,6 +339,11 @@ async function writeSmokeExportReport(
 const SMOKE_EXPORT_READY_TIMEOUT_MS = 30_000;
 const DEFAULT_MP4_EXPORT_FRAME_RATE: ExportMp4FrameRate = 30;
 const SOURCE_AUDIO_FALLBACK_TOAST_ID = "source-audio-fallback-error";
+const SOURCE_AUDIO_PREVIEW_PLAYING_SEEK_DRIFT_SECONDS = 0.18;
+const SOURCE_AUDIO_PREVIEW_PAUSED_SEEK_DRIFT_SECONDS = 0.01;
+const SOURCE_AUDIO_PREVIEW_RATE_TOLERANCE_SECONDS = 0.08;
+const SOURCE_AUDIO_PREVIEW_RATE_CORRECTION_WINDOW_SECONDS = 8;
+const SOURCE_AUDIO_PREVIEW_MAX_RATE_ADJUSTMENT = 0.015;
 const PROJECT_AUTOSAVE_DELAY_MS = 1000;
 const EXPORT_ERROR_TOAST_DURATION_MS = 20000;
 
@@ -439,7 +444,9 @@ function getSmokeExportConfig(search: string): SmokeExportConfig {
 					: enabled && params.get("smokeBackendPreference") === "breeze"
 						? "breeze"
 						: undefined,
-		renderBackend: enabled ? parseSmokeRenderBackend(params.get("smokeRenderBackend")) : undefined,
+		renderBackend: enabled
+			? parseSmokeRenderBackend(params.get("smokeRenderBackend"))
+			: undefined,
 		maxEncodeQueue: enabled
 			? parseSmokeExportNumber(params.get("smokeMaxEncodeQueue"))
 			: undefined,
@@ -595,9 +602,7 @@ export default function VideoEditor() {
 	);
 	const devOpenRecordingConfig = useMemo(
 		() =>
-			getDevOpenRecordingConfig(
-				typeof window === "undefined" ? "" : window.location.search,
-			),
+			getDevOpenRecordingConfig(typeof window === "undefined" ? "" : window.location.search),
 		[],
 	);
 	const [appPlatform, setAppPlatform] = useState<string>(
@@ -1730,16 +1735,16 @@ export default function VideoEditor() {
 	}, [activeEffectSection]);
 
 	const buildPersistedEditorState = useCallback(
-			(
-				editor: Partial<{
-					wallpaper: string;
-					shadowIntensity: number;
-					backgroundBlur: number;
-					zoomMotionBlur: number;
-					zoomMotionBlurTuning: ZoomMotionBlurTuning;
-					zoomTemporalMotionBlur: number;
-					zoomMotionBlurSampleCount: number | null;
-					zoomMotionBlurShutterFraction: number | null;
+		(
+			editor: Partial<{
+				wallpaper: string;
+				shadowIntensity: number;
+				backgroundBlur: number;
+				zoomMotionBlur: number;
+				zoomMotionBlurTuning: ZoomMotionBlurTuning;
+				zoomTemporalMotionBlur: number;
+				zoomMotionBlurSampleCount: number | null;
+				zoomMotionBlurShutterFraction: number | null;
 				connectZooms: boolean;
 				zoomInDurationMs: number;
 				zoomInOverlapMs: number;
@@ -2135,15 +2140,15 @@ export default function VideoEditor() {
 						preserveProjectPath: Boolean(path),
 					},
 				);
-				} else {
-					await window.electronAPI.setCurrentVideoPath(sourcePath, {
-						preserveProjectPath: Boolean(path),
-					});
-				}
-				const sessionResult = await window.electronAPI.getCurrentRecordingSession?.();
-				applySessionPresentation(sessionResult?.success ? sessionResult.session : null);
+			} else {
+				await window.electronAPI.setCurrentVideoPath(sourcePath, {
+					preserveProjectPath: Boolean(path),
+				});
+			}
+			const sessionResult = await window.electronAPI.getCurrentRecordingSession?.();
+			applySessionPresentation(sessionResult?.success ? sessionResult.session : null);
 
-				setWallpaper(normalizedEditor.wallpaper);
+			setWallpaper(normalizedEditor.wallpaper);
 			setShadowIntensity(normalizedEditor.shadowIntensity);
 			setBackgroundBlur(normalizedEditor.backgroundBlur);
 			setZoomMotionBlur(normalizedEditor.zoomMotionBlur);
@@ -2157,10 +2162,10 @@ export default function VideoEditor() {
 			setZoomOutDurationMs(normalizedEditor.zoomOutDurationMs);
 			setConnectedZoomGapMs(normalizedEditor.connectedZoomGapMs);
 			setConnectedZoomDurationMs(normalizedEditor.connectedZoomDurationMs);
-				setZoomInEasing(normalizedEditor.zoomInEasing);
-				setZoomOutEasing(normalizedEditor.zoomOutEasing);
-				setConnectedZoomEasing(normalizedEditor.connectedZoomEasing);
-				setShowCursor(normalizedEditor.showCursor);
+			setZoomInEasing(normalizedEditor.zoomInEasing);
+			setZoomOutEasing(normalizedEditor.zoomOutEasing);
+			setConnectedZoomEasing(normalizedEditor.connectedZoomEasing);
+			setShowCursor(normalizedEditor.showCursor);
 			setLoopCursor(normalizedEditor.loopCursor);
 			setCursorStyle(normalizedEditor.cursorStyle);
 			setCursorSize(normalizedEditor.cursorSize);
@@ -2249,7 +2254,12 @@ export default function VideoEditor() {
 			await refreshProjectLibrary();
 			return true;
 		},
-		[buildPersistedEditorState, refreshProjectLibrary, syncHistoryButtons],
+		[
+			applySessionPresentation,
+			buildPersistedEditorState,
+			refreshProjectLibrary,
+			syncHistoryButtons,
+		],
 	);
 
 	const currentProjectSnapshot = useMemo(() => {
@@ -3907,7 +3917,7 @@ export default function VideoEditor() {
 				),
 			);
 		},
-		[applySessionPresentation],
+		[],
 	);
 
 	const handleAnnotationDelete = useCallback(
@@ -4326,7 +4336,9 @@ export default function VideoEditor() {
 		const previousTimelineTime = lastSourceAudioSyncTimeRef.current;
 		const timelineJumped =
 			previousTimelineTime === null || Math.abs(currentTime - previousTimelineTime) > 0.25;
-		const driftThreshold = isPlaying ? 0.35 : 0.01;
+		const driftThreshold = isPlaying
+			? SOURCE_AUDIO_PREVIEW_PLAYING_SEEK_DRIFT_SECONDS
+			: SOURCE_AUDIO_PREVIEW_PAUSED_SEEK_DRIFT_SECONDS;
 
 		for (const audio of sourceAudioElementsRef.current.values()) {
 			enablePitchPreservingPlayback(audio);
@@ -4354,6 +4366,9 @@ export default function VideoEditor() {
 				basePlaybackRate: targetPlaybackRate,
 				currentTime: audio.currentTime,
 				targetTime,
+				toleranceSeconds: SOURCE_AUDIO_PREVIEW_RATE_TOLERANCE_SECONDS,
+				correctionWindowSeconds: SOURCE_AUDIO_PREVIEW_RATE_CORRECTION_WINDOW_SECONDS,
+				maxAdjustment: SOURCE_AUDIO_PREVIEW_MAX_RATE_ADJUSTMENT,
 			});
 			if (Math.abs(audio.playbackRate - syncedPlaybackRate) > 0.001) {
 				audio.playbackRate = syncedPlaybackRate;
@@ -4606,8 +4621,7 @@ export default function VideoEditor() {
 						? (smokeExportConfig.fps ?? settings.mp4FrameRate ?? mp4FrameRate)
 						: (settings.mp4FrameRate ?? mp4FrameRate);
 					const pipelineModel = smokeExportConfig.enabled
-						? (smokeExportConfig.pipelineModel ??
-							"modern")
+						? (smokeExportConfig.pipelineModel ?? "modern")
 						: (settings.pipelineModel ?? exportPipelineModel);
 					const useExperimentalNativeExport =
 						pipelineModel === "modern" &&
@@ -4617,10 +4631,12 @@ export default function VideoEditor() {
 							? "webcodecs"
 							: useExperimentalNativeExport
 								? "auto"
-							: smokeExportConfig.enabled
-								? (smokeExportConfig.backendPreference ??
-									(smokeExportConfig.useNativeExport ? "breeze" : "webcodecs"))
-								: (settings.backendPreference ?? exportBackendPreference);
+								: smokeExportConfig.enabled
+									? (smokeExportConfig.backendPreference ??
+										(smokeExportConfig.useNativeExport
+											? "breeze"
+											: "webcodecs"))
+									: (settings.backendPreference ?? exportBackendPreference);
 					const supportedSourceDimensions =
 						await ensureSupportedMp4SourceDimensions(selectedMp4FrameRate);
 					const { width: exportWidth, height: exportHeight } =
@@ -5368,31 +5384,35 @@ export default function VideoEditor() {
 		? isExportPreparing
 			? t("editor.exportStatus.preparing", "Preparing export...")
 			: isExportSaving
-			? t("editor.exportStatus.saving", "Opening save dialog...")
-			: isRenderingAudio
-				? t("editor.exportStatus.renderingAudio", "Rendering audio {{percent}}%", {
-						percent: Math.round((exportProgress.audioProgress ?? 0) * 100),
-					})
-				: isExportFinalizing
-					? exportFormat === "mp4" && exportPipelineModel === "modern"
-						? isExportFinalSaveIndeterminate
-							? t(
-									"editor.exportStatus.muxingAndSaving",
-									"Muxing audio and saving file...",
-								)
-							: t(
-								"editor.exportStatus.muxingAndSavingPercent",
-								"Muxing and saving {{percent}}%",
-								{
-									percent: exportFinalizingPercent ?? 100,
-								},
-							)
-						: t("editor.exportStatus.finalizingPercent", "Finalizing {{percent}}%", {
-								percent: exportFinalizingPercent ?? 100,
-							})
-					: t("editor.exportStatus.completePercent", "{{percent}}% complete", {
-							percent: Math.round(exportProgress.percentage),
+				? t("editor.exportStatus.saving", "Opening save dialog...")
+				: isRenderingAudio
+					? t("editor.exportStatus.renderingAudio", "Rendering audio {{percent}}%", {
+							percent: Math.round((exportProgress.audioProgress ?? 0) * 100),
 						})
+					: isExportFinalizing
+						? exportFormat === "mp4" && exportPipelineModel === "modern"
+							? isExportFinalSaveIndeterminate
+								? t(
+										"editor.exportStatus.muxingAndSaving",
+										"Muxing audio and saving file...",
+									)
+								: t(
+										"editor.exportStatus.muxingAndSavingPercent",
+										"Muxing and saving {{percent}}%",
+										{
+											percent: exportFinalizingPercent ?? 100,
+										},
+									)
+							: t(
+									"editor.exportStatus.finalizingPercent",
+									"Finalizing {{percent}}%",
+									{
+										percent: exportFinalizingPercent ?? 100,
+									},
+								)
+						: t("editor.exportStatus.completePercent", "{{percent}}% complete", {
+								percent: Math.round(exportProgress.percentage),
+							})
 		: t("editor.exportStatus.preparing", "Preparing export...");
 
 	const projectBrowser = (

--- a/src/lib/exporter/frameRenderer.test.ts
+++ b/src/lib/exporter/frameRenderer.test.ts
@@ -1,7 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_WEBCAM_OVERLAY } from "../../components/video-editor/types";
 
-const { initializeForwardFrameSourceMock, resolveMediaElementSourceMock } = vi.hoisted(() => ({
+const {
+	cancelForwardFrameSourceMock,
+	destroyForwardFrameSourceMock,
+	getForwardFrameAtTimeMock,
+	initializeForwardFrameSourceMock,
+	resolveMediaElementSourceMock,
+} = vi.hoisted(() => ({
+	cancelForwardFrameSourceMock: vi.fn(),
+	destroyForwardFrameSourceMock: vi.fn(async () => undefined),
+	getForwardFrameAtTimeMock: vi.fn(async () => null),
 	initializeForwardFrameSourceMock: vi.fn(async () => undefined),
 	resolveMediaElementSourceMock: vi.fn(async () => ({
 		src: "blob:background",
@@ -68,6 +77,9 @@ vi.mock("@/components/video-editor/videoPlayback/cursorRenderer", () => ({
 
 vi.mock("./forwardFrameSource", () => ({
 	ForwardFrameSource: class {
+		cancel = cancelForwardFrameSourceMock;
+		destroy = destroyForwardFrameSourceMock;
+		getFrameAtTime = getForwardFrameAtTimeMock;
 		initialize = initializeForwardFrameSourceMock;
 	},
 }));
@@ -449,6 +461,7 @@ describe("FrameRenderer webcam export path", () => {
 	});
 
 	it("prefers decoder-backed sync for video wallpapers during export", async () => {
+		vi.clearAllMocks();
 		const renderer = new FrameRenderer({
 			width: 1920,
 			height: 1080,
@@ -478,5 +491,47 @@ describe("FrameRenderer webcam export path", () => {
 		expect(renderer.backgroundForwardFrameSource).toBeTruthy();
 		expect(renderer.backgroundVideoElement).toBeNull();
 		expect(renderer.backgroundSprite).toBeTruthy();
+	});
+
+	it("falls back to media-element sync when video wallpaper packet streaming fails", async () => {
+		vi.clearAllMocks();
+		initializeForwardFrameSourceMock.mockResolvedValue(undefined);
+		getForwardFrameAtTimeMock.mockRejectedValueOnce(
+			new Error("readAVPacket pipeline failed: Failed after 3 attempts"),
+		);
+		resolveMediaElementSourceMock.mockResolvedValueOnce({
+			src: "blob:background-video",
+			revoke: vi.fn(),
+		});
+		const renderer = new FrameRenderer({
+			width: 1920,
+			height: 1080,
+			wallpaper: "/wallpapers/wispysky.mp4",
+			zoomRegions: [],
+			showShadow: false,
+			shadowIntensity: 0,
+			backgroundBlur: 0,
+			cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+			webcam: {
+				...DEFAULT_WEBCAM_OVERLAY,
+				enabled: false,
+			},
+			videoWidth: 1920,
+			videoHeight: 1080,
+		}) as unknown as {
+			setupBackground: () => Promise<void>;
+			syncBackgroundFrame: (timeSeconds: number) => Promise<void>;
+			backgroundForwardFrameSource: unknown;
+			backgroundVideoElement: FakeVideoElement | null;
+		};
+
+		await renderer.setupBackground();
+		await expect(renderer.syncBackgroundFrame(1)).resolves.toBeUndefined();
+
+		expect(cancelForwardFrameSourceMock).toHaveBeenCalled();
+		expect(destroyForwardFrameSourceMock).toHaveBeenCalled();
+		expect(resolveMediaElementSourceMock).toHaveBeenCalledWith("wallpapers/wispysky.mp4");
+		expect(renderer.backgroundForwardFrameSource).toBeNull();
+		expect(renderer.backgroundVideoElement).toBeTruthy();
 	});
 });

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -153,6 +153,7 @@ type PixiRendererAttempt = {
 };
 
 const PIXI_RENDERER_INIT_TIMEOUT_MS = 8_000;
+const BACKGROUND_MEDIA_ELEMENT_READY_TIMEOUT_MS = 5_000;
 
 function isCanvasRenderer(renderer: Application): boolean {
 	const rendererName = renderer?.renderer?.constructor?.name?.toLowerCase();
@@ -924,31 +925,61 @@ export class FrameRenderer {
 		video.load();
 
 		const ready = await new Promise<boolean>((resolve) => {
-			const onReady = () => {
-				if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
-					return;
+			let settled = false;
+			let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+			function cleanup() {
+				if (timeoutId !== null) {
+					clearTimeout(timeoutId);
 				}
-				cleanup();
-				resolve(true);
-			};
-			const onError = () => {
-				cleanup();
-				resolve(false);
-			};
-			const cleanup = () => {
 				video.removeEventListener("loadeddata", onReady);
 				video.removeEventListener("canplay", onReady);
 				video.removeEventListener("error", onError);
-			};
+			}
+
+			function settle(value: boolean) {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				cleanup();
+				resolve(value);
+			}
+			function onReady() {
+				if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+					return;
+				}
+				settle(true);
+			}
+			function onError() {
+				settle(false);
+			}
 
 			video.addEventListener("loadeddata", onReady);
 			video.addEventListener("canplay", onReady);
 			video.addEventListener("error", onError);
+			timeoutId = setTimeout(() => {
+				console.warn(
+					`[FrameRenderer] Video wallpaper media element fallback did not become ready within ${BACKGROUND_MEDIA_ELEMENT_READY_TIMEOUT_MS}ms`,
+				);
+				settle(false);
+			}, BACKGROUND_MEDIA_ELEMENT_READY_TIMEOUT_MS);
 			onReady();
 		});
 
 		if (!ready) {
 			console.warn(`[FrameRenderer] Failed to load video wallpaper: ${errorLabel}`);
+			try {
+				video.pause();
+				video.src = "";
+				video.load();
+			} catch {
+				// Ignore media element teardown errors on failed fallback.
+			}
+			backgroundSource.revoke();
+			if (this.cleanupBackgroundSource === backgroundSource.revoke) {
+				this.cleanupBackgroundSource = null;
+			}
 			return false;
 		}
 

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -156,7 +156,10 @@ const PIXI_RENDERER_INIT_TIMEOUT_MS = 8_000;
 
 function isCanvasRenderer(renderer: Application): boolean {
 	const rendererName = renderer?.renderer?.constructor?.name?.toLowerCase();
-	return Boolean(rendererName && (rendererName.includes("canvasrenderer") || rendererName.includes("canvas")));
+	return Boolean(
+		rendererName &&
+			(rendererName.includes("canvasrenderer") || rendererName.includes("canvas")),
+	);
 }
 
 function toErrorMessage(error: unknown): string {
@@ -357,7 +360,8 @@ export class FrameRenderer {
 					backend,
 				);
 				const elapsed = Math.round(
-					(typeof performance === "undefined" ? Date.now() : performance.now()) - initStarted,
+					(typeof performance === "undefined" ? Date.now() : performance.now()) -
+						initStarted,
 				);
 				if (isCanvasRenderer(app)) {
 					throw new Error(
@@ -367,9 +371,13 @@ export class FrameRenderer {
 				return { app, backend };
 			} catch (error) {
 				const elapsed = Math.round(
-					(typeof performance === "undefined" ? Date.now() : performance.now()) - initStarted,
+					(typeof performance === "undefined" ? Date.now() : performance.now()) -
+						initStarted,
 				);
-				failures.push({ backend, message: `${toErrorMessage(error)} (after ${elapsed}ms)` });
+				failures.push({
+					backend,
+					message: `${toErrorMessage(error)} (after ${elapsed}ms)`,
+				});
 				console.warn(
 					`[FrameRenderer] ${backend} renderer unavailable after ${elapsed}ms; trying next backend.`,
 					error,
@@ -574,44 +582,9 @@ export class FrameRenderer {
 					);
 				}
 
-				const backgroundSource = await resolveMediaElementSource(videoSrc);
-				this.cleanupBackgroundSource = backgroundSource.revoke;
-
-				const video = document.createElement("video");
-				video.muted = true;
-				video.loop = true;
-				video.playsInline = true;
-				video.preload = "auto";
-				video.src = backgroundSource.src;
-				video.load();
-
-				await new Promise<void>((resolve, reject) => {
-					const onReady = () => {
-						if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
-							return;
-						}
-						cleanup();
-						resolve();
-					};
-					const onError = () => {
-						cleanup();
-						reject(new Error(`Failed to load video wallpaper: ${wallpaper}`));
-					};
-					const cleanup = () => {
-						video.removeEventListener("loadeddata", onReady);
-						video.removeEventListener("canplay", onReady);
-						video.removeEventListener("error", onError);
-					};
-
-					video.addEventListener("loadeddata", onReady);
-					video.addEventListener("canplay", onReady);
-					video.addEventListener("error", onError);
-					onReady();
-				});
-
-				this.backgroundVideoElement = video;
-				this.lastSyncedBackgroundLoopTimeSec = null;
-				this.drawVideoFrameToBackground();
+				if (!(await this.loadBackgroundMediaElementSource(videoSrc, wallpaper))) {
+					throw new Error(`Failed to load video wallpaper: ${wallpaper}`);
+				}
 				this.backgroundSprite = bgCanvas;
 				return;
 			}
@@ -828,8 +801,20 @@ export class FrameRenderer {
 				}
 			}
 
-			const decodedFrame =
-				await this.backgroundForwardFrameSource.getFrameAtTime(normalizedTargetTime);
+			let decodedFrame: VideoFrame | null = null;
+			try {
+				decodedFrame =
+					await this.backgroundForwardFrameSource.getFrameAtTime(normalizedTargetTime);
+			} catch (error) {
+				console.warn(
+					"[FrameRenderer] Decoder-backed video wallpaper failed during export; falling back to media element sync:",
+					error,
+				);
+				if (await this.fallbackBackgroundForwardFrameSourceToMediaElement()) {
+					await this.syncBackgroundFrame(timeSeconds);
+				}
+				return;
+			}
 			const resolvedDecodedDuration =
 				this.backgroundForwardFrameSource.getResolvedDurationSec();
 			if (
@@ -865,6 +850,10 @@ export class FrameRenderer {
 						"[FrameRenderer] Unable to wrap looping video wallpaper at decoded EOF during export:",
 						error,
 					);
+					if (await this.fallbackBackgroundForwardFrameSourceToMediaElement()) {
+						await this.syncBackgroundFrame(timeSeconds);
+					}
+					return;
 				}
 			}
 			this.closeBackgroundDecodedFrame();
@@ -881,6 +870,92 @@ export class FrameRenderer {
 		}
 
 		await this.syncBackgroundVideo(timeSeconds);
+	}
+
+	private async fallbackBackgroundForwardFrameSourceToMediaElement(): Promise<boolean> {
+		const sourceUrl = this.backgroundForwardFrameSourceUrl;
+		this.backgroundForwardFrameSource?.cancel();
+		void this.backgroundForwardFrameSource?.destroy();
+		this.backgroundForwardFrameSource = null;
+		this.backgroundForwardFrameSourceUrl = null;
+		this.backgroundForwardFrameDurationSec = null;
+		this.closeBackgroundDecodedFrame();
+		this.lastSyncedBackgroundLoopTimeSec = null;
+
+		return sourceUrl ? this.loadBackgroundMediaElementSource(sourceUrl, sourceUrl) : false;
+	}
+
+	private async loadBackgroundMediaElementSource(
+		videoSrc: string,
+		errorLabel: string,
+	): Promise<boolean> {
+		if (this.backgroundVideoElement) {
+			try {
+				this.backgroundVideoElement.pause();
+				this.backgroundVideoElement.src = "";
+				this.backgroundVideoElement.load();
+			} catch {
+				// Ignore media element teardown errors during export fallback.
+			}
+			this.backgroundVideoElement = null;
+		}
+		this.backgroundSeekPromise = null;
+		this.cleanupBackgroundSource?.();
+		this.cleanupBackgroundSource = null;
+
+		let backgroundSource: Awaited<ReturnType<typeof resolveMediaElementSource>>;
+		try {
+			backgroundSource = await resolveMediaElementSource(videoSrc);
+		} catch (error) {
+			console.warn(
+				"[FrameRenderer] Unable to resolve video wallpaper fallback source:",
+				error,
+			);
+			return false;
+		}
+		this.cleanupBackgroundSource = backgroundSource.revoke;
+
+		const video = document.createElement("video");
+		video.muted = true;
+		video.loop = true;
+		video.playsInline = true;
+		video.preload = "auto";
+		video.src = backgroundSource.src;
+		video.load();
+
+		const ready = await new Promise<boolean>((resolve) => {
+			const onReady = () => {
+				if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+					return;
+				}
+				cleanup();
+				resolve(true);
+			};
+			const onError = () => {
+				cleanup();
+				resolve(false);
+			};
+			const cleanup = () => {
+				video.removeEventListener("loadeddata", onReady);
+				video.removeEventListener("canplay", onReady);
+				video.removeEventListener("error", onError);
+			};
+
+			video.addEventListener("loadeddata", onReady);
+			video.addEventListener("canplay", onReady);
+			video.addEventListener("error", onError);
+			onReady();
+		});
+
+		if (!ready) {
+			console.warn(`[FrameRenderer] Failed to load video wallpaper: ${errorLabel}`);
+			return false;
+		}
+
+		this.backgroundVideoElement = video;
+		this.lastSyncedBackgroundLoopTimeSec = null;
+		this.drawVideoFrameToBackground();
+		return true;
 	}
 
 	private async syncBackgroundVideo(timeSeconds: number): Promise<void> {

--- a/src/lib/exporter/modernFrameRenderer.test.ts
+++ b/src/lib/exporter/modernFrameRenderer.test.ts
@@ -183,6 +183,11 @@ describe("ModernFrameRenderer blur export path", () => {
 	beforeEach(() => {
 		Object.assign(globalThis, {
 			window: globalThis,
+			requestAnimationFrame: (callback: FrameRequestCallback) => {
+				callback(0);
+				return 1;
+			},
+			cancelAnimationFrame: vi.fn(),
 			HTMLMediaElement: {
 				HAVE_CURRENT_DATA: 2,
 			},
@@ -232,6 +237,7 @@ describe("ModernFrameRenderer blur export path", () => {
 	});
 
 	it("prefers decoder-backed sync for video wallpapers during export", async () => {
+		vi.clearAllMocks();
 		const renderer = new FrameRenderer({
 			width: 1920,
 			height: 1080,
@@ -256,6 +262,44 @@ describe("ModernFrameRenderer blur export path", () => {
 		expect(resolveMediaElementSourceMock).not.toHaveBeenCalled();
 		expect(renderer.backgroundForwardFrameSource).toBeTruthy();
 		expect(renderer.backgroundVideoElement).toBeNull();
+	});
+
+	it("falls back to media-element sync when video wallpaper packet streaming fails", async () => {
+		vi.clearAllMocks();
+		initializeForwardFrameSourceMock.mockResolvedValue(undefined);
+		getForwardFrameAtTimeMock.mockRejectedValueOnce(
+			new Error("readAVPacket pipeline failed: Failed after 3 attempts"),
+		);
+		resolveMediaElementSourceMock.mockResolvedValueOnce({
+			src: "blob:background-video",
+			revoke: vi.fn(),
+		});
+		const renderer = new FrameRenderer({
+			width: 1920,
+			height: 1080,
+			nativeReadbackMode: "pixels",
+			wallpaper: "/wallpapers/wispysky.mp4",
+			zoomRegions: [],
+			showShadow: false,
+			shadowIntensity: 0,
+			backgroundBlur: 0,
+			cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+			webcam: {
+				...DEFAULT_WEBCAM_OVERLAY,
+				enabled: false,
+			},
+			videoWidth: 1920,
+			videoHeight: 1080,
+		}) as any;
+
+		await renderer.setupBackground();
+		await expect(renderer.syncBackgroundFrame(1)).resolves.toBeUndefined();
+
+		expect(cancelForwardFrameSourceMock).toHaveBeenCalled();
+		expect(destroyForwardFrameSourceMock).toHaveBeenCalled();
+		expect(resolveMediaElementSourceMock).toHaveBeenCalledWith("wallpapers/wispysky.mp4");
+		expect(renderer.backgroundForwardFrameSource).toBeNull();
+		expect(renderer.backgroundVideoElement).toBeTruthy();
 	});
 });
 

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -246,6 +246,7 @@ type PixiRendererAttempt = {
 const CANVAS_RENDERER_NOT_IMPLEMENTED_HINT = "CanvasRenderer is not yet implemented";
 const NO_RENDERER_HINT = "no available renderer";
 const PIXI_RENDERER_INIT_TIMEOUT_MS = 8_000;
+const BACKGROUND_MEDIA_ELEMENT_READY_TIMEOUT_MS = 5_000;
 const WEBCAM_MEDIA_ELEMENT_READY_TIMEOUT_MS = 5_000;
 
 function isCanvasRenderer(application: Application): boolean {
@@ -2125,31 +2126,61 @@ export class FrameRenderer {
 		video.load();
 
 		const ready = await new Promise<boolean>((resolve) => {
-			const onReady = () => {
-				if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
-					return;
+			let settled = false;
+			let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+			function cleanup() {
+				if (timeoutId !== null) {
+					clearTimeout(timeoutId);
 				}
-				cleanup();
-				resolve(true);
-			};
-			const onError = () => {
-				cleanup();
-				resolve(false);
-			};
-			const cleanup = () => {
 				video.removeEventListener("loadeddata", onReady);
 				video.removeEventListener("canplay", onReady);
 				video.removeEventListener("error", onError);
-			};
+			}
+
+			function settle(value: boolean) {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				cleanup();
+				resolve(value);
+			}
+			function onReady() {
+				if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+					return;
+				}
+				settle(true);
+			}
+			function onError() {
+				settle(false);
+			}
 
 			video.addEventListener("loadeddata", onReady);
 			video.addEventListener("canplay", onReady);
 			video.addEventListener("error", onError);
+			timeoutId = setTimeout(() => {
+				console.warn(
+					`[FrameRenderer] Video wallpaper media element fallback did not become ready within ${BACKGROUND_MEDIA_ELEMENT_READY_TIMEOUT_MS}ms`,
+				);
+				settle(false);
+			}, BACKGROUND_MEDIA_ELEMENT_READY_TIMEOUT_MS);
 			onReady();
 		});
 
 		if (!ready) {
 			console.warn(`[FrameRenderer] Failed to load video wallpaper: ${errorLabel}`);
+			try {
+				video.pause();
+				video.src = "";
+				video.load();
+			} catch {
+				// Ignore media element teardown errors on failed fallback.
+			}
+			backgroundSource.revoke();
+			if (this.cleanupBackgroundSource === backgroundSource.revoke) {
+				this.cleanupBackgroundSource = null;
+			}
 			return false;
 		}
 

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -1144,44 +1144,9 @@ export class FrameRenderer {
 					);
 				}
 
-				const backgroundSource = await resolveMediaElementSource(videoSrc);
-				this.cleanupBackgroundSource = backgroundSource.revoke;
-
-				const video = document.createElement("video");
-				video.muted = true;
-				video.loop = true;
-				video.playsInline = true;
-				video.preload = "auto";
-				video.src = backgroundSource.src;
-				video.load();
-
-				await new Promise<void>((resolve, reject) => {
-					const onReady = () => {
-						if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
-							return;
-						}
-						cleanup();
-						resolve();
-					};
-					const onError = () => {
-						cleanup();
-						reject(new Error(`Failed to load video wallpaper: ${wallpaper}`));
-					};
-					const cleanup = () => {
-						video.removeEventListener("loadeddata", onReady);
-						video.removeEventListener("canplay", onReady);
-						video.removeEventListener("error", onError);
-					};
-
-					video.addEventListener("loadeddata", onReady);
-					video.addEventListener("canplay", onReady);
-					video.addEventListener("error", onError);
-					onReady();
-				});
-
-				this.backgroundVideoElement = video;
-				this.lastSyncedBackgroundLoopTimeSec = null;
-				this.ensureBackgroundSprite(video, video.videoWidth, video.videoHeight);
+				if (!(await this.loadBackgroundMediaElementSource(videoSrc, wallpaper))) {
+					throw new Error(`Failed to load video wallpaper: ${wallpaper}`);
+				}
 				return;
 			}
 
@@ -1853,8 +1818,20 @@ export class FrameRenderer {
 				}
 			}
 
-			const decodedFrame =
-				await this.backgroundForwardFrameSource.getFrameAtTime(normalizedTargetTime);
+			let decodedFrame: VideoFrame | null = null;
+			try {
+				decodedFrame =
+					await this.backgroundForwardFrameSource.getFrameAtTime(normalizedTargetTime);
+			} catch (error) {
+				console.warn(
+					"[FrameRenderer] Decoder-backed video wallpaper failed during export; falling back to media element sync:",
+					error,
+				);
+				if (await this.fallbackBackgroundForwardFrameSourceToMediaElement()) {
+					await this.syncBackgroundFrame(timeSeconds);
+				}
+				return;
+			}
 			const resolvedDecodedDuration =
 				this.backgroundForwardFrameSource.getResolvedDurationSec();
 			if (
@@ -1897,6 +1874,10 @@ export class FrameRenderer {
 						"[FrameRenderer] Unable to wrap looping video wallpaper at decoded EOF during export:",
 						error,
 					);
+					if (await this.fallbackBackgroundForwardFrameSourceToMediaElement()) {
+						await this.syncBackgroundFrame(timeSeconds);
+					}
+					return;
 				}
 			}
 			this.closeBackgroundDecodedFrame();
@@ -2090,6 +2071,92 @@ export class FrameRenderer {
 			? `file://${encodeURI(wallpaper)}`
 			: wallpaper;
 		return getRenderableAssetUrl(wallpaperAsset);
+	}
+
+	private async fallbackBackgroundForwardFrameSourceToMediaElement(): Promise<boolean> {
+		const sourceUrl = this.backgroundForwardFrameSourceUrl;
+		this.backgroundForwardFrameSource?.cancel();
+		void this.backgroundForwardFrameSource?.destroy();
+		this.backgroundForwardFrameSource = null;
+		this.backgroundForwardFrameSourceUrl = null;
+		this.backgroundForwardFrameDurationSec = null;
+		this.closeBackgroundDecodedFrame();
+		this.lastSyncedBackgroundLoopTimeSec = null;
+
+		return sourceUrl ? this.loadBackgroundMediaElementSource(sourceUrl, sourceUrl) : false;
+	}
+
+	private async loadBackgroundMediaElementSource(
+		videoSrc: string,
+		errorLabel: string,
+	): Promise<boolean> {
+		if (this.backgroundVideoElement) {
+			try {
+				this.backgroundVideoElement.pause();
+				this.backgroundVideoElement.src = "";
+				this.backgroundVideoElement.load();
+			} catch {
+				// Ignore media element teardown errors during export fallback.
+			}
+			this.backgroundVideoElement = null;
+		}
+		this.backgroundSeekPromise = null;
+		this.cleanupBackgroundSource?.();
+		this.cleanupBackgroundSource = null;
+
+		let backgroundSource: Awaited<ReturnType<typeof resolveMediaElementSource>>;
+		try {
+			backgroundSource = await resolveMediaElementSource(videoSrc);
+		} catch (error) {
+			console.warn(
+				"[FrameRenderer] Unable to resolve video wallpaper fallback source:",
+				error,
+			);
+			return false;
+		}
+		this.cleanupBackgroundSource = backgroundSource.revoke;
+
+		const video = document.createElement("video");
+		video.muted = true;
+		video.loop = true;
+		video.playsInline = true;
+		video.preload = "auto";
+		video.src = backgroundSource.src;
+		video.load();
+
+		const ready = await new Promise<boolean>((resolve) => {
+			const onReady = () => {
+				if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+					return;
+				}
+				cleanup();
+				resolve(true);
+			};
+			const onError = () => {
+				cleanup();
+				resolve(false);
+			};
+			const cleanup = () => {
+				video.removeEventListener("loadeddata", onReady);
+				video.removeEventListener("canplay", onReady);
+				video.removeEventListener("error", onError);
+			};
+
+			video.addEventListener("loadeddata", onReady);
+			video.addEventListener("canplay", onReady);
+			video.addEventListener("error", onError);
+			onReady();
+		});
+
+		if (!ready) {
+			console.warn(`[FrameRenderer] Failed to load video wallpaper: ${errorLabel}`);
+			return false;
+		}
+
+		this.backgroundVideoElement = video;
+		this.lastSyncedBackgroundLoopTimeSec = null;
+		await this.ensureBackgroundSprite(video, video.videoWidth, video.videoHeight);
+		return true;
 	}
 
 	private disposeWebcamMediaElement(video: HTMLVideoElement): void {


### PR DESCRIPTION
## Summary
- fall back from decoder-backed video wallpaper/background frames to media-element sync when packet streaming fails mid-export
- add regression coverage for the Lightning and legacy frame renderers so custom/video background exports recover instead of failing
- reduce aggressive companion-audio playback-rate correction in the editor preview to avoid audible flutter/crackle while preserving seek-based sync correction
- clean up two existing hook dependency warnings touched by the VideoEditor formatter pass

## Validation
- `npm test -- src/lib/mediaTiming.test.ts src/lib/exporter/sourceAudioFallback.test.ts src/lib/exporter/modernFrameRenderer.test.ts src/lib/exporter/frameRenderer.test.ts`
- `npx tsc --noEmit`
- `npx biome check src/components/video-editor/VideoEditor.tsx src/lib/exporter/frameRenderer.ts src/lib/exporter/frameRenderer.test.ts src/lib/exporter/modernFrameRenderer.ts src/lib/exporter/modernFrameRenderer.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Video wallpaper/export now reliably falls back to media-element playback when decoder-backed streaming fails
  * Improved preview audio/video synchronization with parameterized drift/correction tolerances for more accurate playback
  * More robust export progress reporting and stability during background/wallpaper exports

* **Tests**
  * Added tests covering decoder failure fallback and media-element fallback behavior to prevent regressions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->