### PR TITLE
fix(export): keep large exports off in-memory save path

### DIFF
--- a/electron/ipc/register/export.ts
+++ b/electron/ipc/register/export.ts
@@ -51,6 +51,16 @@ function getPartialExportDestinationPath(destinationPath: string) {
 	return path.join(parsed.dir, `.recordly-partial-${parsed.name}-${suffix}${parsed.ext}`);
 }
 
+const MAX_IN_MEMORY_EXPORT_BYTES = 0x7fffffff;
+
+function getInMemoryExportTooLargeMessage(byteLength: number) {
+	if (byteLength <= MAX_IN_MEMORY_EXPORT_BYTES) {
+		return null;
+	}
+
+	return "Export is too large for the legacy in-memory save path. Please retry with temp-file streaming enabled.";
+}
+
 export async function moveExportedTempFile(tempPath: string, destinationPath: string) {
 	await fs.mkdir(path.dirname(destinationPath), { recursive: true });
 	try {
@@ -700,6 +710,14 @@ export function registerExportHandlers() {
 		"mux-exported-video-audio",
 		async (_, videoData: ArrayBuffer, options?: NativeVideoExportFinishOptions) => {
 			try {
+				const sizeError = getInMemoryExportTooLargeMessage(videoData.byteLength);
+				if (sizeError) {
+					return {
+						success: false,
+						error: sizeError,
+					};
+				}
+
 				const result = await muxExportedVideoAudioBuffer(videoData, options ?? {});
 				// Register the muxed output so finalize-exported-video / discard-
 				// exported-temp accept it. Returning a temp path (instead of the
@@ -797,6 +815,15 @@ export function registerExportHandlers() {
 		"save-exported-video",
 		async (event, videoData: ArrayBuffer, fileName: string) => {
 			try {
+				const sizeError = getInMemoryExportTooLargeMessage(videoData.byteLength);
+				if (sizeError) {
+					return {
+						success: false,
+						message: sizeError,
+						error: sizeError,
+					};
+				}
+
 				// Determine file type from extension
 				const isGif = fileName.toLowerCase().endsWith(".gif");
 				const filters = isGif
@@ -845,6 +872,16 @@ export function registerExportHandlers() {
 		"write-exported-video-to-path",
 		async (_event, videoData: ArrayBuffer, outputPath: string) => {
 			try {
+				const sizeError = getInMemoryExportTooLargeMessage(videoData.byteLength);
+				if (sizeError) {
+					return {
+						success: false,
+						message: sizeError,
+						canceled: false,
+						error: sizeError,
+					};
+				}
+
 				const resolvedPath = path.resolve(outputPath);
 				await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
 				await fs.writeFile(resolvedPath, Buffer.from(videoData));

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -76,6 +76,10 @@ import {
 	VideoExporter,
 } from "@/lib/exporter";
 import { getMp4ExportBitrate, getSourceQualityBitrate } from "@/lib/exporter/exportBitrate";
+import {
+	canUseInMemoryExportSaveFallback,
+	describeBlockedInMemoryExportSave,
+} from "@/lib/exporter/exportSavePolicy";
 import { resolveMediaElementSource } from "@/lib/exporter/localMediaSource";
 import { resolveSourceAudioFallbackPaths } from "@/lib/exporter/sourceAudioFallback";
 import {
@@ -1485,6 +1489,12 @@ export default function VideoEditor() {
 	const saveBlobExport = useCallback(
 		async (blob: Blob, fileName: string, outputPath: string | null = null) => {
 			const extension = fileName.split(".").pop()?.toLowerCase() || "bin";
+			const hasExportStreamApi =
+				typeof window !== "undefined" &&
+				typeof window.electronAPI?.openExportStream === "function" &&
+				typeof window.electronAPI?.writeExportStreamChunk === "function" &&
+				typeof window.electronAPI?.closeExportStream === "function";
+			let streamError: unknown = null;
 
 			try {
 				const tempFilePath = await streamExportBlobToTempFile(blob, extension);
@@ -1502,9 +1512,37 @@ export default function VideoEditor() {
 					};
 				}
 			} catch (error) {
-				console.warn("[export] Falling back to in-memory blob save", error);
+				streamError = error;
+				console.warn("[export] Temp-file blob save failed", error);
 			}
 
+			if (
+				!canUseInMemoryExportSaveFallback({
+					blobSize: blob.size,
+					extension,
+					hasExportStreamApi,
+				})
+			) {
+				const message = describeBlockedInMemoryExportSave({
+					blobSize: blob.size,
+					extension,
+				});
+				console.error("[export] Refusing in-memory blob save fallback", {
+					fileName,
+					blobSize: blob.size,
+					extension,
+					hasExportStreamApi,
+					streamError,
+				});
+				throw new Error(message);
+			}
+
+			console.warn("[export] Falling back to in-memory blob save", {
+				fileName,
+				blobSize: blob.size,
+				extension,
+				hasExportStreamApi,
+			});
 			const arrayBuffer = await blob.arrayBuffer();
 			return {
 				saveResult: outputPath

--- a/src/lib/exporter/exportSavePolicy.test.ts
+++ b/src/lib/exporter/exportSavePolicy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	canUseInMemoryExportSaveFallback,
+	describeBlockedInMemoryExportSave,
+	isExportTooLargeForInMemorySave,
+	MAX_IN_MEMORY_EXPORT_BYTES,
+	normalizeExportExtension,
+} from "./exportSavePolicy";
+
+describe("exportSavePolicy", () => {
+	it("normalizes export extensions before policy checks", () => {
+		expect(normalizeExportExtension(" MP4 ")).toBe("mp4");
+	});
+
+	it("blocks the legacy in-memory save path above Node's Buffer limit", () => {
+		expect(isExportTooLargeForInMemorySave(MAX_IN_MEMORY_EXPORT_BYTES + 1)).toBe(true);
+		expect(
+			canUseInMemoryExportSaveFallback({
+				blobSize: MAX_IN_MEMORY_EXPORT_BYTES + 1,
+				extension: "gif",
+				hasExportStreamApi: false,
+			}),
+		).toBe(false);
+	});
+
+	it("keeps Electron MP4 exports on the temp-file save path", () => {
+		expect(
+			canUseInMemoryExportSaveFallback({
+				blobSize: 1024,
+				extension: "mp4",
+				hasExportStreamApi: true,
+			}),
+		).toBe(false);
+	});
+
+	it("allows small non-MP4 exports to use the legacy save fallback", () => {
+		expect(
+			canUseInMemoryExportSaveFallback({
+				blobSize: 1024,
+				extension: "gif",
+				hasExportStreamApi: false,
+			}),
+		).toBe(true);
+	});
+
+	it("explains blocked large saves without mentioning implementation stack traces", () => {
+		expect(
+			describeBlockedInMemoryExportSave({
+				blobSize: MAX_IN_MEMORY_EXPORT_BYTES + 1,
+				extension: "mp4",
+			}),
+		).toContain("too large");
+	});
+});

--- a/src/lib/exporter/exportSavePolicy.ts
+++ b/src/lib/exporter/exportSavePolicy.ts
@@ -1,0 +1,46 @@
+export const MAX_IN_MEMORY_EXPORT_BYTES = 0x7fffffff;
+
+export function normalizeExportExtension(extension: string): string {
+	return extension.trim().toLowerCase();
+}
+
+export function isExportTooLargeForInMemorySave(byteLength: number): boolean {
+	return byteLength > MAX_IN_MEMORY_EXPORT_BYTES;
+}
+
+export function canUseInMemoryExportSaveFallback({
+	blobSize,
+	extension,
+	hasExportStreamApi,
+}: {
+	blobSize: number;
+	extension: string;
+	hasExportStreamApi: boolean;
+}): boolean {
+	if (isExportTooLargeForInMemorySave(blobSize)) {
+		return false;
+	}
+
+	// In Electron, MP4 exports should stay on the temp-file path. If that path
+	// failed, silently falling back to ArrayBuffer reintroduces the >2 GiB crash.
+	if (hasExportStreamApi && normalizeExportExtension(extension) === "mp4") {
+		return false;
+	}
+
+	return true;
+}
+
+export function describeBlockedInMemoryExportSave({
+	blobSize,
+	extension,
+}: {
+	blobSize: number;
+	extension: string;
+}): string {
+	const normalizedExtension = normalizeExportExtension(extension) || "export";
+	if (isExportTooLargeForInMemorySave(blobSize)) {
+		return `The ${normalizedExtension.toUpperCase()} export is too large to save through the legacy in-memory path. Please retry the export so Recordly can save it through the temp-file streaming path.`;
+	}
+
+	return `The ${normalizedExtension.toUpperCase()} export could not be saved through the temp-file streaming path, and Recordly will not fall back to the legacy in-memory path for MP4 exports. Please retry the export.`;
+}


### PR DESCRIPTION
## Description

Fixes #445 by keeping MP4 export saves on the temp-file streaming/finalize path instead of silently falling back to renderer/main-process `ArrayBuffer` saves when the output is large or when Electron MP4 streaming fails.

## Motivation

The v1.3.0 beta still had a legacy in-memory save path that could be reached after a Blob export. For outputs over Node/Electron's Buffer limit, that path can fail with the same `>2 GiB` class of error reported in #445.

## Type

Bug fix

## Related Issue(s)

Fixes #445

## Changes Made

- Added an explicit export-save policy for the in-memory fallback limit.
- Blocked Electron MP4 saves from falling back to the legacy `blob.arrayBuffer()` path after temp-file streaming fails.
- Added main-process guards so old IPC paths reject oversized `ArrayBuffer` saves with a clear message.
- Added focused tests for the save policy and kept existing export stream/muxer tests green.

## Scope Note

This does not change rendering, muxing quality, or native CUDA/D3D11 selection. It only hardens the final save/mux handoff so large exports stay on disk-backed paths.

## Testing Guide

1. Export a small MP4 through Lightning and confirm the save dialog still works.
2. Export a large MP4 expected to exceed 2 GiB and confirm it completes through the temp-file path instead of throwing a Buffer/ArrayBuffer size error.
3. If a large MP4 still fails, collect the export error and whether it failed during render, mux/finalize, or save dialog.

## Validation

- `npm test -- src/lib/exporter/exportSavePolicy.test.ts electron/ipc/export/exportStream.test.ts electron/ipc/register/export.test.ts src/lib/exporter/muxer.test.ts`
- `npm exec -- tsc --noEmit`
- `npx biome check --formatter-enabled=false src/lib/exporter/exportSavePolicy.ts src/lib/exporter/exportSavePolicy.test.ts src/components/video-editor/VideoEditor.tsx electron/ipc/register/export.ts`
- `npx vite build --config vite.config.ts`
- `npm run normalize:electron-main-cjs`
- `npm run smoke:electron-main-cjs`

## Checklist

- [x] Focused scope for #445
- [x] Local tests added/updated
- [x] Production build and Electron CJS smoke pass
- [x] Draft PR opened for review/checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file-size validation for video exports to prevent processing failures
  * Implemented intelligent fallback logic that selects the appropriate save method based on video size and format

* **Bug Fixes**
  * Improved handling of large video exports by utilizing streaming-based processing instead of memory-intensive operations
  * Enhanced error messaging when exports exceed system limitations
  * Better MP4 export handling when streaming capabilities are available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->