### PR TITLE
fix: show full slow-speed clips on timeline

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -186,6 +186,7 @@ import {
 	extendAutoFullTrackClip,
 	type FigureData,
 	getClipSourceEndMs,
+	getTimelineDurationMs,
 	type Padding,
 	mapSourceTimeToTimelineTime as resolveSourceTimeToTimelineTime,
 	mapTimelineTimeToSourceTime as resolveTimelineTimeToSourceTime,
@@ -3418,6 +3419,10 @@ export default function VideoEditor() {
 		() => mapSourceTimeToTimelineTime(currentTime * 1000) / 1000,
 		[currentTime, mapSourceTimeToTimelineTime],
 	);
+	const timelineDuration = useMemo(
+		() => getTimelineDurationMs(clipRegions, duration * 1000) / 1000,
+		[clipRegions, duration],
+	);
 
 	// Merge clip speeds into speed regions so playback + export respect per-clip speed
 	const effectiveSpeedRegions = useMemo<SpeedRegion[]>(() => {
@@ -6549,14 +6554,17 @@ export default function VideoEditor() {
 											handleSeek(
 												next
 													? next.time / 1000
-													: Math.min(duration, timelinePlayheadTime + 5),
+													: Math.min(
+															timelineDuration,
+															timelinePlayheadTime + 5,
+														),
 											);
 										}}
 									>
 										<SkipForward className="w-3.5 h-3.5" weight="fill" />
 									</Button>
 									<span className="text-[10px] font-medium text-muted-foreground/70 tabular-nums ml-1">
-										{formatTime(duration)}
+										{formatTime(timelineDuration)}
 									</span>
 								</div>
 							</div>
@@ -6642,7 +6650,7 @@ export default function VideoEditor() {
 					<TimelineEditor
 						ref={timelineRef}
 						hideToolbar
-						videoDuration={duration}
+						videoDuration={timelineDuration}
 						currentTime={currentTime}
 						playheadTime={timelinePlayheadTime}
 						onSeek={handleSeek}

--- a/src/components/video-editor/types.test.ts
+++ b/src/components/video-editor/types.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
+import { deriveNextId } from "./projectPersistence";
 
 import {
 	extendAutoFullTrackClip,
 	findClipAtTimelineTime,
+	getTimelineDurationMs,
 	mapSourceTimeToTimelineTime,
 	mapTimelineTimeToSourceTime,
 	trimsToClips,
 } from "./types";
-import { deriveNextId } from "./projectPersistence";
 
 describe("extendAutoFullTrackClip", () => {
 	it("extends the default full-track clip when metadata duration grows", () => {
@@ -155,5 +156,25 @@ describe("clip timeline mapping", () => {
 
 		expect(clipsFromTrims.map((clip) => clip.id)).toEqual(["clip-1", "clip-2", "clip-3"]);
 		expect(deriveNextId("clip", clipsFromTrims.map((clip) => clip.id))).toBe(4);
+	});
+});
+
+describe("getTimelineDurationMs", () => {
+	it("extends the timeline when a slow clip becomes longer than the source duration", () => {
+		expect(
+			getTimelineDurationMs(
+				[{ id: "clip-1", startMs: 0, endMs: 20_000, speed: 0.5 }],
+				10_000,
+			),
+		).toBe(20_000);
+	});
+
+	it("keeps the source duration when speed edits make clips shorter", () => {
+		expect(
+			getTimelineDurationMs(
+				[{ id: "clip-1", startMs: 0, endMs: 5_000, speed: 2 }],
+				10_000,
+			),
+		).toBe(10_000);
 	});
 });

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -177,6 +177,18 @@ export function getClipSourceEndMs(clip: ClipRegion): number {
 	return Math.round(clip.startMs + displayDurationMs * speed);
 }
 
+export function getTimelineDurationMs(clips: ClipRegion[], sourceDurationMs: number): number {
+	const baseDurationMs = Math.max(0, Math.round(sourceDurationMs));
+	if (clips.length === 0) {
+		return baseDurationMs;
+	}
+
+	return clips.reduce(
+		(durationMs, clip) => Math.max(durationMs, Math.max(0, Math.round(clip.endMs))),
+		baseDurationMs,
+	);
+}
+
 export function sortClipRegions(clips: ClipRegion[]): ClipRegion[] {
 	return [...clips].sort((left, right) => left.startMs - right.startMs);
 }


### PR DESCRIPTION
## Description
Fixes slow-speed clips becoming partially unreachable on the timeline by deriving the editor timeline duration from both the source duration and the furthest clip end.

## Motivation
When a clip is slowed down, the editor extends that clip's timeline end so playback/export can represent the longer effective duration. The timeline ruler still used only the raw source duration, so the extended tail of the slow clip could be clipped out of view.

## Type
Bug fix

## Related Issue(s)
Closes #434

## Changes Made
- Added `getTimelineDurationMs` to keep the source duration as the floor while allowing slow clips to extend the visible timeline.
- Passed the derived timeline duration into `TimelineEditor`.
- Updated the editor duration display and skip-forward clamp to use the effective timeline duration.
- Added tests for slow clips extending the timeline and fast clips not shrinking it below the source duration.

## Scope Note
This intentionally does not reflow later clips or timeline items after speed edits. It only fixes the visible/reachable timeline range for slow clips.

## Testing Guide
1. Open a recording in the editor.
2. Select a clip and set speed below 1x, for example 0.5x.
3. Confirm the timeline extends far enough to show the whole slowed clip.
4. Confirm fast-speed clips do not unexpectedly shrink the base timeline.

## Validation
- `npm test -- src/components/video-editor/types.test.ts src/components/video-editor/timeline/timelineLayout.test.ts`
- `npm exec -- tsc --noEmit`
- `npx biome check --formatter-enabled=false src/components/video-editor/types.ts src/components/video-editor/types.test.ts src/components/video-editor/VideoEditor.tsx`
- `npx vite build --config vite.config.ts`

## Checklist
- [x] Focused fix for the reported bug
- [x] Added targeted tests
- [x] Typecheck passed
- [x] Scoped Biome check passed
- [x] Production build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline duration now correctly accounts for speed-edited clips, so the timeline extends when clips are slowed and displayed time labels reflect the true video length.
  * Skip-forward and playback controls now use the calculated timeline duration, preventing seeks beyond the visible timeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->