### PR TITLE
test: cover preview skipping cut regions

### DIFF
--- a/src/components/video-editor/videoPlayback/videoEventHandlers.test.ts
+++ b/src/components/video-editor/videoPlayback/videoEventHandlers.test.ts
@@ -123,6 +123,35 @@ describe("createVideoEventHandlers", () => {
 		expect(onTimeUpdate).toHaveBeenCalledWith(0.75);
 	});
 
+	it("skips removed footage when playback reaches a cut region", () => {
+		let animationFrameCallback: FrameRequestCallback | null = null;
+		requestAnimationFrameMock.mockImplementation((callback: FrameRequestCallback) => {
+			animationFrameCallback = callback;
+			return 29;
+		});
+		const video = createMockVideo({ currentTime: 1.25, duration: 10 });
+		const onTimeUpdate = vi.fn();
+		const handlers = createVideoEventHandlers({
+			video,
+			isSeekingRef: createMutableRef(false),
+			isPlayingRef: createMutableRef(false),
+			allowPlaybackRef: createMutableRef(true),
+			currentTimeRef: createMutableRef(0),
+			timeUpdateAnimationRef: createMutableRef<number | null>(null),
+			onPlayStateChange: vi.fn(),
+			onTimeUpdate,
+			trimRegionsRef: createMutableRef([{ id: "trim-1", startMs: 1000, endMs: 2000 }]),
+			speedRegionsRef: createMutableRef([]),
+		});
+
+		handlers.handlePlay();
+		animationFrameCallback?.(0);
+
+		expect(video.currentTime).toBe(2);
+		expect(video.pause).not.toHaveBeenCalled();
+		expect(onTimeUpdate).toHaveBeenLastCalledWith(2);
+	});
+
 	it("cancels a pending requestVideoFrameCallback on pause and dispose", () => {
 		const cancelVideoFrameCallback = vi.fn();
 		const video = createMockVideo({


### PR DESCRIPTION
## Description
Adds a focused regression test for preview playback crossing a cut/trim region.

## Motivation
Issue #408 reported that the editor preview could play through removed footage instead of skipping the cut. Current `main` already skips active trim regions during preview playback; this PR locks that behavior so the timeline playback path does not regress.

## Type
Test coverage / bug regression guard

## Related Issue(s)
Closes #408

## Changes Made
- Added a playback regression test that simulates the video reaching a removed `1s -> 2s` region while playing.
- Verifies preview jumps to the trim end, keeps playback alive, and emits the corrected time.

## Scope Note
No runtime behavior is changed here. The current preview event handler already has the desired skip behavior; this PR adds the missing coverage for the reported playback path.

## Testing Guide
1. Create a timeline cut that removes a middle segment, for example `3s -> 10s`.
2. Play preview from before the cut.
3. Confirm preview jumps over the removed range instead of showing it.

## Validation
- `npm test -- src/components/video-editor/videoPlayback/videoEventHandlers.test.ts src/components/video-editor/types.test.ts`
- `npx biome check --formatter-enabled=false src/components/video-editor/videoPlayback/videoEventHandlers.test.ts`
- `npm exec -- tsc --noEmit`

## Checklist
- [x] Focused regression coverage for the reported behavior
- [x] No unrelated runtime changes
- [x] Targeted tests passed
- [x] Typecheck passed
- [x] Scoped Biome check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for video playback behavior when encountering trim/cut regions, validating proper time advancement past removed footage and correct event handling during playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->