### PR TITLE
fix(export): fallback native Lightning errors

### DIFF
--- a/src/lib/exporter/modernVideoExporter.fallback.test.ts
+++ b/src/lib/exporter/modernVideoExporter.fallback.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+	const videoInfo = {
+		width: 1920,
+		height: 1080,
+		duration: 1,
+		streamDuration: 1,
+		frameRate: 30,
+		codec: "h264",
+		hasAudio: false,
+		audioCodec: null,
+		audioSampleRate: null,
+	};
+
+	return {
+		videoInfo,
+		streamingDecoderDestroy: vi.fn(),
+		streamingDecoderCancel: vi.fn(),
+		streamingDecoderDecodeAll: vi.fn(async () => {}),
+		streamingDecoderGetDemuxer: vi.fn(() => null),
+		streamingDecoderGetEffectiveDuration: vi.fn(() => 0),
+		streamingDecoderLoadMetadata: vi.fn(async () => videoInfo),
+		frameRendererDestroy: vi.fn(),
+		frameRendererGetBackend: vi.fn(() => "webgl"),
+		frameRendererInitialize: vi.fn(async () => {}),
+		muxerDestroy: vi.fn(),
+		muxerFinalize: vi.fn(async () => ({
+			mode: "buffer" as const,
+			blob: new Blob([], { type: "video/mp4" }),
+		})),
+		muxerInitialize: vi.fn(async () => {}),
+	};
+});
+
+vi.mock("./streamingDecoder", () => ({
+	StreamingVideoDecoder: vi.fn().mockImplementation(function () {
+		return {
+			cancel: mocks.streamingDecoderCancel,
+			decodeAll: mocks.streamingDecoderDecodeAll,
+			destroy: mocks.streamingDecoderDestroy,
+			getDemuxer: mocks.streamingDecoderGetDemuxer,
+			getEffectiveDuration: mocks.streamingDecoderGetEffectiveDuration,
+			loadMetadata: mocks.streamingDecoderLoadMetadata,
+		};
+	}),
+}));
+
+vi.mock("./modernFrameRenderer", () => ({
+	FrameRenderer: vi.fn().mockImplementation(function () {
+		return {
+			destroy: mocks.frameRendererDestroy,
+			getRendererBackend: mocks.frameRendererGetBackend,
+			initialize: mocks.frameRendererInitialize,
+		};
+	}),
+}));
+
+vi.mock("./muxer", () => ({
+	VideoMuxer: vi.fn().mockImplementation(function () {
+		return {
+			destroy: mocks.muxerDestroy,
+			finalize: mocks.muxerFinalize,
+			initialize: mocks.muxerInitialize,
+		};
+	}),
+}));
+
+describe("ModernVideoExporter native fallback routing", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("falls back to WebCodecs instead of surfacing a native error when Breeze is unavailable", async () => {
+		const { ModernVideoExporter } = await import("./modernVideoExporter");
+		const exporter = new ModernVideoExporter({
+			videoUrl: "file:///recording.mp4",
+			width: 1920,
+			height: 1080,
+			frameRate: 30,
+			bitrate: 8_000_000,
+			wallpaper: "#101010",
+			padding: 0,
+			borderRadius: 0,
+			backgroundBlur: 0,
+			shadowIntensity: 0,
+			showShadow: false,
+			cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+			experimentalNativeExport: true,
+			backendPreference: "breeze",
+		} as never) as unknown as {
+			export: () => Promise<{ success: boolean; blob?: Blob; error?: string }>;
+			initializeEncoder: () => Promise<unknown>;
+			loadNativeStaticLayoutVideoInfo: () => Promise<unknown>;
+			tryExportNativeStaticLayout: () => Promise<unknown>;
+			tryStartNativeVideoExport: () => Promise<boolean>;
+			lastNativeExportError: string | null;
+		};
+
+		vi.spyOn(exporter, "loadNativeStaticLayoutVideoInfo").mockResolvedValue(mocks.videoInfo);
+		vi.spyOn(exporter, "tryExportNativeStaticLayout").mockResolvedValue(null);
+		vi.spyOn(exporter, "tryStartNativeVideoExport").mockImplementation(async () => {
+			exporter.lastNativeExportError = "Breeze native encoder unavailable";
+			return false;
+		});
+		const initializeEncoder = vi.spyOn(exporter, "initializeEncoder").mockResolvedValue({
+			codec: "avc1.640034",
+			hardwareAcceleration: "prefer-hardware",
+		});
+
+		const result = await exporter.export();
+
+		expect(result.success).toBe(true);
+		expect(result.error).toBeUndefined();
+		expect(result.blob).toBeInstanceOf(Blob);
+		expect(initializeEncoder).toHaveBeenCalledTimes(1);
+		expect(mocks.muxerFinalize).toHaveBeenCalledTimes(1);
+	}, 15_000);
+});

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -346,7 +346,7 @@ export class ModernVideoExporter {
 			const runtimePlatform = this.getRuntimePlatform();
 			let useNativeEncoder = false;
 			let triedNativeStaticLayoutWithProbe = false;
-			const shouldDeferNativeEncoderStart = backendPreference === "breeze";
+			let shouldDeferNativeEncoderStart = backendPreference === "breeze";
 			this.lastNativeExportError = null;
 
 			let stageStartedAt = this.getNowMs();
@@ -512,10 +512,23 @@ export class ModernVideoExporter {
 				useNativeEncoder = await this.tryStartNativeVideoExport();
 				this.nativeSessionStartTimeMs = this.getNowMs() - stageStartedAt;
 				if (!useNativeEncoder) {
-					throw new Error(
+					const nativeFailure =
 						this.lastNativeExportError ??
-							`${NATIVE_EXPORT_ENGINE_NAME} export is unavailable for this output profile on this system.`,
+						`${NATIVE_EXPORT_ENGINE_NAME} export is unavailable for this output profile on this system.`;
+					console.warn(
+						`[VideoExporter] ${NATIVE_EXPORT_ENGINE_NAME} native export unavailable after static-layout fallback; falling back to WebCodecs.`,
+						nativeFailure,
 					);
+					shouldDeferNativeEncoderStart = false;
+					this.backpressureProfile = getExportBackpressureProfile({
+						encodeBackend: "webcodecs",
+						width: this.config.width,
+						height: this.config.height,
+						frameRate: this.config.frameRate,
+						encodingMode: this.config.encodingMode,
+					});
+					this.maxNativeWriteInFlight = 1;
+					await this.initializeEncoder();
 				}
 			}
 


### PR DESCRIPTION
﻿## Description

Fixes the Lightning export UX where a native/Breeze failure can surface as an "Export issue" even though Lightning should fall back to WebCodecs and continue.

## Motivation

Issue #458 reports that Lightning export shows a scary failure message first, then appears to keep exporting through a fallback path. That is confusing because the UI says Lightning automatically chooses the fastest compatible backend and falls back when needed.

Root cause: the deferred native/Breeze encoder path treated native unavailability as a hard error after the static-layout attempt had already fallen through. In that state, the exporter returned an error to the editor instead of initializing the WebCodecs path as the actual fallback.

## Type of Change

- Bug fix
- Export UX/reliability hardening

## Related Issues

Closes #458

## Changes Made

- When deferred Breeze/native startup fails after static-layout routing, log the native failure and initialize WebCodecs instead of throwing.
- Reset the active backpressure profile to the WebCodecs profile before initializing the fallback encoder.
- Add a focused regression test covering the native/Breeze unavailable -> WebCodecs success path.

## Scope Note

This does not change native static-layout eligibility, CUDA/D3D11 routing, audio muxing, save/finalize behavior, or WebCodecs encoder selection. It only prevents a recoverable native failure from becoming a user-visible export error before fallback.

## Testing Guide

1. Use Lightning export on a Windows machine/path where native/Breeze is unavailable or fails early.
2. Confirm the export continues through WebCodecs without showing an "Export issue" modal first.
3. Confirm true export failures still surface normally.

## Local Checks

- `npm test -- src/lib/exporter/modernVideoExporter.fallback.test.ts src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts`
- `npx biome check src/lib/exporter/modernVideoExporter.fallback.test.ts`
- `npx biome check --formatter-enabled=false src/lib/exporter/modernVideoExporter.ts src/lib/exporter/modernVideoExporter.fallback.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npx vite build --config vite.config.ts`
- `npm run smoke:electron-main-cjs`

## Checklist

- [x] Focused fix with no unrelated refactor
- [x] Regression test added
- [x] Typecheck/build/smoke pass
- [x] PR opened as draft for CodeRabbit review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Improved video export reliability with enhanced fallback handling. When native encoding becomes unavailable during export, the system now automatically switches to an alternative encoding method while logging diagnostic information, rather than failing the entire operation. This ensures video exports continue seamlessly without requiring user intervention, improving overall export robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->