### PR TITLE
fix(export): use portrait target dimensions

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -97,6 +97,10 @@ import {
 	getAspectRatioValue,
 } from "@/utils/aspectRatioUtils";
 import { ExtensionIcon } from "./ExtensionIcon";
+import {
+	calculateMp4ExportDimensions,
+	calculateMp4SourceDimensions,
+} from "./exportDimensions";
 
 const PhCursorFill = (props: { className?: string; weight?: "fill" | "regular" }) => (
 	<Cursor weight="fill" className={props.className} />
@@ -515,76 +519,6 @@ function areDeepEqual(left: unknown, right: unknown): boolean {
 	}
 
 	return true;
-}
-
-function calculateMp4SourceDimensions(
-	sourceWidth: number,
-	sourceHeight: number,
-	aspectRatio: AspectRatio,
-): { width: number; height: number } {
-	const safeSourceWidth = Math.max(2, Math.floor(sourceWidth / 2) * 2);
-	const safeSourceHeight = Math.max(2, Math.floor(sourceHeight / 2) * 2);
-	const sourceAspectRatio = safeSourceHeight > 0 ? safeSourceWidth / safeSourceHeight : 16 / 9;
-	const aspectRatioValue = getAspectRatioValue(aspectRatio, sourceAspectRatio);
-
-	if (aspectRatio === "native") {
-		return { width: safeSourceWidth, height: safeSourceHeight };
-	}
-
-	if (aspectRatioValue === 1) {
-		const baseDimension = Math.max(
-			2,
-			Math.floor(Math.min(safeSourceWidth, safeSourceHeight) / 2) * 2,
-		);
-		return { width: baseDimension, height: baseDimension };
-	}
-
-	if (aspectRatioValue > 1) {
-		const baseWidth = safeSourceWidth;
-		for (let width = baseWidth; width >= 100; width -= 2) {
-			const height = Math.round(width / aspectRatioValue);
-			if (height % 2 === 0 && Math.abs(width / height - aspectRatioValue) < 0.0001) {
-				return { width, height };
-			}
-		}
-
-		return {
-			width: baseWidth,
-			height: Math.max(2, Math.floor(baseWidth / aspectRatioValue / 2) * 2),
-		};
-	}
-
-	const baseHeight = safeSourceHeight;
-	for (let height = baseHeight; height >= 100; height -= 2) {
-		const width = Math.round(height * aspectRatioValue);
-		if (width % 2 === 0 && Math.abs(width / height - aspectRatioValue) < 0.0001) {
-			return { width, height };
-		}
-	}
-
-	return {
-		height: baseHeight,
-		width: Math.max(2, Math.floor((baseHeight * aspectRatioValue) / 2) * 2),
-	};
-}
-
-function calculateMp4ExportDimensions(
-	baseWidth: number,
-	baseHeight: number,
-	quality: ExportQuality,
-): { width: number; height: number } {
-	if (quality === "source") {
-		return {
-			width: Math.max(2, Math.floor(baseWidth / 2) * 2),
-			height: Math.max(2, Math.floor(baseHeight / 2) * 2),
-		};
-	}
-
-	const qualityScale = quality === "medium" ? 0.6 : quality === "good" ? 0.75 : 0.9;
-	return {
-		width: Math.max(2, Math.floor((baseWidth * qualityScale) / 2) * 2),
-		height: Math.max(2, Math.floor((baseHeight * qualityScale) / 2) * 2),
-	};
 }
 
 function getErrorMessage(error: unknown): string {

--- a/src/components/video-editor/exportDimensions.test.ts
+++ b/src/components/video-editor/exportDimensions.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { calculateMp4ExportDimensions, calculateMp4SourceDimensions } from "./exportDimensions";
+
+describe("calculateMp4SourceDimensions", () => {
+	it("keeps native exports at the source dimensions", () => {
+		expect(calculateMp4SourceDimensions(1920, 1080, "native")).toEqual({
+			width: 1920,
+			height: 1080,
+		});
+	});
+
+	it("uses the rotated source bounds for 9:16 original exports", () => {
+		expect(calculateMp4SourceDimensions(1920, 1080, "9:16")).toEqual({
+			width: 1080,
+			height: 1920,
+		});
+	});
+
+	it("uses the rotated source bounds for portrait social ratios", () => {
+		expect(calculateMp4SourceDimensions(1920, 1080, "4:5")).toEqual({
+			width: 1080,
+			height: 1350,
+		});
+	});
+
+	it("keeps landscape aspect-ratio exports inside the source bounds", () => {
+		expect(calculateMp4SourceDimensions(1920, 1080, "4:3")).toEqual({
+			width: 1440,
+			height: 1080,
+		});
+	});
+});
+
+describe("calculateMp4ExportDimensions", () => {
+	it("scales portrait output dimensions from the aspect target", () => {
+		const sourceDimensions = calculateMp4SourceDimensions(1920, 1080, "9:16");
+
+		expect(
+			calculateMp4ExportDimensions(sourceDimensions.width, sourceDimensions.height, "source"),
+		).toEqual({
+			width: 1080,
+			height: 1920,
+		});
+		expect(
+			calculateMp4ExportDimensions(sourceDimensions.width, sourceDimensions.height, "high"),
+		).toEqual({
+			width: 972,
+			height: 1728,
+		});
+	});
+});

--- a/src/components/video-editor/exportDimensions.ts
+++ b/src/components/video-editor/exportDimensions.ts
@@ -1,0 +1,68 @@
+import type { ExportQuality } from "@/lib/exporter";
+import { type AspectRatio, getAspectRatioValue } from "@/utils/aspectRatioUtils";
+
+function normalizeEvenDimension(value: number): number {
+	return Math.max(2, Math.floor(value / 2) * 2);
+}
+
+function fitAspectRatioWithinBounds(
+	maxWidth: number,
+	maxHeight: number,
+	aspectRatioValue: number,
+): { width: number; height: number } {
+	const safeMaxWidth = normalizeEvenDimension(maxWidth);
+	const safeMaxHeight = normalizeEvenDimension(maxHeight);
+	const safeAspectRatio =
+		Number.isFinite(aspectRatioValue) && aspectRatioValue > 0 ? aspectRatioValue : 16 / 9;
+
+	if (safeMaxWidth / safeMaxHeight > safeAspectRatio) {
+		const height = safeMaxHeight;
+		const width = normalizeEvenDimension(height * safeAspectRatio);
+		return { width: Math.min(width, safeMaxWidth), height };
+	}
+
+	const width = safeMaxWidth;
+	const height = normalizeEvenDimension(width / safeAspectRatio);
+	return { width, height: Math.min(height, safeMaxHeight) };
+}
+
+export function calculateMp4SourceDimensions(
+	sourceWidth: number,
+	sourceHeight: number,
+	aspectRatio: AspectRatio,
+): { width: number; height: number } {
+	const safeSourceWidth = normalizeEvenDimension(sourceWidth);
+	const safeSourceHeight = normalizeEvenDimension(sourceHeight);
+	const sourceAspectRatio = safeSourceHeight > 0 ? safeSourceWidth / safeSourceHeight : 16 / 9;
+	const aspectRatioValue = getAspectRatioValue(aspectRatio, sourceAspectRatio);
+
+	if (aspectRatio === "native") {
+		return { width: safeSourceWidth, height: safeSourceHeight };
+	}
+
+	const longSide = Math.max(safeSourceWidth, safeSourceHeight);
+	const shortSide = Math.min(safeSourceWidth, safeSourceHeight);
+	const maxWidth = aspectRatioValue >= 1 ? longSide : shortSide;
+	const maxHeight = aspectRatioValue >= 1 ? shortSide : longSide;
+
+	return fitAspectRatioWithinBounds(maxWidth, maxHeight, aspectRatioValue);
+}
+
+export function calculateMp4ExportDimensions(
+	baseWidth: number,
+	baseHeight: number,
+	quality: ExportQuality,
+): { width: number; height: number } {
+	if (quality === "source") {
+		return {
+			width: normalizeEvenDimension(baseWidth),
+			height: normalizeEvenDimension(baseHeight),
+		};
+	}
+
+	const qualityScale = quality === "medium" ? 0.6 : quality === "good" ? 0.75 : 0.9;
+	return {
+		width: normalizeEvenDimension(baseWidth * qualityScale),
+		height: normalizeEvenDimension(baseHeight * qualityScale),
+	};
+}


### PR DESCRIPTION
## Summary
- Fix MP4 target dimension calculation for non-native aspect ratios so portrait exports use rotated source bounds instead of shrinking into the original landscape height.
- Move MP4 dimension helpers into a small testable module.
- Add coverage for 9:16, 4:5, 4:3, native, and quality scaling.

## Why
Fixes #460. A 1920x1080 recording exported as 9:16 Original should target 1080x1920, not a smaller canvas fit inside 1920x1080.

## Validation
- npm test -- src/components/video-editor/exportDimensions.test.ts
- npx biome check src/components/video-editor/exportDimensions.ts src/components/video-editor/exportDimensions.test.ts
- npx biome check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/exportDimensions.ts src/components/video-editor/exportDimensions.test.ts
- npx tsc --noEmit --pretty false
- git diff --check
- npx vite build --config vite.config.ts
- npm run smoke:electron-main-cjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved MP4 export dimension calculations with enhanced support for multiple aspect ratios (native, 9:16, 4:5, 4:3) and quality presets, ensuring optimized video output.

* **Tests**
  * Added comprehensive test coverage for MP4 dimension calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->