### PR TITLE
test(export): cover odd MP4 dimension normalization

### DIFF
--- a/src/components/video-editor/exportDimensions.test.ts
+++ b/src/components/video-editor/exportDimensions.test.ts
@@ -32,6 +32,27 @@ describe("calculateMp4SourceDimensions", () => {
 });
 
 describe("calculateMp4ExportDimensions", () => {
+	it("normalizes odd source dimensions to even export dimensions", () => {
+		const sourceDimensions = calculateMp4SourceDimensions(1919, 1079, "native");
+
+		expect(sourceDimensions).toEqual({
+			width: 1918,
+			height: 1078,
+		});
+		expect(
+			calculateMp4ExportDimensions(sourceDimensions.width, sourceDimensions.height, "source"),
+		).toEqual({
+			width: 1918,
+			height: 1078,
+		});
+		expect(
+			calculateMp4ExportDimensions(sourceDimensions.width, sourceDimensions.height, "high"),
+		).toEqual({
+			width: 1726,
+			height: 970,
+		});
+	});
+
 	it("scales portrait output dimensions from the aspect target", () => {
 		const sourceDimensions = calculateMp4SourceDimensions(1920, 1080, "9:16");
 


### PR DESCRIPTION
## Description
Add focused regression coverage for odd MP4 source dimensions in the export dimension helpers.

## Motivation
Follow-up to #462 and CodeRabbit's test-coverage note: the helper already normalizes odd dimensions for encoder safety, but the behavior should be locked by a direct test.

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [x] Other: test coverage

## Related Issue(s)
- Follow-up to #460 / #462

## Changes Made
- add an odd-dimension regression case for `calculateMp4SourceDimensions`
- verify `calculateMp4ExportDimensions` keeps `source` and `high` outputs even

## Scope Note
Test-only follow-up. No export logic changes.

## Testing Guide
1. Run the focused export-dimension test suite.
2. Confirm the odd-dimension case passes for native/source and high-quality outputs.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the change locally.
- [x] I have kept the PR test-only.

Local checks run:
- `npm test -- src/components/video-editor/exportDimensions.test.ts`
- `npx biome check src/components/video-editor/exportDimensions.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for video export dimensions, verifying that odd source dimensions are properly normalized to even export dimensions across different export quality modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->