### PR TITLE
fix(recording): stop browser recorder before cleanup

### DIFF
--- a/src/hooks/useScreenRecorder.test.ts
+++ b/src/hooks/useScreenRecorder.test.ts
@@ -132,6 +132,11 @@ function stopRecording(
 		if (webcamRecorder && webcamRecorder.state !== "inactive") {
 			webcamRecorder.stop();
 		}
+		try {
+			recorder.requestData();
+		} catch {
+			// Stopping should continue even if the browser refuses an explicit flush.
+		}
 		recorder.stop();
 		return { stopped: true, wasNative: false };
 	}
@@ -326,6 +331,31 @@ describe("useScreenRecorder state machine", () => {
 			stopRecording(recorder, false);
 
 			expect(callOrder).toEqual(["resume", "stop"]);
+		});
+
+		it("flushes the current recorder data before stopping", () => {
+			const callOrder: string[] = [];
+			recorder.requestData.mockImplementation(() => {
+				callOrder.push("requestData");
+			});
+			recorder.stop.mockImplementation(() => {
+				callOrder.push("stop");
+			});
+
+			stopRecording(recorder, false);
+
+			expect(callOrder).toEqual(["requestData", "stop"]);
+		});
+
+		it("still stops when the explicit data flush fails", () => {
+			recorder.requestData.mockImplementation(() => {
+				throw new Error("flush failed");
+			});
+
+			const result = stopRecording(recorder, false);
+
+			expect(result.stopped).toBe(true);
+			expect(recorder.stop).toHaveBeenCalled();
 		});
 
 		it("still stops when resume throws from paused state", () => {

--- a/src/hooks/useScreenRecorder.test.ts
+++ b/src/hooks/useScreenRecorder.test.ts
@@ -347,6 +347,24 @@ describe("useScreenRecorder state machine", () => {
 			expect(callOrder).toEqual(["requestData", "stop"]);
 		});
 
+		it("resumes, flushes, then stops from paused state", () => {
+			recorder.pause();
+			const callOrder: string[] = [];
+			recorder.resume.mockImplementation(() => {
+				callOrder.push("resume");
+			});
+			recorder.requestData.mockImplementation(() => {
+				callOrder.push("requestData");
+			});
+			recorder.stop.mockImplementation(() => {
+				callOrder.push("stop");
+			});
+
+			stopRecording(recorder, false);
+
+			expect(callOrder).toEqual(["resume", "requestData", "stop"]);
+		});
+
 		it("still stops when the explicit data flush fails", () => {
 			recorder.requestData.mockImplementation(() => {
 				throw new Error("flush failed");
@@ -356,6 +374,26 @@ describe("useScreenRecorder state machine", () => {
 
 			expect(result.stopped).toBe(true);
 			expect(recorder.stop).toHaveBeenCalled();
+		});
+
+		it("still stops from paused state when the explicit data flush fails", () => {
+			recorder.pause();
+			const callOrder: string[] = [];
+			recorder.resume.mockImplementation(() => {
+				callOrder.push("resume");
+			});
+			recorder.requestData.mockImplementation(() => {
+				callOrder.push("requestData");
+				throw new Error("flush failed");
+			});
+			recorder.stop.mockImplementation(() => {
+				callOrder.push("stop");
+			});
+
+			const result = stopRecording(recorder, false);
+
+			expect(result.stopped).toBe(true);
+			expect(callOrder).toEqual(["resume", "requestData", "stop"]);
 		});
 
 		it("still stops when resume throws from paused state", () => {

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1092,7 +1092,11 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				}
 			}
 			pendingWebcamPathPromise.current = stopWebcamRecorder();
-			cleanupCapturedMedia();
+			try {
+				recorder.requestData();
+			} catch (error) {
+				console.warn("Failed to flush recorder before stopping:", error);
+			}
 			recorder.stop();
 			setRecording(false);
 			setFinalizing(true);


### PR DESCRIPTION
## Description

Stops the browser MediaRecorder before tearing down the captured media tracks, and explicitly requests the final data chunk before stop.

## Motivation

Issue #400 still has evidence of raw recordings ending shorter when system audio is enabled. The browser fallback stop path was stopping the underlying media tracks before `MediaRecorder.stop()`, which can drop or shorten the final encoder chunk on mixed audio/video streams.

## Type of Change

- Bug fix
- Regression coverage

## Related Issue(s)

Fixes #400

## Changes Made

- Removed the pre-stop `cleanupCapturedMedia()` call from the browser recorder stop path.
- Added a guarded `recorder.requestData()` flush immediately before `recorder.stop()`.
- Added state-machine tests covering final data flush and flush-failure fallback.

## Scope Note

This is intentionally narrow. It does not change native Windows/macOS recording, export planning, or the earlier audio processing changes.

## Validation

- `npm test -- src/hooks/useScreenRecorder.test.ts`
- `npx biome check --formatter-enabled=false src/hooks/useScreenRecorder.ts src/hooks/useScreenRecorder.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npx vite build --config vite.config.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen recording stop behavior to flush pending recorded data (when possible) before stopping, with graceful error handling so recordings still stop reliably; fixes edge cases around paused recordings and preserves expected operation order.

* **Tests**
  * Added tests covering flush-before-stop behavior, paused/resume paths, error handling, and call-order verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->