### PR TITLE
fix(editor): keep cursor size stable during zoom

### DIFF
--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -2182,6 +2182,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 						baseMaskRef.current,
 						showCursorRef.current,
 						!isPlayingRef.current || isSeekingRef.current,
+						animationStateRef.current.appliedScale || 1,
 					);
 
 					smoothedCursorForHooks = mapSmoothedCursorToCanvasNormalized(

--- a/src/components/video-editor/videoPlayback/cursorRenderer.test.ts
+++ b/src/components/video-editor/videoPlayback/cursorRenderer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCursorDrawHeight } from "./cursorRenderer";
+
+describe("resolveCursorDrawHeight", () => {
+	const viewport = {
+		x: 100,
+		y: 50,
+		width: 960,
+		height: 540,
+	};
+
+	it("keeps cursor output size stable when the zoom parent scales up", () => {
+		const baseHeight = resolveCursorDrawHeight(viewport, 70, 1);
+		const zoomedLocalHeight = resolveCursorDrawHeight(viewport, 70, 2);
+
+		expect(zoomedLocalHeight).toBeCloseTo(baseHeight / 2, 6);
+		expect(zoomedLocalHeight * 2).toBeCloseTo(baseHeight, 6);
+	});
+
+	it("falls back to unscaled sizing for invalid parent scale values", () => {
+		const baseHeight = resolveCursorDrawHeight(viewport, 70, 1);
+
+		expect(resolveCursorDrawHeight(viewport, 70, 0)).toBe(baseHeight);
+		expect(resolveCursorDrawHeight(viewport, 70, Number.NaN)).toBe(baseHeight);
+	});
+});

--- a/src/components/video-editor/videoPlayback/cursorRenderer.ts
+++ b/src/components/video-editor/videoPlayback/cursorRenderer.ts
@@ -1,8 +1,8 @@
 import { Assets, BlurFilter, Container, Graphics, Sprite, Texture } from "pixi.js";
 import { MotionBlurFilter } from "pixi-filters/motion-blur";
+import minimalCursorUrl from "@/assets/cursors/custom/minimal-cursor.svg";
 import { getRenderableAssetUrl } from "@/lib/assetPath";
 import { extensionHost } from "@/lib/extensions";
-import minimalCursorUrl from "@/assets/cursors/custom/minimal-cursor.svg";
 import {
 	type CursorStyle,
 	type CursorTelemetryPoint,
@@ -12,11 +12,11 @@ import {
 import { computeCursorSwayRotation } from "./cursorSway";
 import { type CursorViewportRect, projectCursorPositionToViewport } from "./cursorViewport";
 import {
+	type CursorSpringTuning,
 	createSpringState,
 	getCursorSpringConfig,
 	resetSpringState,
 	stepSpringValue,
-	type CursorSpringTuning,
 } from "./motionSmoothing";
 import { cursorSetAssets, getCursorStyleSizeMultiplier } from "./uploadedCursorAssets";
 
@@ -745,6 +745,15 @@ function getCursorViewportScale(viewport: CursorViewportRect) {
 	return Math.max(MIN_CURSOR_VIEWPORT_SCALE, viewport.width / REFERENCE_WIDTH);
 }
 
+export function resolveCursorDrawHeight(
+	viewport: CursorViewportRect,
+	dotRadius: number,
+	parentScale = 1,
+) {
+	const safeParentScale = Number.isFinite(parentScale) && parentScale > 0 ? parentScale : 1;
+	return (dotRadius * getCursorViewportScale(viewport)) / safeParentScale;
+}
+
 function getCursorSwaySpringConfig(
 	smoothingFactor: number,
 	springTuning: CursorSpringTuning,
@@ -1061,6 +1070,7 @@ export class PixiCursorOverlay {
 		viewport: CursorViewportRect,
 		visible: boolean,
 		freeze = false,
+		parentScale = 1,
 	): void {
 		if (!visible || samples.length === 0 || viewport.width <= 0 || viewport.height <= 0) {
 			this.container.visible = false;
@@ -1107,7 +1117,7 @@ export class PixiCursorOverlay {
 
 		const px = viewport.x + this.state.x * viewport.width;
 		const py = viewport.y + this.state.y * viewport.height;
-		const h = this.config.dotRadius * getCursorViewportScale(viewport);
+		const h = resolveCursorDrawHeight(viewport, this.config.dotRadius, parentScale);
 		const { cursorType, clickBounceProgress } = getCursorVisualState(
 			samples,
 			timeMs,
@@ -1303,6 +1313,7 @@ export function drawCursorOnCanvas(
 	viewport: CursorViewportRect,
 	smoothedState: SmoothedCursorState,
 	config: CursorRenderConfig = DEFAULT_CURSOR_CONFIG,
+	parentScale = 1,
 ): void {
 	if (samples.length === 0 || viewport.width <= 0 || viewport.height <= 0) return;
 
@@ -1316,7 +1327,7 @@ export function drawCursorOnCanvas(
 
 	const px = viewport.x + smoothedState.x * viewport.width;
 	const py = viewport.y + smoothedState.y * viewport.height;
-	const h = config.dotRadius * getCursorViewportScale(viewport);
+	const h = resolveCursorDrawHeight(viewport, config.dotRadius, parentScale);
 	const { cursorType, clickBounceProgress } = getCursorVisualState(
 		samples,
 		timeMs,

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -1626,6 +1626,12 @@ export class FrameRenderer {
 		const timeMs = this.currentVideoTime * 1000;
 		const cursorTimeMs = cursorTimestamp / 1000;
 
+		const TICKS_PER_FRAME = 1;
+
+		for (let i = 0; i < TICKS_PER_FRAME; i++) {
+			this.updateAnimationState(timeMs);
+		}
+
 		if (this.cursorOverlay) {
 			this.cursorOverlay.update(
 				this.config.cursorTelemetry ?? [],
@@ -1633,6 +1639,7 @@ export class FrameRenderer {
 				layoutCache.maskRect,
 				this.config.showCursor ?? true,
 				false,
+				this.animationState.appliedScale || 1,
 			);
 		}
 
@@ -1654,12 +1661,6 @@ export class FrameRenderer {
 					}
 				: null,
 		);
-
-		const TICKS_PER_FRAME = 1;
-
-		for (let i = 0; i < TICKS_PER_FRAME; i++) {
-			this.updateAnimationState(timeMs);
-		}
 
 		applyZoomTransform({
 			cameraContainer: this.cameraContainer,
@@ -2110,6 +2111,8 @@ export class FrameRenderer {
 		const timeMs = this.currentVideoTime * 1000;
 		const cursorTimeMs = cursorTimestamp / 1000;
 
+		this.updateAnimationState(timeMs);
+
 		if (this.cursorOverlay) {
 			this.cursorOverlay.update(
 				this.config.cursorTelemetry ?? [],
@@ -2117,6 +2120,7 @@ export class FrameRenderer {
 				layoutCache.maskRect,
 				this.config.showCursor ?? true,
 				false,
+				this.animationState.appliedScale || 1,
 			);
 		}
 
@@ -2128,8 +2132,6 @@ export class FrameRenderer {
 				canvasHeight: this.config.height,
 			},
 		);
-
-		this.updateAnimationState(timeMs);
 
 		applyZoomTransform({
 			cameraContainer: this.cameraContainer,

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -2885,6 +2885,8 @@ export class FrameRenderer {
 		const timeMs = this.currentVideoTime * 1000;
 		const cursorTimeMs = cursorTimestamp / 1000;
 
+		this.updateAnimationState(timeMs);
+
 		if (this.cursorOverlay) {
 			this.cursorOverlay.update(
 				this.config.cursorTelemetry ?? [],
@@ -2892,10 +2894,9 @@ export class FrameRenderer {
 				layoutCache.maskRect,
 				this.config.showCursor ?? true,
 				false,
+				this.animationState.appliedScale || 1,
 			);
 		}
-
-		this.updateAnimationState(timeMs);
 
 		applyZoomTransform({
 			cameraContainer: this.cameraContainer,
@@ -3132,6 +3133,8 @@ export class FrameRenderer {
 		const timeMs = this.currentVideoTime * 1000;
 		const cursorTimeMs = cursorTimestamp / 1000;
 
+		this.updateAnimationState(timeMs);
+
 		if (this.cursorOverlay) {
 			this.cursorOverlay.update(
 				this.config.cursorTelemetry ?? [],
@@ -3139,10 +3142,9 @@ export class FrameRenderer {
 				layoutCache.maskRect,
 				this.config.showCursor ?? true,
 				false,
+				this.animationState.appliedScale || 1,
 			);
 		}
-
-		this.updateAnimationState(timeMs);
 
 		applyZoomTransform({
 			cameraContainer: this.cameraContainer,


### PR DESCRIPTION
﻿## Summary

Fixes #395 by keeping the cursor's rendered output size independent from the active zoom transform.

## Root Cause

The Pixi cursor overlay sits under the zoomed camera container so its position correctly follows the zoomed screen content, but its local sprite size was also multiplied by the camera zoom. That made cursors grow during zoom-ins and shrink during zoom-outs.

## Changes

- add a cursor draw-height helper that compensates for the parent zoom scale
- pass the active zoom scale from preview, legacy export, and modern export renderers
- update export renderer ordering so the cursor uses the current frame's zoom scale
- add focused regression coverage for the zoom compensation math

## Validation

- `npm test -- src/components/video-editor/videoPlayback/cursorRenderer.test.ts src/components/video-editor/videoPlayback/cursorViewport.test.ts src/components/video-editor/videoPlayback/zoomTransform.test.ts`
- `npm test -- src/lib/exporter/frameRenderer.test.ts src/lib/exporter/modernFrameRenderer.test.ts src/lib/exporter/temporalMotionBlur.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check --formatter-enabled=false src/components/video-editor/videoPlayback/cursorRenderer.ts src/components/video-editor/videoPlayback/cursorRenderer.test.ts src/components/video-editor/VideoPlayback.tsx src/lib/exporter/frameRenderer.ts src/lib/exporter/modernFrameRenderer.ts` (passes with existing `VideoPlayback.tsx` hook-dependency warnings only)
- `git diff --check`
- `npx vite build --config vite.config.ts`
- `npm run smoke:electron-main-cjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor rendering to accurately display when video zoom or scale animations are applied.

* **Tests**
  * Added unit tests to verify cursor height calculations remain stable across different scaling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->