### PR TITLE
fix(export): scale MP4 bitrate with frame rate

### DIFF
--- a/src/lib/exporter/exportBitrate.test.ts
+++ b/src/lib/exporter/exportBitrate.test.ts
@@ -15,6 +15,28 @@ describe("export bitrate policy", () => {
 		).toBe(27_000_000);
 	});
 
+	it("raises high-resolution 60fps source-quality exports above the 30fps budget", () => {
+		const sharedOptions = {
+			width: 2560,
+			height: 1440,
+			quality: "source" as const,
+			encodingMode: "quality" as const,
+		};
+
+		const thirtyFpsBitrate = getMp4ExportBitrate({
+			...sharedOptions,
+			frameRate: 30,
+		});
+		const sixtyFpsBitrate = getMp4ExportBitrate({
+			...sharedOptions,
+			frameRate: 60,
+		});
+
+		expect(thirtyFpsBitrate).toBe(45_000_000);
+		expect(sixtyFpsBitrate).toBeGreaterThan(thirtyFpsBitrate);
+		expect(sixtyFpsBitrate).toBe(63_639_610);
+	});
+
 	it("keeps modern native static-layout source exports high enough for screen text", () => {
 		expect(
 			getMp4ExportBitrate({

--- a/src/lib/exporter/exportBitrate.ts
+++ b/src/lib/exporter/exportBitrate.ts
@@ -2,6 +2,7 @@ import type { ExportEncodingMode, ExportMp4FrameRate, ExportQuality } from "./ty
 
 const MIN_MP4_BITRATE = 2_000_000;
 const REFERENCE_PIXEL_RATE = 1920 * 1080 * 30;
+const REFERENCE_FRAME_RATE = 30;
 
 export function getEncodingModeBitrateMultiplier(encodingMode: ExportEncodingMode): number {
 	switch (encodingMode) {
@@ -39,6 +40,10 @@ function getBaseMp4ExportBitrate(width: number, height: number, quality: ExportQ
 		return 20_000_000;
 	}
 	return 30_000_000;
+}
+
+function getFrameRateBitrateMultiplier(frameRate: ExportMp4FrameRate): number {
+	return Math.sqrt(Math.max(1, frameRate / REFERENCE_FRAME_RATE));
 }
 
 function getModernNativeStaticLayoutBitrateCap(
@@ -87,6 +92,7 @@ export function getMp4ExportBitrate(options: {
 }): number {
 	const requestedBitrate = Math.round(
 		getBaseMp4ExportBitrate(options.width, options.height, options.quality) *
+			getFrameRateBitrateMultiplier(options.frameRate) *
 			getEncodingModeBitrateMultiplier(options.encodingMode),
 	);
 	const nativeStaticLayoutBitrate =


### PR DESCRIPTION
## Description

Raises MP4 export bitrate for higher frame-rate exports so 60fps outputs do not reuse the same per-second bitrate budget as 30fps outputs.

## Motivation

Issue #350 reports visible speckle/artifacting at 1440p/60fps, with artifacts reduced or gone when only FPS is lowered to 30. The current bitrate policy scales by output resolution and quality, but the non-native/WebCodecs requested bitrate does not scale with frame rate. That means 60fps exports get roughly half the bits per frame compared with the same 30fps setting.

## Type of Change

- [x] Bug fix candidate
- [x] Export quality tuning

## Related Issue(s)

Refs #350

## Changes Made

- Add a frame-rate multiplier to the shared MP4 bitrate policy.
- Keep 30fps and lower exports on the existing bitrate budget.
- Add regression coverage for 2560x1440 source-quality 60fps exports receiving a higher bitrate than the same 30fps export.

## Scope Note

This does not change rendering, muxing, native CUDA/D3D11 routing, WebCodecs support probing, or export dimensions. It is intentionally kept as a narrow bitrate-policy fix. Leaving this PR as draft until #350 gets a visual retest with the reporter's 1440p/60 project/settings.

## Testing Guide

1. Export the #350 project at 1440p/source quality and 60fps.
2. Compare against the prior 60fps output for speckle artifacts.
3. Export the same project at 30fps and confirm file size/quality behavior remains in the expected range.

## Local Checks

- `npm test -- src/lib/exporter/exportBitrate.test.ts`
- `npx biome check --formatter-enabled=false src/lib/exporter/exportBitrate.ts src/lib/exporter/exportBitrate.test.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`

## Checklist

- [x] Focused change only
- [x] Regression test added
- [x] Local checks pass
- [ ] Visual retest on #350 project/settings