### PR TITLE
fix(recording): clamp cursor samples at pause boundary

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -254,12 +254,12 @@ interface Window {
 			message?: string;
 			error?: string;
 		}>;
-		pauseCursorCapture: () => Promise<{
+		pauseCursorCapture: (pausedAtMs?: number) => Promise<{
 			success: boolean;
 			message?: string;
 			error?: string;
 		}>;
-		resumeCursorCapture: () => Promise<{
+		resumeCursorCapture: (resumedAtMs?: number) => Promise<{
 			success: boolean;
 			message?: string;
 			error?: string;

--- a/electron/ipc/cursor/telemetry.test.ts
+++ b/electron/ipc/cursor/telemetry.test.ts
@@ -29,21 +29,24 @@ vi.mock("../utils", () => ({
 	})),
 }));
 
+import { activeCursorSamples, setActiveCursorSamples, setCursorCaptureStartTimeMs } from "../state";
 import {
 	getCursorCaptureElapsedMs,
 	normalizeCursorTelemetrySamples,
 	pauseCursorCapture,
+	pauseCursorCaptureAtBoundary,
+	pushCursorSample,
 	resetCursorCaptureClock,
 	resumeCursorCapture,
 	writeCursorTelemetry,
 } from "./telemetry";
-import { setCursorCaptureStartTimeMs } from "../state";
 
 describe("cursor telemetry pause clock", () => {
 	beforeEach(() => {
 		writeFile.mockReset();
 		rm.mockReset();
 		setCursorCaptureStartTimeMs(1_000);
+		setActiveCursorSamples([]);
 		resetCursorCaptureClock();
 	});
 
@@ -64,6 +67,20 @@ describe("cursor telemetry pause clock", () => {
 		resumeCursorCapture(1_650);
 
 		expect(getCursorCaptureElapsedMs(1_900)).toBe(550);
+	});
+
+	it("drops cursor samples captured after the renderer pause boundary", () => {
+		pushCursorSample(0.1, 0.1, 120, "move");
+		pushCursorSample(0.2, 0.2, 205, "move");
+		pushCursorSample(0.3, 0.3, 260, "move");
+
+		pauseCursorCaptureAtBoundary(1_200);
+
+		expect(getCursorCaptureElapsedMs(1_500)).toBe(200);
+		expect(activeCursorSamples.map((sample) => sample.timeMs)).toEqual([120]);
+
+		resumeCursorCapture(1_700);
+		expect(getCursorCaptureElapsedMs(1_900)).toBe(400);
 	});
 
 	it("normalizes cursor telemetry samples before persisting them", async () => {

--- a/electron/ipc/cursor/telemetry.ts
+++ b/electron/ipc/cursor/telemetry.ts
@@ -1,28 +1,29 @@
 import fs from "node:fs/promises";
-import { getTelemetryPathForVideo, getScreen } from "../utils";
 import {
+	CURSOR_SAMPLE_INTERVAL_MS,
 	CURSOR_TELEMETRY_VERSION,
 	MAX_CURSOR_SAMPLES,
-	CURSOR_SAMPLE_INTERVAL_MS,
 } from "../constants";
-import type { CursorVisualType, CursorInteractionType, CursorTelemetryPoint } from "../types";
 import {
-	cursorCaptureInterval,
-	setCursorCaptureInterval,
+	activeCursorSamples,
+	currentCursorVisualType,
 	cursorCaptureAccumulatedPausedMs,
+	cursorCaptureInterval,
 	cursorCapturePauseStartedAtMs,
 	cursorCaptureStartTimeMs,
-	activeCursorSamples,
-	pendingCursorSamples,
-	setPendingCursorSamples,
 	isCursorCaptureActive,
-	currentCursorVisualType,
 	linuxCursorScreenPoint,
+	pendingCursorSamples,
 	selectedSource,
 	selectedWindowBounds,
+	setActiveCursorSamples,
 	setCursorCaptureAccumulatedPausedMs,
+	setCursorCaptureInterval,
 	setCursorCapturePauseStartedAtMs,
+	setPendingCursorSamples,
 } from "../state";
+import type { CursorInteractionType, CursorTelemetryPoint, CursorVisualType } from "../types";
+import { getScreen, getTelemetryPathForVideo } from "../utils";
 
 export function clamp(value: number, min: number, max: number) {
 	return Math.min(max, Math.max(min, value));
@@ -122,6 +123,18 @@ export function pauseCursorCapture(pausedAtMs: number) {
 		return;
 	}
 
+	setCursorCapturePauseStartedAtMs(pausedAtMs);
+}
+
+export function pauseCursorCaptureAtBoundary(pausedAtMs: number) {
+	if (cursorCapturePauseStartedAtMs !== null) {
+		return;
+	}
+
+	const pausedElapsedMs = getCursorCaptureElapsedMs(pausedAtMs);
+	setActiveCursorSamples(
+		activeCursorSamples.filter((sample) => sample.timeMs <= pausedElapsedMs),
+	);
 	setCursorCapturePauseStartedAtMs(pausedAtMs);
 }
 
@@ -310,6 +323,6 @@ export function startCursorSampling() {
 	setCursorCaptureInterval(setTimeout(tick, CURSOR_SAMPLE_INTERVAL_MS));
 }
 
+export { CURSOR_SAMPLE_INTERVAL_MS } from "../constants";
 // Re-export for consumers that use it from this module
 export { getTelemetryPathForVideo } from "../utils";
-export { CURSOR_SAMPLE_INTERVAL_MS } from "../constants";

--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -198,7 +198,7 @@ function normalizeRendererTimestampMs(value: unknown) {
 		return nowMs;
 	}
 
-	return Math.min(Math.max(0, Math.round(value)), nowMs + 1000);
+	return Math.min(Math.max(0, Math.round(value)), nowMs);
 }
 
 function pickMicrophoneChunkEvents(value: unknown): MicrophoneChunkTimingEvent[] | null {

--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -19,7 +19,7 @@ import { startInteractionCapture, stopInteractionCapture } from "../cursor/inter
 import { startNativeCursorMonitor, stopNativeCursorMonitor } from "../cursor/monitor";
 import {
 	normalizeCursorTelemetrySamples,
-	pauseCursorCapture,
+	pauseCursorCaptureAtBoundary,
 	resetCursorCaptureClock,
 	resumeCursorCapture,
 	sampleCursorPoint,
@@ -190,6 +190,15 @@ function pickPrimitiveRecord(value: unknown) {
 	);
 
 	return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+function normalizeRendererTimestampMs(value: unknown) {
+	const nowMs = Date.now();
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return nowMs;
+	}
+
+	return Math.min(Math.max(0, Math.round(value)), nowMs + 1000);
 }
 
 function pickMicrophoneChunkEvents(value: unknown): MicrophoneChunkTimingEvent[] | null {
@@ -1715,14 +1724,13 @@ export function registerRecordingHandlers(
 		}
 	});
 
-	ipcMain.handle("pause-cursor-capture", () => {
-		sampleCursorPoint();
-		pauseCursorCapture(Date.now());
+	ipcMain.handle("pause-cursor-capture", (_, pausedAtMs?: unknown) => {
+		pauseCursorCaptureAtBoundary(normalizeRendererTimestampMs(pausedAtMs));
 		return { success: true };
 	});
 
-	ipcMain.handle("resume-cursor-capture", () => {
-		resumeCursorCapture(Date.now());
+	ipcMain.handle("resume-cursor-capture", (_, resumedAtMs?: unknown) => {
+		resumeCursorCapture(normalizeRendererTimestampMs(resumedAtMs));
 		sampleCursorPoint();
 		return { success: true };
 	});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -493,11 +493,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	resumeNativeScreenRecording: () => {
 		return ipcRenderer.invoke("resume-native-screen-recording");
 	},
-	pauseCursorCapture: () => {
-		return ipcRenderer.invoke("pause-cursor-capture");
+	pauseCursorCapture: (pausedAtMs?: number) => {
+		return ipcRenderer.invoke("pause-cursor-capture", pausedAtMs);
 	},
-	resumeCursorCapture: () => {
-		return ipcRenderer.invoke("resume-cursor-capture");
+	resumeCursorCapture: (resumedAtMs?: number) => {
+		return ipcRenderer.invoke("resume-cursor-capture", resumedAtMs);
 	},
 	startFfmpegRecording: (source: ProcessedDesktopSource) => {
 		return ipcRenderer.invoke("start-ffmpeg-recording", source);

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1781,7 +1781,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				markRecordingPaused(boundaryMs);
 				setPaused(true);
 				try {
-					await window.electronAPI.pauseCursorCapture();
+					await window.electronAPI.pauseCursorCapture(boundaryMs);
 				} catch (error) {
 					console.warn("Failed to pause cursor capture:", error);
 				}
@@ -1798,7 +1798,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				markRecordingPaused(boundaryMs);
 				setPaused(true);
 				try {
-					await window.electronAPI.pauseCursorCapture();
+					await window.electronAPI.pauseCursorCapture(boundaryMs);
 				} catch (error) {
 					console.warn("Failed to pause cursor capture:", error);
 				}
@@ -1827,7 +1827,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				markRecordingResumed(boundaryMs);
 				setPaused(false);
 				try {
-					await window.electronAPI.resumeCursorCapture();
+					await window.electronAPI.resumeCursorCapture(boundaryMs);
 				} catch (error) {
 					console.warn("Failed to resume cursor capture:", error);
 				}
@@ -1844,7 +1844,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				markRecordingResumed(boundaryMs);
 				setPaused(false);
 				try {
-					await window.electronAPI.resumeCursorCapture();
+					await window.electronAPI.resumeCursorCapture(boundaryMs);
 				} catch (error) {
 					console.warn("Failed to resume cursor capture:", error);
 				}


### PR DESCRIPTION
## Summary
- pass the renderer pause/resume boundary timestamp through the cursor IPC path
- trim cursor samples captured after the pause boundary before the cursor clock enters paused state
- keep resume sampling aligned with the same renderer/main timestamp boundary

## Root cause
#470 appears to be a remaining edge case after #399: if the user pauses and moves the mouse before the main-process cursor pause IPC runs, late cursor samples can be recorded even though the video timeline is already paused. Those samples then show the cursor in the wrong place after resume.

Fixes #470

## Validation
- `npm test -- electron/ipc/cursor/telemetry.test.ts src/hooks/useScreenRecorder.test.ts`
- `npx biome check --formatter-enabled=false electron/ipc/cursor/telemetry.ts electron/ipc/cursor/telemetry.test.ts electron/ipc/register/recording.ts electron/preload.ts electron/electron-env.d.ts src/hooks/useScreenRecorder.ts`
- `npx tsc --noEmit --pretty false`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pause/resume cursor capture now accept an optional timestamp to align capture timing.

* **Bug Fixes**
  * Cursor samples recorded after a pause are correctly excluded from recordings.
  * Timestamp inputs for pause/resume are validated and normalized to prevent timing drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->