### PR TITLE
fix: Recording doesn't work with different windows

### DIFF
--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -412,6 +412,9 @@ export function registerRecordingHandlers(
 					let orphanedMicAudioPath: string | null = null;
 					const browserMicFallbackRequested =
 						shouldStartWindowsBrowserMicrophoneFallback(options);
+					const windowId = parseWindowId(source?.id);
+					const isWindowCapture = Boolean(windowId && source?.id?.startsWith("window:"));
+
 					const resolvedDisplay = resolveWindowsCaptureDisplay(
 						source,
 						getScreen().getAllDisplays(),
@@ -423,12 +426,17 @@ export function registerRecordingHandlers(
 					const config: Record<string, unknown> = {
 						outputPath,
 						fps: 60,
-						displayId: resolvedDisplay.displayId,
-						displayX: Math.round(resolvedDisplay.bounds.x),
-						displayY: Math.round(resolvedDisplay.bounds.y),
-						displayW: Math.round(resolvedDisplay.bounds.width),
-						displayH: Math.round(resolvedDisplay.bounds.height),
 					};
+
+					if (isWindowCapture) {
+						config.windowHandle = windowId;
+					} else {
+						config.displayId = resolvedDisplay.displayId;
+						config.displayX = Math.round(resolvedDisplay.bounds.x);
+						config.displayY = Math.round(resolvedDisplay.bounds.y);
+						config.displayW = Math.round(resolvedDisplay.bounds.width);
+						config.displayH = Math.round(resolvedDisplay.bounds.height);
+					}
 
 					if (options?.capturesSystemAudio) {
 						systemAudioPath = path.join(


### PR DESCRIPTION
Closes #483 Recording doesn't work with different windows 

Since we refactored LaunchWindow, maybe we omitted those two lines of code : 
```js
const windowId = parseWindowId(source?.id);
					const isWindowCapture = Boolean(windowId && source?.id?.startsWith("window:"));
````

This is why recording would only work on the screen itself and never on the window  you wanted. Now it works on both. This path was taken only by "Windows" machine and shouldn't affect other platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen recording to properly handle both window-specific and display-wide capture modes. Each capture type now uses appropriate configuration settings, resulting in better accuracy and more reliable diagnostic reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/485)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->