### PR TITLE
fix: Mouse passthrough bug, v 1.3.0beta

### DIFF
--- a/electron/ipc/register/sources.ts
+++ b/electron/ipc/register/sources.ts
@@ -13,6 +13,7 @@ import {
 	resolveLinuxWindowBounds,
 	stopWindowBoundsCapture,
 } from "../cursor/bounds";
+import { reassertHudOverlayMousePassthrough } from "../../windows";
 
 const execFileAsync = promisify(execFile);
 const SOURCE_LIST_CACHE_TTL_MS = 1200;
@@ -487,11 +488,24 @@ body{background:transparent;overflow:hidden;width:100vw;height:100vh}
 				throw loadError
 			}
 
-      setTimeout(() => {
-        if (!highlightWin.isDestroyed()) highlightWin.close()
-      }, 1700)
+			// The highlight window appearing (even with focusable:false) can corrupt
+			// the WS_EX_TRANSPARENT flag on the HUD on Windows 11+, breaking hover
+			// detection until the user moves their mouse over the bar again.
+			// Re-assert passthrough immediately so click-through is restored at once.
+			reassertHudOverlayMousePassthrough();
 
-      return { success: true }
+			const highlightCloseTimer = setTimeout(() => {
+				if (!highlightWin.isDestroyed()) highlightWin.close()
+			}, 1700)
+
+			highlightWin.on("closed", () => {
+				clearTimeout(highlightCloseTimer);
+				// Re-assert once more when the window is actually destroyed so the
+				// native flag is clean regardless of timing.
+				reassertHudOverlayMousePassthrough();
+			});
+
+			return { success: true }
     } catch (error) {
       console.error('Failed to show source highlight:', error)
       return { success: false }

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -373,6 +373,7 @@ export function createHudOverlayWindow(): BrowserWindow {
 		skipTaskbar: true,
 		hasShadow: false,
 		show: false,
+		focusable: false,
 		webPreferences: {
 			preload: path.join(electronWindowsDir, "preload.mjs"),
 			nodeIntegration: false,
@@ -511,6 +512,36 @@ export function createHudOverlayWindow(): BrowserWindow {
 
 export function getHudOverlayWindow(): BrowserWindow | null {
 	return hudOverlayWindow && !hudOverlayWindow.isDestroyed() ? hudOverlayWindow : null;
+}
+
+/**
+ * Re-initialise the HUD overlay's mouse passthrough state.
+ *
+ * On Windows 11+, any new BrowserWindow appearing (even focusable:false ones
+ * like the source highlight overlay) can silently corrupt the
+ * WS_EX_TRANSPARENT flag that backs setIgnoreMouseEvents forwarding.  Call
+ * this after any operation that creates or destroys a sibling window so that
+ * hover detection on the HUD is immediately restored without requiring the
+ * user to move their mouse over the bar.
+ */
+export function reassertHudOverlayMousePassthrough(): void {
+	if (process.platform !== "win32" || !isHudOverlayMousePassthroughSupported()) {
+		return;
+	}
+
+	const hud = getHudOverlayWindow();
+	if (!hud) {
+		return;
+	}
+
+	// Toggle off then back on so the native WS_EX_TRANSPARENT flag is fully
+	// re-initialised rather than merely re-asserted in a potentially broken state.
+	hud.setIgnoreMouseEvents(false);
+	setTimeout(() => {
+		if (!hud.isDestroyed()) {
+			hud.setIgnoreMouseEvents(true, { forward: true });
+		}
+	}, 50);
 }
 
 export function createUpdateToastWindow(): BrowserWindow {

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -515,6 +515,7 @@ function LaunchWindowContent() {
 						<div
 							ref={recordingWebcamPreviewContainerRef}
 							className={`${styles.recordingWebcamPreview} ${styles.electronNoDrag} pointer-events-auto`}
+							data-hud-interactive
 							title={t("recording.webcam")}
 							style={{
 								transform: `translate(${webcamPreviewOffset.x}px, ${webcamPreviewOffset.y}px)`,

--- a/src/components/launch/hooks/useLaunchHudInteractionState.ts
+++ b/src/components/launch/hooks/useLaunchHudInteractionState.ts
@@ -12,6 +12,7 @@ export function useLaunchHudInteractionState({
 	webcamPreviewDragStartRef: RefObject<unknown>;
 }) {
 	const isMouseOverHudRef = useRef(false);
+	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
 	useEffect(() => {
 		if (openId !== null) {
@@ -31,7 +32,7 @@ export function useLaunchHudInteractionState({
 			const target = e.target as HTMLElement | null;
 			if (!target) return;
 			const isInteractive = !!target.closest(
-				'.pointer-events-auto, [data-radix-popper-content-wrapper], [class*="menuCard"], [class*="recordingWebcamPreview"]'
+				".pointer-events-auto, [data-hud-interactive], [data-radix-popper-content-wrapper]"
 			);
 
 			if (isInteractive) {
@@ -68,8 +69,6 @@ export function useLaunchHudInteractionState({
 		if (timeoutRef.current) clearTimeout(timeoutRef.current);
 		window.electronAPI?.hudOverlaySetIgnoreMouse?.(false);
 	}, []);
-
-	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
 	const handleHudMouseLeave = useCallback((event: MouseEvent<HTMLDivElement>) => {
 		const nextTarget = event.relatedTarget;

--- a/src/components/launch/hooks/useLaunchHudInteractionState.ts
+++ b/src/components/launch/hooks/useLaunchHudInteractionState.ts
@@ -11,22 +11,52 @@ export function useLaunchHudInteractionState({
 	isWebcamPreviewDraggingRef: RefObject<boolean>;
 	webcamPreviewDragStartRef: RefObject<unknown>;
 }) {
-	const anyPopoverOpenRef = useRef(false);
 	const isMouseOverHudRef = useRef(false);
 
 	useEffect(() => {
-		anyPopoverOpenRef.current = openId !== null;
 		if (openId !== null) {
 			window.electronAPI?.hudOverlaySetIgnoreMouse?.(false);
 		} else {
 			// Proactively check if we should ignore mouse when popover closes
 			setTimeout(() => {
-				if (!isMouseOverHudRef.current && !anyPopoverOpenRef.current) {
+				if (!isMouseOverHudRef.current) {
 					window.electronAPI?.hudOverlaySetIgnoreMouse?.(true);
 				}
 			}, 150);
 		}
 	}, [openId]);
+
+	useEffect(() => {
+		const handleMouseOver = (e: globalThis.MouseEvent) => {
+			const target = e.target as HTMLElement | null;
+			if (!target) return;
+			const isInteractive = !!target.closest(
+				'.pointer-events-auto, [data-radix-popper-content-wrapper], [class*="menuCard"], [class*="recordingWebcamPreview"]'
+			);
+
+			if (isInteractive) {
+				isMouseOverHudRef.current = true;
+				if (timeoutRef.current) clearTimeout(timeoutRef.current);
+				window.electronAPI?.hudOverlaySetIgnoreMouse?.(false);
+			} else {
+				isMouseOverHudRef.current = false;
+				if (timeoutRef.current) clearTimeout(timeoutRef.current);
+				timeoutRef.current = setTimeout(() => {
+					if (
+						!isHudDraggingRef.current &&
+						!isWebcamPreviewDraggingRef.current &&
+						!webcamPreviewDragStartRef.current &&
+						!isMouseOverHudRef.current
+					) {
+						window.electronAPI?.hudOverlaySetIgnoreMouse?.(true);
+					}
+				}, 300);
+			}
+		};
+
+		window.addEventListener("mouseover", handleMouseOver);
+		return () => window.removeEventListener("mouseover", handleMouseOver);
+	}, [isHudDraggingRef, isWebcamPreviewDraggingRef, webcamPreviewDragStartRef]);
 
 	const beginInteractiveHudAction = useCallback(() => {
 		isMouseOverHudRef.current = true;
@@ -56,11 +86,8 @@ export function useLaunchHudInteractionState({
 				!isHudDraggingRef.current &&
 				!isWebcamPreviewDraggingRef.current &&
 				!webcamPreviewDragStartRef.current &&
-				!isMouseOverHudRef.current &&
-				!anyPopoverOpenRef.current
+				!isMouseOverHudRef.current
 			) {
-				// If a popover is open, we can still ignore mouse if the mouse is truly gone,
-				// but we give a bit more breathing room (the 300ms timeout).
 				window.electronAPI?.hudOverlaySetIgnoreMouse?.(true);
 			}
 		}, 300);

--- a/src/components/launch/popovers/LaunchPopoverCoordinator.tsx
+++ b/src/components/launch/popovers/LaunchPopoverCoordinator.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 
 interface LaunchPopoverCoordinatorValue {
 	openId: string | null;
@@ -21,6 +21,12 @@ export function LaunchPopoverCoordinatorProvider({ children }: { children: React
 	}, []);
 
 	const isOpen = useCallback((id: string) => openId === id, [openId]);
+
+	useEffect(() => {
+		const handleBlur = () => setOpenId(null);
+		window.addEventListener("blur", handleBlur);
+		return () => window.removeEventListener("blur", handleBlur);
+	}, []);
 
 	const value = useMemo(
 		() => ({

--- a/src/components/launch/popovers/PopoverScaffold.tsx
+++ b/src/components/launch/popovers/PopoverScaffold.tsx
@@ -80,6 +80,7 @@ export function HudPopover({
 			<PopoverTrigger asChild>{trigger}</PopoverTrigger>
 			<PopoverContent
 				className={`launch-theme ${styles.menuCard} ${styles.electronNoDrag}`}
+				data-hud-interactive
 				unstyled
 				side="top"
 				align={align}


### PR DESCRIPTION
# Fixing mouse passthrough

## Description
Mouse doesn't passthrough , wether recording or not.
This issue has been confirmed not to be related to resolution / dual monitor setup

## What has been done here
1. Fixed Mouse Passthrough Corruption (Windows 11+)
Files: electron/windows.ts, electron/ipc/register/sources.ts
Change: Added reassertHudOverlayMousePassthrough(). This function forces a reset of the native WS_EX_TRANSPARENT flag.
Rationale: On Windows 11, creating ephemeral windows (like the source highlight rectangle) often silently breaks the HUD's hover detection. We now force a "repair" of this state whenever a highlight appears or disappears.

2. Eliminated Focus Stealing
File: electron/windows.ts
Change: Set the HUD overlay window to focusable: false.
Rationale: This fixes the issue where clicking a HUD button would cause background apps (like Discord or games) to freeze, turn black, or stop showing a blinking text cursor. The HUD now receives clicks without becoming the "Active" window in the OS.

3. Intelligent Interaction Tracking (DOM Raycasting)
File: useLaunchHudInteractionState.ts
Change: Replaced local onMouseEnter/Leave events with a global mouseover listener that dynamically checks if the target (target.closest) is an interactive element (the bar, Radix popovers, or the webcam preview).
Rationale: This allows the HUD to track the mouse even when it moves into popovers rendered via Portals (which sit outside the main bar's DOM hierarchy).

4. Immediate Mouse Release & Auto-Close
Files: useLaunchHudInteractionState.ts, LaunchPopoverCoordinator.tsx
Change: The HUD now enables click-through (ignoreMouseEvents: true) immediately when the mouse leaves interactive areas, even if a menu is open. We added a window.blur listener to handle closing the menus when the user clicks another application.
Rationale: This ensures that users can click on background apps (like Discord) instantly, without the HUD "swallowing" the first click to close itself.
In summary: These changes make the HUD overlay completely transparent to the OS when not in use, and ensure it never disrupts the user's focus or workflow in other applications.

## Type of Change
- [x] Bug Fix

## Related Issue(s)
Mouse passthrough bug, v 1.3.0beta #479
Reported from discord. and happened to me too. on Windows 11 latest version

## Testing Guide
Run the app `npm run dev` You should for example, if you are on Youtube, and you are on a video, if you switch sources, the popover shouldn't make the video go black

Other example, with Recordly open, try going into an input box, it should continue to trigger the little marker of where you are typing (blinking caret). This was not possible before the fix as the popovers and most of the HUD would not be seen as transparent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD overlay mouse interaction on Windows to prevent persistent click-through and forwarding issues
  * Reapplies passthrough when source highlights are shown and after they close
  * Better detection of pointer over interactive HUD elements to avoid premature ignore-mouse state
  * Launch popovers now close automatically when the application window loses focus

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/486)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->