### PR TITLE
feat: add timeline zoom in/out controls

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -27,8 +27,8 @@ import {
 	MagicWand as WandSparkles,
 	X,
 	MagnifyingGlassPlus as ZoomIn,
-} from "@phosphor-icons/react";
-import type { Span } from "dnd-timeline";
+	MagnifyingGlassMinus as ZoomOut,
+	} from "@phosphor-icons/react";import type { Span } from "dnd-timeline";
 import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -6239,6 +6239,25 @@ export default function VideoEditor() {
 									title={t("editor.toolbar.splitClip")}
 								>
 									<Scissors className="w-4 h-4" />
+								</Button>
+								<div className="w-[1px] h-4 bg-foreground/10 mx-1" />
+								<Button
+									onClick={() => timelineRef.current?.zoomOut()}
+									variant="ghost"
+									size="icon"
+									className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground"
+									title="Zoom Timeline Out"
+								>
+									<ZoomOut className="w-4 h-4" />
+								</Button>
+								<Button
+									onClick={() => timelineRef.current?.zoomIn()}
+									variant="ghost"
+									size="icon"
+									className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground"
+									title="Zoom Timeline In"
+								>
+									<ZoomIn className="w-4 h-4" />
 								</Button>
 							</div>
 							{/* Playback controls - centered */}

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -109,14 +109,15 @@ function buildSourceSidecarPath(source: string, suffix: "mic" | "system"): strin
 }
 
 export interface TimelineEditorHandle {
-	addZoom: () => void;
-	suggestZooms: () => void;
-	splitClip: () => void;
-	addAnnotation: (trackIndex?: number) => void;
-	addAudio: (trackIndex?: number) => Promise<void>;
-	keyframes: { id: string; time: number }[];
+        addZoom: () => void;
+        suggestZooms: () => void;
+        splitClip: () => void;
+        addAnnotation: (trackIndex?: number) => void;
+        addAudio: (trackIndex?: number) => Promise<void>;
+        keyframes: { id: string; time: number }[];
+        zoomIn: () => void;
+        zoomOut: () => void;
 }
-
 
 const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 	function TimelineEditor(
@@ -189,7 +190,7 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 
 		const timelineContainerRef = useRef<HTMLDivElement>(null);
 		const isTimelineFocusedRef = useRef(false);
-		const { setRange, clampedRange, handleTimelineWheel } = useTimelineRange({
+		const { setRange, clampedRange, handleTimelineWheel, zoomIn, zoomOut } = useTimelineRange({
 			totalMs,
 			timelineContainerRef,
 		});

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -373,6 +373,8 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			isMac,
 			keyShortcuts,
 			isTimelineFocusedRef,
+			zoomIn,
+			zoomOut,
 		});
 
 		if (!videoDuration || videoDuration === 0) {

--- a/src/components/video-editor/timeline/hooks/useTimelineEditorRuntime.ts
+++ b/src/components/video-editor/timeline/hooks/useTimelineEditorRuntime.ts
@@ -62,6 +62,8 @@ interface UseTimelineEditorRuntimeParams {
 	isMac: boolean;
 	keyShortcuts: TimelineShortcutBindings;
 	isTimelineFocusedRef: RefObject<boolean>;
+        zoomIn: () => void;
+        zoomOut: () => void;
 }
 
 export function useTimelineEditorRuntime({
@@ -106,6 +108,8 @@ export function useTimelineEditorRuntime({
 	isMac,
 	keyShortcuts,
 	isTimelineFocusedRef,
+        zoomIn,
+        zoomOut,
 }: UseTimelineEditorRuntimeParams) {
 	const {
 		keyframes,
@@ -258,8 +262,10 @@ export function useTimelineEditorRuntime({
 			addAnnotation: handleAddAnnotation,
 			addAudio: handleAddAudio,
 			keyframes,
+                        zoomIn,
+                        zoomOut,
 		}),
-		[handleAddAnnotation, handleAddAudio, handleAddZoom, handleSuggestZooms, handleSplitClip, keyframes],
+		[handleAddAnnotation, handleAddAudio, handleAddZoom, handleSuggestZooms, handleSplitClip, keyframes, zoomIn, zoomOut],
 	);
 
 	return {

--- a/src/components/video-editor/timeline/hooks/useTimelineRange.ts
+++ b/src/components/video-editor/timeline/hooks/useTimelineRange.ts
@@ -25,23 +25,52 @@ export function useTimelineRange({ totalMs, timelineContainerRef }: UseTimelineR
 	}, [range, totalMs]);
 
 	const panTimelineRange = useCallback(
-		(deltaMs: number) => {
-			if (!Number.isFinite(deltaMs) || deltaMs === 0 || totalMs <= 0) {
-				return;
-			}
+	        (deltaMs: number) => {
+	                if (!Number.isFinite(deltaMs) || deltaMs === 0 || totalMs <= 0) {
+	                        return;
+	                }
 
-			setRange((previous) => {
-				const visibleSpan = Math.max(1, previous.end - previous.start);
-				const maxStart = Math.max(0, totalMs - visibleSpan);
-				const nextStart = Math.max(0, Math.min(previous.start + deltaMs, maxStart));
-				return { start: nextStart, end: nextStart + visibleSpan };
-			});
-		},
-		[totalMs],
+	                setRange((previous) => {
+	                        const visibleSpan = Math.max(1, previous.end - previous.start);
+	                        const maxStart = Math.max(0, totalMs - visibleSpan);
+	                        const nextStart = Math.max(0, Math.min(previous.start + deltaMs, maxStart));
+	                        return { start: nextStart, end: nextStart + visibleSpan };
+	                });
+	        },
+	        [totalMs],
 	);
 
-	const handleTimelineWheel = useCallback(
-		(event: WheelEvent<HTMLDivElement>) => {
+	const zoomTimelineRange = useCallback(
+	        (scaleFactor: number) => {
+	                if (totalMs <= 0) return;
+
+	                setRange((previous) => {
+	                        const currentVisibleSpan = Math.max(1, previous.end - previous.start);
+	                        const currentCenter = previous.start + currentVisibleSpan / 2;
+
+	                        const newVisibleSpan = Math.max(10, Math.min(totalMs, currentVisibleSpan * scaleFactor));
+
+	                        let newStart = currentCenter - newVisibleSpan / 2;
+	                        let newEnd = currentCenter + newVisibleSpan / 2;
+
+	                        if (newStart < 0) {
+	                                newStart = 0;
+	                                newEnd = Math.min(totalMs, newVisibleSpan);
+	                        } else if (newEnd > totalMs) {
+	                                newEnd = totalMs;
+	                                newStart = Math.max(0, totalMs - newVisibleSpan);
+	                        }
+
+	                        return { start: newStart, end: newEnd };
+	                });
+	        },
+	        [totalMs],
+	);
+
+	const zoomIn = useCallback(() => zoomTimelineRange(0.75), [zoomTimelineRange]);
+	const zoomOut = useCallback(() => zoomTimelineRange(1.33), [zoomTimelineRange]);
+
+	const handleTimelineWheel = useCallback(		(event: WheelEvent<HTMLDivElement>) => {
 			if (event.ctrlKey || event.metaKey || totalMs <= 0) {
 				return;
 			}
@@ -72,9 +101,10 @@ export function useTimelineRange({ totalMs, timelineContainerRef }: UseTimelineR
 	);
 
 	return {
-		range,
-		setRange,
-		clampedRange,
-		handleTimelineWheel,
-	};
-}
+	        range,
+	        setRange,
+	        clampedRange,
+	        handleTimelineWheel,
+	        zoomIn,
+	        zoomOut,
+	};}


### PR DESCRIPTION
Closes #495 by adding timeline zoom in/out controls to the editor toolbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zoom In and Zoom Out controls to the timeline toolbar for finer or broader editing views.
  * Timeline zoom preserves the current center and enforces sensible minimum/maximum limits for stable, predictable zooming.
  * Zoom controls are exposed to timeline editing tools for direct invocation (e.g., toolbar buttons and runtime handlers).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/510)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->