### PR TITLE
feat: add option to add clips to timeline

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -3631,6 +3631,15 @@ export default function VideoEditor() {
 		}
 	}, []);
 
+	const handleClipAdded = useCallback(() => {
+		setClipRegions((prev) => {
+			const id = `clip-${nextClipIdRef.current++}`;
+			const startMs = 0;
+			const endMs = Math.min(5000, Math.round(duration * 1000));
+			return [...prev, { id, startMs, endMs, speed: 1 }];
+		});
+	}, [duration]);
+
 	const handleClipSplit = useCallback(
 		(splitMs: number) => {
 			setClipRegions((prev) => {
@@ -6210,6 +6219,14 @@ export default function VideoEditor() {
 										>
 											{t("timeline.audio.label")}
 										</DropdownMenuItem>
+										<DropdownMenuItem
+											onClick={() => {
+												timelineRef.current?.addClip();
+											}}
+											className="text-muted-foreground hover:text-foreground hover:bg-foreground/10 cursor-pointer"
+										>
+											{t("editor.toolbar.clip", "Clip")}
+										</DropdownMenuItem>
 									</DropdownMenuContent>
 								</DropdownMenu>
 								<div className="w-[1px] h-4 bg-foreground/10 mx-1" />
@@ -6426,6 +6443,7 @@ export default function VideoEditor() {
 						onSelectZoom={handleSelectZoom}
 						trimRegions={trimRegions}
 						clipRegions={clipRegions}
+						onClipAdded={handleClipAdded}
 						onClipSplit={handleClipSplit}
 						onClipSpanChange={handleClipSpanChange}
 						selectedClipId={selectedClipId}

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -27,8 +27,8 @@ import {
 	MagicWand as WandSparkles,
 	X,
 	MagnifyingGlassPlus as ZoomIn,
-} from "@phosphor-icons/react";
-import type { Span } from "dnd-timeline";
+	MagnifyingGlassMinus as ZoomOut,
+	} from "@phosphor-icons/react";import type { Span } from "dnd-timeline";
 import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -6239,6 +6239,25 @@ export default function VideoEditor() {
 									title={t("editor.toolbar.splitClip")}
 								>
 									<Scissors className="w-4 h-4" />
+								</Button>
+								<div className="w-[1px] h-4 bg-foreground/10 mx-1" />
+								<Button
+									onClick={() => timelineRef.current?.zoomOut()}
+									variant="ghost"
+									size="icon"
+									className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground"
+									title="Zoom Timeline Out"
+								>
+									<ZoomOut className="w-4 h-4" />
+								</Button>
+								<Button
+									onClick={() => timelineRef.current?.zoomIn()}
+									variant="ghost"
+									size="icon"
+									className="h-7 w-7 rounded-full text-muted-foreground transition-all hover:bg-foreground/10 hover:text-foreground"
+									title="Zoom Timeline In"
+								>
+									<ZoomIn className="w-4 h-4" />
 								</Button>
 							</div>
 							{/* Playback controls - centered */}

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -52,6 +52,7 @@ export interface TimelineEditorProps {
 	trimRegions?: TrimRegion[];
 	onTrimSpanChange?: (id: string, span: Span) => void;
 	clipRegions?: ClipRegion[];
+	onClipAdded?: () => void;
 	onClipSplit?: (splitMs: number) => void;
 	onClipSpanChange?: (id: string, span: Span) => void;
 	onClipDelete?: (id: string) => void;
@@ -112,6 +113,7 @@ export interface TimelineEditorHandle {
         addZoom: () => void;
         suggestZooms: () => void;
         splitClip: () => void;
+        addClip: () => void;
         addAnnotation: (trackIndex?: number) => void;
         addAudio: (trackIndex?: number) => Promise<void>;
         keyframes: { id: string; time: number }[];
@@ -351,6 +353,7 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			trimRegions,
 			onTrimSpanChange,
 			clipRegions,
+			onClipAdded,
 			onClipSplit,
 			onClipSpanChange,
 			onClipDelete,

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -109,14 +109,15 @@ function buildSourceSidecarPath(source: string, suffix: "mic" | "system"): strin
 }
 
 export interface TimelineEditorHandle {
-	addZoom: () => void;
-	suggestZooms: () => void;
-	splitClip: () => void;
-	addAnnotation: (trackIndex?: number) => void;
-	addAudio: (trackIndex?: number) => Promise<void>;
-	keyframes: { id: string; time: number }[];
+        addZoom: () => void;
+        suggestZooms: () => void;
+        splitClip: () => void;
+        addAnnotation: (trackIndex?: number) => void;
+        addAudio: (trackIndex?: number) => Promise<void>;
+        keyframes: { id: string; time: number }[];
+        zoomIn: () => void;
+        zoomOut: () => void;
 }
-
 
 const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 	function TimelineEditor(
@@ -189,7 +190,7 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 
 		const timelineContainerRef = useRef<HTMLDivElement>(null);
 		const isTimelineFocusedRef = useRef(false);
-		const { setRange, clampedRange, handleTimelineWheel } = useTimelineRange({
+		const { setRange, clampedRange, handleTimelineWheel, zoomIn, zoomOut } = useTimelineRange({
 			totalMs,
 			timelineContainerRef,
 		});

--- a/src/components/video-editor/timeline/TimelineEditor.tsx
+++ b/src/components/video-editor/timeline/TimelineEditor.tsx
@@ -373,6 +373,8 @@ const TimelineEditor = forwardRef<TimelineEditorHandle, TimelineEditorProps>(
 			isMac,
 			keyShortcuts,
 			isTimelineFocusedRef,
+			zoomIn,
+			zoomOut,
 		});
 
 		if (!videoDuration || videoDuration === 0) {

--- a/src/components/video-editor/timeline/hooks/useTimelineEditorRuntime.ts
+++ b/src/components/video-editor/timeline/hooks/useTimelineEditorRuntime.ts
@@ -40,6 +40,7 @@ interface UseTimelineEditorRuntimeParams {
 	trimRegions: TrimRegion[];
 	onTrimSpanChange?: (id: string, span: Span) => void;
 	clipRegions: ClipRegion[];
+	onClipAdded?: () => void;
 	onClipSplit?: (splitMs: number) => void;
 	onClipSpanChange?: (id: string, span: Span) => void;
 	onClipDelete?: (id: string) => void;
@@ -86,6 +87,7 @@ export function useTimelineEditorRuntime({
 	trimRegions,
 	onTrimSpanChange,
 	clipRegions,
+	onClipAdded,
 	onClipSplit,
 	onClipSpanChange,
 	onClipDelete,
@@ -201,6 +203,13 @@ export function useTimelineEditorRuntime({
 		onClipSplit(currentTimeMs);
 	}, [videoDuration, totalMs, currentTimeMs, onClipSplit]);
 
+	const handleAddClip = useCallback(() => {
+		if (!videoDuration || videoDuration === 0 || totalMs === 0 || !onClipAdded) {
+			return;
+		}
+		onClipAdded();
+	}, [videoDuration, totalMs, onClipAdded]);
+
 	const { handleAddAudio } = useTimelineAudioActions({
 		timeline: { videoDuration, totalMs, currentTimeMs },
 		regions: { audio: audioRegions },
@@ -259,13 +268,14 @@ export function useTimelineEditorRuntime({
 			addZoom: handleAddZoom,
 			suggestZooms: handleSuggestZooms,
 			splitClip: handleSplitClip,
+			addClip: handleAddClip,
 			addAnnotation: handleAddAnnotation,
 			addAudio: handleAddAudio,
 			keyframes,
                         zoomIn,
                         zoomOut,
 		}),
-		[handleAddAnnotation, handleAddAudio, handleAddZoom, handleSuggestZooms, handleSplitClip, keyframes, zoomIn, zoomOut],
+		[handleAddAnnotation, handleAddAudio, handleAddZoom, handleSuggestZooms, handleSplitClip, handleAddClip, keyframes, zoomIn, zoomOut],
 	);
 
 	return {

--- a/src/components/video-editor/timeline/hooks/useTimelineEditorRuntime.ts
+++ b/src/components/video-editor/timeline/hooks/useTimelineEditorRuntime.ts
@@ -62,6 +62,8 @@ interface UseTimelineEditorRuntimeParams {
 	isMac: boolean;
 	keyShortcuts: TimelineShortcutBindings;
 	isTimelineFocusedRef: RefObject<boolean>;
+        zoomIn: () => void;
+        zoomOut: () => void;
 }
 
 export function useTimelineEditorRuntime({
@@ -106,6 +108,8 @@ export function useTimelineEditorRuntime({
 	isMac,
 	keyShortcuts,
 	isTimelineFocusedRef,
+        zoomIn,
+        zoomOut,
 }: UseTimelineEditorRuntimeParams) {
 	const {
 		keyframes,
@@ -258,8 +262,10 @@ export function useTimelineEditorRuntime({
 			addAnnotation: handleAddAnnotation,
 			addAudio: handleAddAudio,
 			keyframes,
+                        zoomIn,
+                        zoomOut,
 		}),
-		[handleAddAnnotation, handleAddAudio, handleAddZoom, handleSuggestZooms, handleSplitClip, keyframes],
+		[handleAddAnnotation, handleAddAudio, handleAddZoom, handleSuggestZooms, handleSplitClip, keyframes, zoomIn, zoomOut],
 	);
 
 	return {

--- a/src/components/video-editor/timeline/hooks/useTimelineRange.ts
+++ b/src/components/video-editor/timeline/hooks/useTimelineRange.ts
@@ -25,23 +25,52 @@ export function useTimelineRange({ totalMs, timelineContainerRef }: UseTimelineR
 	}, [range, totalMs]);
 
 	const panTimelineRange = useCallback(
-		(deltaMs: number) => {
-			if (!Number.isFinite(deltaMs) || deltaMs === 0 || totalMs <= 0) {
-				return;
-			}
+	        (deltaMs: number) => {
+	                if (!Number.isFinite(deltaMs) || deltaMs === 0 || totalMs <= 0) {
+	                        return;
+	                }
 
-			setRange((previous) => {
-				const visibleSpan = Math.max(1, previous.end - previous.start);
-				const maxStart = Math.max(0, totalMs - visibleSpan);
-				const nextStart = Math.max(0, Math.min(previous.start + deltaMs, maxStart));
-				return { start: nextStart, end: nextStart + visibleSpan };
-			});
-		},
-		[totalMs],
+	                setRange((previous) => {
+	                        const visibleSpan = Math.max(1, previous.end - previous.start);
+	                        const maxStart = Math.max(0, totalMs - visibleSpan);
+	                        const nextStart = Math.max(0, Math.min(previous.start + deltaMs, maxStart));
+	                        return { start: nextStart, end: nextStart + visibleSpan };
+	                });
+	        },
+	        [totalMs],
 	);
 
-	const handleTimelineWheel = useCallback(
-		(event: WheelEvent<HTMLDivElement>) => {
+	const zoomTimelineRange = useCallback(
+	        (scaleFactor: number) => {
+	                if (totalMs <= 0) return;
+
+	                setRange((previous) => {
+	                        const currentVisibleSpan = Math.max(1, previous.end - previous.start);
+	                        const currentCenter = previous.start + currentVisibleSpan / 2;
+
+	                        const newVisibleSpan = Math.max(10, Math.min(totalMs, currentVisibleSpan * scaleFactor));
+
+	                        let newStart = currentCenter - newVisibleSpan / 2;
+	                        let newEnd = currentCenter + newVisibleSpan / 2;
+
+	                        if (newStart < 0) {
+	                                newStart = 0;
+	                                newEnd = Math.min(totalMs, newVisibleSpan);
+	                        } else if (newEnd > totalMs) {
+	                                newEnd = totalMs;
+	                                newStart = Math.max(0, totalMs - newVisibleSpan);
+	                        }
+
+	                        return { start: newStart, end: newEnd };
+	                });
+	        },
+	        [totalMs],
+	);
+
+	const zoomIn = useCallback(() => zoomTimelineRange(0.75), [zoomTimelineRange]);
+	const zoomOut = useCallback(() => zoomTimelineRange(1.33), [zoomTimelineRange]);
+
+	const handleTimelineWheel = useCallback(		(event: WheelEvent<HTMLDivElement>) => {
 			if (event.ctrlKey || event.metaKey || totalMs <= 0) {
 				return;
 			}
@@ -72,9 +101,10 @@ export function useTimelineRange({ totalMs, timelineContainerRef }: UseTimelineR
 	);
 
 	return {
-		range,
-		setRange,
-		clampedRange,
-		handleTimelineWheel,
-	};
-}
+	        range,
+	        setRange,
+	        clampedRange,
+	        handleTimelineWheel,
+	        zoomIn,
+	        zoomOut,
+	};}


### PR DESCRIPTION
Adds a button to the Add Layer dropdown to append a new 5-second clip of the source video to the timeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added the ability to add clips directly from the "Add layer" dropdown menu in the video editor
* Added "Zoom Timeline In" and "Zoom Timeline Out" buttons to the timeline toolbar for improved control over timeline view and navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/511)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->