### PR TITLE
fix: macOS Safari capture and editor frame crashes

### DIFF
--- a/electron/native/ScreenCaptureKitRecorder.swift
+++ b/electron/native/ScreenCaptureKitRecorder.swift
@@ -107,12 +107,17 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 				throw NSError(domain: "RecordlyCapture", code: 3, userInfo: [NSLocalizedDescriptionKey: "Window not found"])
 			}
 
-			filter = SCContentFilter(desktopIndependentWindow: window)
-
 			let candidateDisplay = availableContent.displays.first(where: {
 				$0.frame.intersects(window.frame) || $0.frame.contains(CGPoint(x: window.frame.midX, y: window.frame.midY))
-			})
-			let scaleFactor = ScreenCaptureRecorder.scaleFactor(for: candidateDisplay?.displayID ?? CGMainDisplayID())
+			}) ?? availableContent.displays.first
+
+			guard let display = candidateDisplay else {
+				throw NSError(domain: "RecordlyCapture", code: 4, userInfo: [NSLocalizedDescriptionKey: "No display found for window"])
+			}
+
+			filter = SCContentFilter(display: display, including: [window], exceptingApplications: [], exceptingWindows: [])
+
+			let scaleFactor = ScreenCaptureRecorder.scaleFactor(for: display.displayID)
 			outputWidth = max(2, Int(window.frame.width) * scaleFactor)
 			outputHeight = max(2, Int(window.frame.height) * scaleFactor)
 			if #available(macOS 14.0, *) {

--- a/electron/native/ScreenCaptureKitRecorder.swift
+++ b/electron/native/ScreenCaptureKitRecorder.swift
@@ -109,10 +109,10 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 
 			let candidateDisplay = availableContent.displays.first(where: {
 				$0.frame.intersects(window.frame) || $0.frame.contains(CGPoint(x: window.frame.midX, y: window.frame.midY))
-			}) ?? availableContent.displays.first
+			})
 
 			guard let display = candidateDisplay else {
-				throw NSError(domain: "RecordlyCapture", code: 4, userInfo: [NSLocalizedDescriptionKey: "No display found for window"])
+				throw NSError(domain: "RecordlyCapture", code: 4, userInfo: [NSLocalizedDescriptionKey: "No intersecting display found for window"])
 			}
 
 			filter = SCContentFilter(display: display, including: [window], exceptingApplications: [], exceptingWindows: [])
@@ -660,8 +660,8 @@ guard CommandLine.arguments.count >= 2 else {
 }
 
 // Force CoreGraphics Services initialization on the main thread.
-// Without this, SCContentFilter(desktopIndependentWindow:) crashes with
-// CGS_REQUIRE_INIT because CGS is never initialised in a CLI tool.
+// Without this, CoreGraphics operations may fail with CGS_REQUIRE_INIT
+// because CGS is never initialised in a CLI tool.
 let _ = CGMainDisplayID()
 
 // Pre-flight check: ensure screen recording permission is granted before

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -1097,20 +1097,24 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				if (!frameData) return false;
 
 				if (frameData.draw) {
-					// Resolution-independent: draw at a reasonable size, Pixi handles the rest
-					const drawW = 1920;
-					const drawH = 1080;
-					const canvas = document.createElement("canvas");
-					canvas.width = drawW;
-					canvas.height = drawH;
-					const ctx = canvas.getContext("2d");
-					if (ctx) frameData.draw(ctx, drawW, drawH);
-					if (cancelled || frameIdRef.current !== frame) return true;
-					const texture = Texture.from(canvas);
-					const sprite = new Sprite(texture);
-					frameSpriteRef.current = sprite;
-					container.addChild(sprite);
-					layoutVideoContentRef.current?.();
+					try {
+						// Resolution-independent: draw at a reasonable size, Pixi handles the rest
+						const drawW = 1920;
+						const drawH = 1080;
+						const canvas = document.createElement("canvas");
+						canvas.width = drawW;
+						canvas.height = drawH;
+						const ctx = canvas.getContext("2d");
+						if (ctx) frameData.draw(ctx, drawW, drawH);
+						if (cancelled || frameIdRef.current !== frame) return true;
+						const texture = Texture.from(canvas);
+						const sprite = new Sprite(texture);
+						frameSpriteRef.current = sprite;
+						container.addChild(sprite);
+						layoutVideoContentRef.current?.();
+					} catch (err) {
+						console.error(`[VideoPlayback] Failed to draw frame '${frameData.id}':`, err);
+					}
 				} else {
 					const img = new Image();
 					img.onload = () => {
@@ -1120,6 +1124,9 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 						frameSpriteRef.current = sprite;
 						container.addChild(sprite);
 						layoutVideoContentRef.current?.();
+					};
+					img.onerror = (err) => {
+						console.error(`[VideoPlayback] Failed to load frame image from '${frameData.filePath}':`, err);
 					};
 					img.src = frameData.filePath;
 				}


### PR DESCRIPTION
This PR fixes two Safari-related crashes:

1. **Mac Native Capture:** Uses \SCContentFilter(display:including:)\ to fix the macOS bug where Safari windows are captured as completely black or white.
2. **Editor Frame Rendering:** Adds a \	ry/catch\ to \rameData.draw\ in \VideoPlayback.tsx\. Previously, if a frame extension (like the Safari frame) failed to render or load its SVG, it threw a synchronous error inside the Pixi rendering loop, crashing the entire React UI and leaving the editor blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window capture to better handle multi-display setups with more reliable display selection and clearer errors when a display cannot be resolved (no automatic fallback).
  * Added robust error handling and logging for video frame rendering and image asset loading to surface failures instead of failing silently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/512)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->