### PR TITLE
fix: support exporting recordings larger than 2 GiB

### DIFF
--- a/electron/ipc/register/assets.ts
+++ b/electron/ipc/register/assets.ts
@@ -116,11 +116,28 @@ export function registerAssetHandlers() {
       // require a real on-disk file so this cannot be used to read directories.
       const resolved = await resolveReadableLocalFilePath(filePath)
 
-      const data = await fs.readFile(resolved)
-      return { success: true, data }
+      // Use fileHandle.read instead of fs.readFile to support files >2 GiB.
+      // fs.readFile throws ERR_FS_FILE_TOO_LARGE on large files, but
+      // fileHandle.read has no such restriction.
+      const fileHandle = await fs.open(resolved, 'r')
+      try {
+        const stat = await fileHandle.stat()
+        const fileSize = stat.size
+        const buffer = Buffer.allocUnsafe(fileSize)
+        let offset = 0
+        while (offset < fileSize) {
+          const chunkSize = Math.min(64 * 1024 * 1024, fileSize - offset) // 64 MiB chunks
+          const { bytesRead } = await fileHandle.read(buffer, offset, chunkSize, offset)
+          if (bytesRead === 0) break
+          offset += bytesRead
+        }
+        return { success: true as const, data: buffer }
+      } finally {
+        await fileHandle.close()
+      }
     } catch (error) {
       console.error('Failed to read local file:', error)
-      return { success: false, error: String(error) }
+      return { success: false as const, error: String(error) }
     }
   })
 

--- a/electron/ipc/register/assets.ts
+++ b/electron/ipc/register/assets.ts
@@ -131,7 +131,7 @@ export function registerAssetHandlers() {
           if (bytesRead === 0) break
           offset += bytesRead
         }
-        return { success: true as const, data: buffer }
+        return { success: true as const, data: offset < fileSize ? buffer.slice(0, offset) : buffer }
       } finally {
         await fileHandle.close()
       }

--- a/src/lib/exporter/localMediaSource.ts
+++ b/src/lib/exporter/localMediaSource.ts
@@ -122,16 +122,16 @@ export async function createReadableMediaResourceFile(resource: string): Promise
 
 	if (localFilePath && typeof window !== "undefined" && window.electronAPI?.readLocalFile) {
 		const result = await window.electronAPI.readLocalFile(localFilePath);
-		if (!result.success || !result.data) {
-			throw new Error(result.error || "Failed to read local media file");
+		if (result.success && result.data) {
+			const bytes =
+				result.data instanceof Uint8Array ? result.data : new Uint8Array(result.data);
+			const arrayBuffer = bytes.buffer.slice(
+				bytes.byteOffset,
+				bytes.byteOffset + bytes.byteLength,
+			) as ArrayBuffer;
+			return new File([arrayBuffer], filename, { type: inferMimeType(filename) });
 		}
-
-		const bytes = result.data instanceof Uint8Array ? result.data : new Uint8Array(result.data);
-		const arrayBuffer = bytes.buffer.slice(
-			bytes.byteOffset,
-			bytes.byteOffset + bytes.byteLength,
-		) as ArrayBuffer;
-		return new File([arrayBuffer], filename, { type: inferMimeType(filename) });
+		// readLocalFile failed — fall through to URL-based fetch
 	}
 
 	const resourceUrl = await resolveMediaResourceUrl(resource);


### PR DESCRIPTION
## Description

Export fails with `RangeError [ERR_FS_FILE_TOO_LARGE]` when the source recording exceeds 2 GiB. The `read-local-file` IPC handler used `fs.readFile`, which has a hard ~2 GiB limit in Node.js. This caused both legacy and Lightning (Beta) exports of long recordings to fail.

## Motivation

Users recording tutorials commonly produce recordings over 2 GiB. The error was unrecoverable — there was no fallback and the export dialog showed a cryptic range error with no guidance.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

#493

## Screenshots / Video

**Error before fix:**

<img width="756" height="842" alt="image" src="https://github.com/user-attachments/assets/ed357aa9-3b8f-4fbb-836c-761be6d50b64" />


## Testing Guide

1. Record or source a video file larger than 2 GiB
2. Open it in the editor and start an export (both legacy and Lightning paths)
3. Confirm the export completes without `ERR_FS_FILE_TOO_LARGE`
4. Also confirm a normal (<2 GiB) recording still exports correctly (no regression)

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.
