### PR TITLE
fix(export): clamp oversized Lightning media probe ranges

### DIFF
--- a/electron/mediaServer.test.ts
+++ b/electron/mediaServer.test.ts
@@ -70,3 +70,29 @@ describe("media server path policy", () => {
 		expect(isAllowedMediaPath(missingPath)).toBe(false);
 	});
 });
+
+describe("resolveHttpByteRange", () => {
+	it("clamps oversized explicit end offsets to EOF", async () => {
+		const { resolveHttpByteRange } = await import("./mediaServer");
+
+		expect(resolveHttpByteRange("bytes=0-9999999999", 3_221_225_472)).toEqual({
+			start: 0,
+			end: 3_221_225_471,
+		});
+	});
+
+	it("rejects ranges that start beyond EOF", async () => {
+		const { resolveHttpByteRange } = await import("./mediaServer");
+
+		expect(resolveHttpByteRange("bytes=500-999", 500)).toBeNull();
+	});
+
+	it("preserves suffix range semantics", async () => {
+		const { resolveHttpByteRange } = await import("./mediaServer");
+
+		expect(resolveHttpByteRange("bytes=-500", 1_000)).toEqual({
+			start: 500,
+			end: 999,
+		});
+	});
+});

--- a/electron/mediaServer.test.ts
+++ b/electron/mediaServer.test.ts
@@ -72,6 +72,13 @@ describe("media server path policy", () => {
 });
 
 describe("resolveHttpByteRange", () => {
+	it("rejects malformed and multi-range headers", async () => {
+		const { resolveHttpByteRange } = await import("./mediaServer");
+
+		expect(resolveHttpByteRange("bytes=0-1,2-3", 100)).toBeNull();
+		expect(resolveHttpByteRange("bytes=0-1foo", 100)).toBeNull();
+	});
+
 	it("clamps oversized explicit end offsets to EOF", async () => {
 		const { resolveHttpByteRange } = await import("./mediaServer");
 

--- a/electron/mediaServer.ts
+++ b/electron/mediaServer.ts
@@ -12,7 +12,7 @@ export function resolveHttpByteRange(
 	rangeHeader: string,
 	fileSize: number,
 ): { start: number; end: number } | null {
-	const match = rangeHeader.match(/bytes=(\d*)-(\d*)/);
+	const match = rangeHeader.trim().match(/^bytes=(\d*)-(\d*)$/);
 	if (!match || (!match[1] && !match[2])) {
 		return null;
 	}

--- a/electron/mediaServer.ts
+++ b/electron/mediaServer.ts
@@ -8,6 +8,48 @@ import { getMediaContentType } from "./mediaTypes";
 let mediaServerBaseUrl: string | null = null;
 let mediaServerStartPromise: Promise<string> | null = null;
 
+export function resolveHttpByteRange(
+	rangeHeader: string,
+	fileSize: number,
+): { start: number; end: number } | null {
+	const match = rangeHeader.match(/bytes=(\d*)-(\d*)/);
+	if (!match || (!match[1] && !match[2])) {
+		return null;
+	}
+
+	if (fileSize === 0) {
+		return null;
+	}
+
+	if (!match[1] && match[2]) {
+		// Suffix range: bytes=-500
+		const suffixLength = Number.parseInt(match[2], 10);
+		if (Number.isNaN(suffixLength) || suffixLength <= 0) {
+			return null;
+		}
+
+		return {
+			start: Math.max(0, fileSize - suffixLength),
+			end: fileSize - 1,
+		};
+	}
+
+	const start = Number.parseInt(match[1], 10);
+	if (Number.isNaN(start) || start < 0 || start >= fileSize) {
+		return null;
+	}
+
+	const requestedEnd = match[2] ? Number.parseInt(match[2], 10) : fileSize - 1;
+	if (Number.isNaN(requestedEnd) || requestedEnd < start) {
+		return null;
+	}
+
+	return {
+		start,
+		end: Math.min(requestedEnd, fileSize - 1),
+	};
+}
+
 async function resolveRealPath(filePath: string): Promise<string | null> {
 	try {
 		return await fs.realpath(path.resolve(filePath));
@@ -76,42 +118,20 @@ async function handleMediaRequest(
 		}
 
 		if (rangeHeader) {
-			const match = rangeHeader.match(/bytes=(\d*)-(\d*)/);
-			if (!match || (!match[1] && !match[2])) {
-				response.writeHead(416, { ...corsHeaders, "Content-Range": `bytes */${fileSize}` });
-				response.end();
-				return;
-			}
-
-			let start: number;
-			let end: number;
-
-			if (!match[1] && match[2]) {
-				// Suffix range: bytes=-500
-				const suffixLength = Number.parseInt(match[2], 10);
-				if (Number.isNaN(suffixLength) || suffixLength <= 0) {
-					response.writeHead(416, { ...corsHeaders, "Content-Range": `bytes */${fileSize}` });
-					response.end();
-					return;
-				}
-				start = Math.max(0, fileSize - suffixLength);
-				end = fileSize - 1;
-			} else {
-				start = Number.parseInt(match[1], 10);
-				end = match[2] ? Number.parseInt(match[2], 10) : fileSize - 1;
-			}
-
-			if (Number.isNaN(start) || Number.isNaN(end) || start > end || start >= fileSize || end >= fileSize) {
-				response.writeHead(416, { ...corsHeaders, "Content-Range": `bytes */${fileSize}` });
-				response.end();
-				return;
-			}
-
 			if (fileSize === 0) {
 				response.writeHead(416, { ...corsHeaders, "Content-Range": `bytes */0` });
 				response.end();
 				return;
 			}
+
+			const byteRange = resolveHttpByteRange(rangeHeader, fileSize);
+			if (!byteRange) {
+				response.writeHead(416, { ...corsHeaders, "Content-Range": `bytes */${fileSize}` });
+				response.end();
+				return;
+			}
+
+			const { start, end } = byteRange;
 
 			const chunkSize = end - start + 1;
 			response.writeHead(206, {


### PR DESCRIPTION
## Summary
- clamp oversized HTTP byte-range end offsets to EOF in the local `/video` media server
- keep valid suffix ranges working while still rejecting requests that start beyond EOF
- add focused tests covering the large-file probe behavior

## Root Cause
Lightning metadata probing goes through the local loopback media server. For large files, the demuxer can request a byte range whose end overshoots the file size. Our server treated that as a hard `416 Range Not Satisfiable` instead of clamping the end to EOF, which could cause `get_media_info failed: Failed after 3 attempts` before export even started.

## Impact
This fixes the media-server bug at the source instead of adding another exporter fallback. Large local recordings should now survive oversized probe ranges during Lightning startup.

## Testing
- `npx vitest run electron/mediaServer.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of HTTP byte-range requests for media streaming and resumable downloads.
  * Returns correct HTTP error for invalid ranges and for empty files.
  * Supports suffix-range requests and various partial-content formats.
  * Clamps ranges that extend beyond file boundaries to the actual file end to improve playback reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->