### PR TITLE
feat: persist & restore screen/mic/webcam selection across sessions

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -830,6 +830,10 @@ interface Window {
 			webcamDeviceId?: string;
 			selectedSourceId?: string;
 			selectedSourceName?: string;
+			selectedSourceDisplayId?: string;
+			selectedSourceThumbnail?: string | null;
+			selectedSourceAppIcon?: string | null;
+			selectedSourceType?: "screen" | "window";
 		}>;
 		getRecordingAudioLabConfig: () => Promise<{
 			browserMicrophoneProfile: string;
@@ -843,6 +847,10 @@ interface Window {
 			webcamDeviceId?: string;
 			selectedSourceId?: string;
 			selectedSourceName?: string;
+			selectedSourceDisplayId?: string;
+			selectedSourceThumbnail?: string | null;
+			selectedSourceAppIcon?: string | null;
+			selectedSourceType?: "screen" | "window";
 		}) => Promise<{ success: boolean; error?: string }>;
 		/** Countdown timer before recording */
 		getCountdownDelay: () => Promise<{ success: boolean; delay: number }>;

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -830,10 +830,6 @@ interface Window {
 			webcamDeviceId?: string;
 			selectedSourceId?: string;
 			selectedSourceName?: string;
-			selectedSourceDisplayId?: string;
-			selectedSourceThumbnail?: string | null;
-			selectedSourceAppIcon?: string | null;
-			selectedSourceType?: "screen" | "window";
 		}>;
 		getRecordingAudioLabConfig: () => Promise<{
 			browserMicrophoneProfile: string;
@@ -847,10 +843,6 @@ interface Window {
 			webcamDeviceId?: string;
 			selectedSourceId?: string;
 			selectedSourceName?: string;
-			selectedSourceDisplayId?: string;
-			selectedSourceThumbnail?: string | null;
-			selectedSourceAppIcon?: string | null;
-			selectedSourceType?: "screen" | "window";
 		}) => Promise<{ success: boolean; error?: string }>;
 		/** Countdown timer before recording */
 		getCountdownDelay: () => Promise<{ success: boolean; delay: number }>;

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -826,6 +826,10 @@ interface Window {
 			microphoneEnabled: boolean;
 			microphoneDeviceId?: string;
 			systemAudioEnabled: boolean;
+			webcamEnabled?: boolean;
+			webcamDeviceId?: string;
+			selectedSourceId?: string;
+			selectedSourceName?: string;
 		}>;
 		getRecordingAudioLabConfig: () => Promise<{
 			browserMicrophoneProfile: string;
@@ -835,6 +839,10 @@ interface Window {
 			microphoneEnabled?: boolean;
 			microphoneDeviceId?: string;
 			systemAudioEnabled?: boolean;
+			webcamEnabled?: boolean;
+			webcamDeviceId?: string;
+			selectedSourceId?: string;
+			selectedSourceName?: string;
 		}) => Promise<{ success: boolean; error?: string }>;
 		/** Countdown timer before recording */
 		getCountdownDelay: () => Promise<{ success: boolean; delay: number }>;

--- a/electron/ipc/register/settings.ts
+++ b/electron/ipc/register/settings.ts
@@ -147,9 +147,22 @@ export function registerSettingsHandlers() {
           microphoneEnabled: parsed.microphoneEnabled === true,
           microphoneDeviceId: typeof parsed.microphoneDeviceId === 'string' ? parsed.microphoneDeviceId : undefined,
           systemAudioEnabled: parsed.systemAudioEnabled === true,
+          webcamEnabled: parsed.webcamEnabled === true,
+          webcamDeviceId: typeof parsed.webcamDeviceId === 'string' ? parsed.webcamDeviceId : undefined,
+          selectedSourceId: typeof parsed.selectedSourceId === 'string' ? parsed.selectedSourceId : undefined,
+          selectedSourceName: typeof parsed.selectedSourceName === 'string' ? parsed.selectedSourceName : undefined,
         }
       } catch {
-        return { success: true, microphoneEnabled: false, microphoneDeviceId: undefined, systemAudioEnabled: false }
+        return {
+          success: true,
+          microphoneEnabled: false,
+          microphoneDeviceId: undefined,
+          systemAudioEnabled: false,
+          webcamEnabled: false,
+          webcamDeviceId: undefined,
+          selectedSourceId: undefined,
+          selectedSourceName: undefined,
+        }
       }
     })
 
@@ -157,7 +170,7 @@ export function registerSettingsHandlers() {
       return getBrowserMicrophoneProfileFromEnv()
     })
 
-    ipcMain.handle('set-recording-preferences', async (_, prefs: { microphoneEnabled?: boolean; microphoneDeviceId?: string; systemAudioEnabled?: boolean }) => {
+    ipcMain.handle('set-recording-preferences', async (_, prefs: { microphoneEnabled?: boolean; microphoneDeviceId?: string; systemAudioEnabled?: boolean; webcamEnabled?: boolean; webcamDeviceId?: string; selectedSourceId?: string; selectedSourceName?: string }) => {
       try {
         let existing: Record<string, unknown> = {}
         try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -907,6 +907,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		microphoneEnabled?: boolean;
 		microphoneDeviceId?: string;
 		systemAudioEnabled?: boolean;
+		webcamEnabled?: boolean;
+		webcamDeviceId?: string;
+		selectedSourceId?: string;
+		selectedSourceName?: string;
 	}) => ipcRenderer.invoke("set-recording-preferences", prefs),
 	getCountdownDelay: () => ipcRenderer.invoke("get-countdown-delay"),
 	setCountdownDelay: (delay: number) => ipcRenderer.invoke("set-countdown-delay", delay),

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -119,11 +119,11 @@ function LaunchWindowContent() {
 	const supportsHudCaptureProtection = platform !== "linux";
 
 	useEffect(() => {
-		if (!selectedDeviceId) {
+		if (!selectedDeviceId || selectedDeviceId === "default") {
 			return;
 		}
 
-		setMicrophoneDeviceId(selectedDeviceId === "default" ? undefined : selectedDeviceId);
+		setMicrophoneDeviceId(selectedDeviceId);
 	}, [selectedDeviceId, setMicrophoneDeviceId]);
 
 	useEffect(() => {

--- a/src/components/launch/hooks/useLaunchWindowActions.ts
+++ b/src/components/launch/hooks/useLaunchWindowActions.ts
@@ -12,10 +12,6 @@ export function useLaunchWindowActions() {
 		void window.electronAPI.setRecordingPreferences({
 			selectedSourceId: source.id,
 			selectedSourceName: source.name,
-			selectedSourceDisplayId: source.display_id,
-			selectedSourceThumbnail: source.thumbnail,
-			selectedSourceAppIcon: source.appIcon,
-			selectedSourceType: source.sourceType,
 		});
 		setSelectedSource(source.name);
 		setHasSelectedSource(true);

--- a/src/components/launch/hooks/useLaunchWindowActions.ts
+++ b/src/components/launch/hooks/useLaunchWindowActions.ts
@@ -9,6 +9,14 @@ export function useLaunchWindowActions() {
 
 	const handleSourceSelect = useCallback(async (source: DesktopSource) => {
 		await window.electronAPI.selectSource(source);
+		void window.electronAPI.setRecordingPreferences({
+			selectedSourceId: source.id,
+			selectedSourceName: source.name,
+			selectedSourceDisplayId: source.display_id,
+			selectedSourceThumbnail: source.thumbnail,
+			selectedSourceAppIcon: source.appIcon,
+			selectedSourceType: source.sourceType,
+		});
 		setSelectedSource(source.name);
 		setHasSelectedSource(true);
 		window.electronAPI.showSourceHighlight?.({

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1204,6 +1204,16 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				if (result.webcamDeviceId) {
 					setWebcamDeviceId(result.webcamDeviceId);
 				}
+				if (result.selectedSourceId && result.selectedSourceName) {
+					void window.electronAPI.selectSource({
+						id: result.selectedSourceId,
+						name: result.selectedSourceName,
+						display_id: result.selectedSourceDisplayId || "",
+						thumbnail: result.selectedSourceThumbnail || null,
+						appIcon: result.selectedSourceAppIcon || null,
+						sourceType: result.selectedSourceType || "screen",
+					});
+				}
 			}
 		})();
 	}, []);

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1205,14 +1205,23 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					setWebcamDeviceId(result.webcamDeviceId);
 				}
 				if (result.selectedSourceId && result.selectedSourceName) {
-					void window.electronAPI.selectSource({
-						id: result.selectedSourceId,
-						name: result.selectedSourceName,
-						display_id: result.selectedSourceDisplayId || "",
-						thumbnail: result.selectedSourceThumbnail || null,
-						appIcon: result.selectedSourceAppIcon || null,
-						sourceType: result.selectedSourceType || "screen",
-					});
+					// Electron desktopCapturer ids are not stable across
+					// reboots / display changes. Only restore the source if it
+					// still exists in the current capture list, otherwise the
+					// app would silently capture a non-existent target.
+					try {
+						const available = await window.electronAPI.getSources({
+							types: ["screen", "window"],
+						});
+						const match = available.find(
+							(source) => source.id === result.selectedSourceId,
+						);
+						if (match) {
+							void window.electronAPI.selectSource(match);
+						}
+					} catch {
+						// Source enumeration failed — skip restore silently.
+					}
 				}
 			}
 		})();

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1198,6 +1198,12 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					setMicrophoneDeviceId(result.microphoneDeviceId);
 				}
 				setSystemAudioEnabled(result.systemAudioEnabled);
+				if (result.webcamEnabled) {
+					setWebcamEnabled(true);
+				}
+				if (result.webcamDeviceId) {
+					setWebcamDeviceId(result.webcamDeviceId);
+				}
 			}
 		})();
 	}, []);
@@ -1215,6 +1221,16 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	const persistSystemAudioEnabled = useCallback((enabled: boolean) => {
 		setSystemAudioEnabled(enabled);
 		void window.electronAPI.setRecordingPreferences({ systemAudioEnabled: enabled });
+	}, []);
+
+	const persistWebcamEnabled = useCallback((enabled: boolean) => {
+		setWebcamEnabled(enabled);
+		void window.electronAPI.setRecordingPreferences({ webcamEnabled: enabled });
+	}, []);
+
+	const persistWebcamDeviceId = useCallback((deviceId: string | undefined) => {
+		setWebcamDeviceId(deviceId);
+		void window.electronAPI.setRecordingPreferences({ webcamDeviceId: deviceId });
 	}, []);
 
 	useEffect(() => {
@@ -2009,9 +2025,9 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		systemAudioEnabled,
 		setSystemAudioEnabled: persistSystemAudioEnabled,
 		webcamEnabled,
-		setWebcamEnabled,
+		setWebcamEnabled: persistWebcamEnabled,
 		webcamDeviceId,
-		setWebcamDeviceId,
+		setWebcamDeviceId: persistWebcamDeviceId,
 		countdownDelay,
 		setCountdownDelay,
 	};


### PR DESCRIPTION
## What this adds

Persist and restore the last selected **screen source, microphone, and webcam** across app restarts. Today every launch starts from scratch and you re-pick all three devices before recording — annoying when you record often with the same setup.

## Why

Pure quality-of-life. The settings file already had `selectedSourceId` / `selectedSourceName` fields that were never written; this finishes that wiring and fixes the mic side.

## What changed

- **Screen source**: persisted on selection and restored on startup. Restore is validated against the **live capture list** — `desktopCapturer` ids are not stable across reboots / display changes, so we only re-select the saved source if it still exists, otherwise we skip silently instead of capturing a dead target. The existing `onSelectedSourceChanged` broadcast syncs the HUD.
- **Microphone**: fixed a real race — the init sync effect was overwriting the saved device id with `undefined` before the real devices enumerated. Guard added so `"default"` no longer clobbers a persisted device.
- **Webcam**: device + enabled state persisted and hydrated on startup.

## Design note

An earlier revision persisted the full source object (display_id/thumbnail/appIcon/type). I dropped that on review: the live-enumeration approach is strictly more robust (a stale persisted blob would happily restore a source that no longer exists), and the live source object already carries those fields. So this PR persists only the stable id+name and rehydrates the rest from the live list.

## Testing

- Manual: select screen/mic/webcam, restart, confirm all three restore; confirm a removed source is skipped rather than producing a black capture.
- `tsc --noEmit` clean.

Independent of #531 / #533. Targets `v1.3.0-beta.3`.

## Context

Built with Claude Code as a tool (maintainers know I work this way); design and validation are mine.