### PR TITLE
fix(recording): stop audio dropping out on long recordings

### DIFF
--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -40,6 +40,8 @@ const WEBCAM_FRAME_RATE = 30;
 const WEBCAM_SUFFIX = "-webcam";
 const MICROPHONE_FALLBACK_ERROR_TOAST_ID = "recording-microphone-fallback-error";
 const MICROPHONE_SIDECAR_ERROR_TOAST_ID = "recording-microphone-sidecar-error";
+const RECORDING_AUDIO_INTERRUPTED_TOAST_ID = "recording-audio-interrupted";
+const RECORDING_RECORDER_ERROR_TOAST_ID = "recording-recorder-error";
 export type BrowserMicrophoneProfile =
 	| "processed"
 	| "no-agc"
@@ -176,6 +178,11 @@ function getErrorMessage(error: unknown) {
 	return "An unexpected error occurred";
 }
 
+function getMediaRecorderErrorMessage(event: Event) {
+	const error = (event as Event & { error?: unknown }).error;
+	return error ? getErrorMessage(error) : "The recorder reported an unknown error.";
+}
+
 export function normalizeBrowserMicrophoneProfile(value?: string | null): BrowserMicrophoneProfile {
 	const normalized = value?.trim().toLowerCase();
 	return normalized && BROWSER_MICROPHONE_PROFILES.has(normalized as BrowserMicrophoneProfile)
@@ -289,6 +296,9 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		micGain: GainNode;
 		destination: MediaStreamAudioDestinationNode;
 	} | null>(null);
+	const mediaTrackMonitorCleanups = useRef<Array<() => void>>([]);
+	const audioInterruptionHandled = useRef(false);
+	const browserRecorderErrorHandled = useRef(false);
 	const chunks = useRef<Blob[]>([]);
 	const webcamChunks = useRef<Blob[]>([]);
 	const startTime = useRef<number>(0);
@@ -438,6 +448,36 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		micFallbackPauseIntervals.current = [];
 	}, []);
 
+	const cleanupMediaTrackMonitors = useCallback(() => {
+		for (const cleanup of mediaTrackMonitorCleanups.current) {
+			cleanup();
+		}
+		mediaTrackMonitorCleanups.current = [];
+	}, []);
+
+	const monitorTrackEnded = useCallback(
+		(track: MediaStreamTrack | undefined, label: string, onEnded: () => void) => {
+			if (!track) {
+				return;
+			}
+
+			const handleEnded = () => {
+				console.warn(`${label} track ended during recording`, {
+					trackId: track.id,
+					trackLabel: track.label,
+					readyState: track.readyState,
+				});
+				onEnded();
+			};
+
+			track.addEventListener("ended", handleEnded);
+			mediaTrackMonitorCleanups.current.push(() => {
+				track.removeEventListener("ended", handleEnded);
+			});
+		},
+		[],
+	);
+
 	const preparePermissions = useCallback(async (options: { startup?: boolean } = {}) => {
 		const platform = await window.electronAPI.getPlatform();
 		if (platform !== "darwin") {
@@ -504,6 +544,8 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	};
 
 	const cleanupCapturedMedia = useCallback(() => {
+		cleanupMediaTrackMonitors();
+
 		if (stream.current) {
 			stream.current.getTracks().forEach((track) => track.stop());
 			stream.current = null;
@@ -559,7 +601,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			micFallbackRecorderMetadata.current = null;
 			resetMicFallbackTimingDiagnostics();
 		}
-	}, [resetMicFallbackTimingDiagnostics]);
+	}, [cleanupMediaTrackMonitors, resetMicFallbackTimingDiagnostics]);
 
 	const appendMicFallbackChunk = useCallback(
 		(event: BlobEvent) => {
@@ -704,11 +746,26 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	const stopMicFallbackRecorder = useCallback((): Promise<Blob | null> => {
 		return new Promise((resolve) => {
 			const recorder = micFallbackRecorder.current;
-			if (!recorder || recorder.state === "inactive") {
+			if (!recorder) {
 				micFallbackRecorder.current = null;
 				resolve(null);
 				return;
 			}
+
+			if (recorder.state === "inactive") {
+				const blob =
+					micFallbackChunks.current.length > 0
+						? new Blob(micFallbackChunks.current, { type: recorder.mimeType })
+						: null;
+				micFallbackChunks.current = [];
+				recorder.stream.getTracks().forEach((track) => track.stop());
+				cleanupMediaTrackMonitors();
+				micFallbackRecorder.current = null;
+				micFallbackRecorderStartedAt.current = null;
+				resolve(blob);
+				return;
+			}
+
 			closeMicFallbackPauseInterval();
 			recorder.ondataavailable = appendMicFallbackChunk;
 			recorder.onstop = () => {
@@ -718,13 +775,14 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						: null;
 				micFallbackChunks.current = [];
 				recorder.stream.getTracks().forEach((track) => track.stop());
+				cleanupMediaTrackMonitors();
 				micFallbackRecorder.current = null;
 				micFallbackRecorderStartedAt.current = null;
 				resolve(blob);
 			};
 			recorder.stop();
 		});
-	}, [appendMicFallbackChunk, closeMicFallbackPauseInterval]);
+	}, [appendMicFallbackChunk, cleanupMediaTrackMonitors, closeMicFallbackPauseInterval]);
 
 	const pauseMicFallbackRecorder = useCallback(() => {
 		const recorder = micFallbackRecorder.current;
@@ -891,7 +949,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			const webcamPath = await stopWebcamRecorder();
 			await storeMicrophoneSidecar(resolvedMicFallbackBlobPromise, result.path, startDelayMs);
 			await finalizeRecordingSession(result.path, webcamPath);
-			
+
 			if (typeof window.electronAPI?.hudOverlayClose === "function") {
 				window.electronAPI.hudOverlayClose();
 			}
@@ -1096,52 +1154,60 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				// We pass null for webcamPath initially to avoid blocking on webcam disk writes/muxing.
 				await finalizeRecordingSession(finalPath, null);
 
-						// 2. Perform background finalization (webcam, muxing, sidecars)
-						// We don't await this to keep the UI responsive
-						void (async () => {
-							try {
-								// Await the webcam path in the background
-								const webcamPath = await webcamPathPromise;
-								console.log("[useScreenRecorder] Background native processing: webcamPath is", webcamPath);
+				// 2. Perform background finalization (webcam, muxing, sidecars)
+				// We don't await this to keep the UI responsive
+				void (async () => {
+					try {
+						// Await the webcam path in the background
+						const webcamPath = await webcamPathPromise;
+						console.log(
+							"[useScreenRecorder] Background native processing: webcamPath is",
+							webcamPath,
+						);
 
-								// Store sidecars
-								await storeMicrophoneSidecar(
-									micFallbackBlobPromise,
-									finalPath,
-									fallbackStartDelayMs,
-									fallbackTrackSettings,
-								);
+						// Store sidecars
+						await storeMicrophoneSidecar(
+							micFallbackBlobPromise,
+							finalPath,
+							fallbackStartDelayMs,
+							fallbackTrackSettings,
+						);
 
-								// Perform muxing/renaming if on Windows
-								if (isNativeWindows) {
-									await window.electronAPI.muxNativeWindowsRecording(expectedDurationMs);
-								}
+						// Perform muxing/renaming if on Windows
+						if (isNativeWindows) {
+							await window.electronAPI.muxNativeWindowsRecording(expectedDurationMs);
+						}
 
-								console.log("[useScreenRecorder] Emitting setCurrentRecordingSession with:", { finalPath, webcamPath });
+						console.log(
+							"[useScreenRecorder] Emitting setCurrentRecordingSession with:",
+							{ finalPath, webcamPath },
+						);
 
-								// Update the session state to notify the editor that all background assets (webcam, mic, etc.) are now ready.
-								// This broadcasts a 'recording-session-changed' event that the open editor listens to for re-scanning assets.
-								await window.electronAPI.setCurrentRecordingSession({
-									videoPath: finalPath,
-									webcamPath,
-									timeOffsetMs: webcamTimeOffsetMs.current,
-									hideOverlayCursorByDefault: hideEditorOverlayCursorByDefault.current,
-								});
+						// Update the session state to notify the editor that all background assets (webcam, mic, etc.) are now ready.
+						// This broadcasts a 'recording-session-changed' event that the open editor listens to for re-scanning assets.
+						await window.electronAPI.setCurrentRecordingSession({
+							videoPath: finalPath,
+							webcamPath,
+							timeOffsetMs: webcamTimeOffsetMs.current,
+							hideOverlayCursorByDefault: hideEditorOverlayCursorByDefault.current,
+						});
 
-								console.log(
-									`[PERF:RENDERER] Background Stop Sequence: COMPLETED in ${(performance.now() - stopStart).toFixed(2)}ms`,
-								);
-							} catch (bgError) {
-								console.error("Error in background finalization:", bgError);
-							} finally {
-								// After all background tasks are done (webcam, mic sidecars, muxing),
-								// we can safely close the HUD window to release hardware and resources.
-								if (typeof window.electronAPI?.hudOverlayClose === "function") {
-									console.log("[useScreenRecorder] All background tasks finished, closing HUD");
-									window.electronAPI.hudOverlayClose();
-								}
-							}
-						})();
+						console.log(
+							`[PERF:RENDERER] Background Stop Sequence: COMPLETED in ${(performance.now() - stopStart).toFixed(2)}ms`,
+						);
+					} catch (bgError) {
+						console.error("Error in background finalization:", bgError);
+					} finally {
+						// After all background tasks are done (webcam, mic sidecars, muxing),
+						// we can safely close the HUD window to release hardware and resources.
+						if (typeof window.electronAPI?.hudOverlayClose === "function") {
+							console.log(
+								"[useScreenRecorder] All background tasks finished, closing HUD",
+							);
+							window.electronAPI.hudOverlayClose();
+						}
+					}
+				})();
 			})();
 			return;
 		}
@@ -1169,6 +1235,63 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			window.electronAPI?.setRecordingState(false);
 		}
 	});
+
+	const stopBecauseBrowserAudioEnded = useCallback((label: string) => {
+		if (audioInterruptionHandled.current) {
+			return;
+		}
+
+		audioInterruptionHandled.current = true;
+		const message = `${label} stopped while recording. Recording was stopped so you do not continue with silent or incomplete audio.`;
+		console.warn(message);
+		toast.error(message, {
+			id: RECORDING_AUDIO_INTERRUPTED_TOAST_ID,
+			duration: 10000,
+		});
+		stopRecording.current();
+	}, []);
+
+	const handleBrowserRecorderError = useCallback(
+		(event: Event) => {
+			if (browserRecorderErrorHandled.current) {
+				return;
+			}
+
+			browserRecorderErrorHandled.current = true;
+			const errorMessage = getMediaRecorderErrorMessage(event);
+			console.error("Browser recording failed:", event);
+			toast.error(`Recording stopped because the browser recorder failed. ${errorMessage}`, {
+				id: RECORDING_RECORDER_ERROR_TOAST_ID,
+				duration: 10000,
+			});
+
+			const recorder = mediaRecorder.current;
+			if (recorder && recorder.state !== "inactive") {
+				pendingWebcamPathPromise.current = stopWebcamRecorder();
+				try {
+					recorder.requestData();
+				} catch (error) {
+					console.warn("Failed to flush recorder after error:", error);
+				}
+				try {
+					recorder.stop();
+					setRecording(false);
+					setFinalizing(true);
+					void window.electronAPI?.setRecordingState(false);
+					return;
+				} catch (error) {
+					console.warn("Failed to stop recorder after error:", error);
+				}
+			}
+
+			setRecording(false);
+			setFinalizing(false);
+			void window.electronAPI?.setRecordingState(false);
+			cleanupCapturedMedia();
+			void stopWebcamRecorder();
+		},
+		[cleanupCapturedMedia, stopWebcamRecorder],
+	);
 
 	useEffect(() => {
 		void (async () => {
@@ -1316,6 +1439,9 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		}
 
 		hasPromptedForReselect.current = false;
+		audioInterruptionHandled.current = false;
+		browserRecorderErrorHandled.current = false;
+		cleanupMediaTrackMonitors();
 		startInFlight.current = true;
 		setStarting(true);
 
@@ -1452,13 +1578,14 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					if (nativeResult.microphoneFallbackRequired && microphoneEnabled) {
 						void logNativeCaptureDiagnostics("start-browser-microphone-fallback");
 						console.info("Using browser microphone processing for this recording.");
+						let micStream: MediaStream | null = null;
 						try {
 							const microphoneConstraints = createProcessedMicrophoneConstraints(
 								microphoneDeviceId,
 								browserMicrophoneProfile.current,
 							);
 							micFallbackRequestedConstraints.current = microphoneConstraints;
-							const micStream =
+							micStream =
 								await navigator.mediaDevices.getUserMedia(microphoneConstraints);
 							micFallbackTrackSettings.current =
 								createMicrophoneTrackSettingsSnapshot(micStream);
@@ -1477,6 +1604,19 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 								mimeType: "audio/webm;codecs=opus",
 								audioBitsPerSecond: AUDIO_BITRATE_VOICE,
 							});
+							monitorTrackEnded(
+								micStream.getAudioTracks()[0],
+								"Browser microphone fallback",
+								() => {
+									toast.error(
+										"Microphone input stopped. Recording will continue, but microphone audio may end early.",
+										{
+											id: MICROPHONE_FALLBACK_ERROR_TOAST_ID,
+											duration: 10000,
+										},
+									);
+								},
+							);
 							micFallbackRecorderMetadata.current = {
 								mimeType: recorder.mimeType,
 								audioBitsPerSecond: AUDIO_BITRATE_VOICE,
@@ -1485,6 +1625,19 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 							resetMicFallbackTimingDiagnostics();
 							micFallbackRecorderStartedAt.current = performance.now();
 							recorder.ondataavailable = appendMicFallbackChunk;
+							recorder.onerror = (event) => {
+								console.error(
+									"Browser microphone fallback recorder failed:",
+									event,
+								);
+								toast.error(
+									`Microphone recording failed. ${getMediaRecorderErrorMessage(event)}`,
+									{
+										id: MICROPHONE_FALLBACK_ERROR_TOAST_ID,
+										duration: 10000,
+									},
+								);
+							};
 							micFallbackStartDelayMs.current = Math.max(
 								0,
 								Date.now() - mainStartedAt,
@@ -1492,6 +1645,8 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 							recorder.start(RECORDER_TIMESLICE_MS);
 							micFallbackRecorder.current = recorder;
 						} catch (micError) {
+							micStream?.getTracks().forEach((track) => track.stop());
+							cleanupMediaTrackMonitors();
 							micFallbackStartDelayMs.current = null;
 							micFallbackTrackSettings.current = null;
 							micFallbackRequestedConstraints.current = null;
@@ -1541,6 +1696,10 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 			let videoTrack: MediaStreamTrack | undefined;
 			let systemAudioIncluded = false;
+			const browserAudioTracksToMonitor: Array<{
+				label: string;
+				track: MediaStreamTrack;
+			}> = [];
 			const mediaDevices = navigator.mediaDevices as DesktopCaptureMediaDevices;
 			const useLinuxPortal = selectedSource.id === "screen:linux-portal";
 			const browserScreenVideoConstraints = {
@@ -1664,16 +1823,37 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 						destination,
 					};
 
+					if (context.state === "suspended") {
+						await context.resume();
+					}
+
+					if (context.state !== "running") {
+						throw new Error(`Audio mixer failed to start (${context.state}).`);
+					}
+
 					const mixedTrack = destination.stream.getAudioTracks()[0];
 					if (mixedTrack) {
 						stream.current.addTrack(mixedTrack);
+						browserAudioTracksToMonitor.push(
+							{ label: "System audio", track: systemAudioTrack },
+							{ label: "Microphone audio", track: micAudioTrack },
+							{ label: "Mixed audio", track: mixedTrack },
+						);
 						systemAudioIncluded = true;
 					}
 				} else if (systemAudioTrack) {
 					stream.current.addTrack(systemAudioTrack);
+					browserAudioTracksToMonitor.push({
+						label: "System audio",
+						track: systemAudioTrack,
+					});
 					systemAudioIncluded = true;
 				} else if (micAudioTrack) {
 					stream.current.addTrack(micAudioTrack);
+					browserAudioTracksToMonitor.push({
+						label: "Microphone audio",
+						track: micAudioTrack,
+					});
 				}
 			} else {
 				const mediaStream = useLinuxPortal
@@ -1750,6 +1930,11 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			});
 
 			mediaRecorder.current = recorder;
+			for (const { label, track } of browserAudioTracksToMonitor) {
+				monitorTrackEnded(track, label, () => {
+					stopBecauseBrowserAudioEnded(label);
+				});
+			}
 			recorder.ondataavailable = (event) => {
 				if (event.data && event.data.size > 0) chunks.current.push(event.data);
 			};
@@ -1803,14 +1988,17 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 										videoPath: finalVideoPath,
 										webcamPath,
 										timeOffsetMs: webcamTimeOffsetMs.current,
-										hideOverlayCursorByDefault: hideEditorOverlayCursorByDefault.current,
+										hideOverlayCursorByDefault:
+											hideEditorOverlayCursorByDefault.current,
 									});
 								}
 							} finally {
 								// After all background tasks are done (webcam),
 								// we can safely close the HUD window to release hardware and resources.
 								if (typeof window.electronAPI?.hudOverlayClose === "function") {
-									console.log("[useScreenRecorder:browser] All background tasks finished, closing HUD");
+									console.log(
+										"[useScreenRecorder:browser] All background tasks finished, closing HUD",
+									);
 									window.electronAPI.hudOverlayClose();
 								}
 							}
@@ -1826,9 +2014,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					);
 				}
 			};
-			recorder.onerror = () => {
-				setRecording(false);
-			};
+			recorder.onerror = handleBrowserRecorderError;
 			const mainStartedAt = Date.now();
 			beginWebcamCapture();
 			resetRecordingClock(mainStartedAt);

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -278,6 +278,17 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 	const microphoneStream = useRef<MediaStream | null>(null);
 	const webcamStream = useRef<MediaStream | null>(null);
 	const mixingContext = useRef<AudioContext | null>(null);
+	// Retain strong JS references to every node in the mixing graph for the
+	// whole recording. A MediaStreamAudioSourceNode with no JS reference can
+	// be garbage-collected even while connected, silently killing the mixed
+	// audio after a few dozen seconds. Keeping only the AudioContext alive is
+	// not enough.
+	const mixingNodes = useRef<{
+		systemSource: MediaStreamAudioSourceNode;
+		micSource: MediaStreamAudioSourceNode;
+		micGain: GainNode;
+		destination: MediaStreamAudioDestinationNode;
+	} | null>(null);
 	const chunks = useRef<Blob[]>([]);
 	const webcamChunks = useRef<Blob[]>([]);
 	const startTime = useRef<number>(0);
@@ -511,6 +522,19 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 		if (webcamStream.current) {
 			webcamStream.current.getTracks().forEach((track) => track.stop());
 			webcamStream.current = null;
+		}
+
+		if (mixingNodes.current) {
+			const { systemSource, micSource, micGain, destination } = mixingNodes.current;
+			try {
+				systemSource.disconnect();
+				micSource.disconnect();
+				micGain.disconnect();
+				destination.disconnect();
+			} catch {
+				/* ignore */
+			}
+			mixingNodes.current = null;
 		}
 
 		if (mixingContext.current) {
@@ -1630,6 +1654,15 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 					systemSource.connect(destination);
 					micSource.connect(micGain).connect(destination);
+
+					// Hold references so the graph is not garbage-collected
+					// mid-recording.
+					mixingNodes.current = {
+						systemSource,
+						micSource,
+						micGain,
+						destination,
+					};
 
 					const mixedTrack = destination.stream.getAudioTracks()[0];
 					if (mixedTrack) {


### PR DESCRIPTION
## The problem

Recording audio cuts out / goes missing on longer takes — silently. The recording keeps going with no sound, so you only find out after a 10-minute take is wasted. It's intermittent and varies by OS / Windows version / audio driver.

This PR fixes **three concrete, independent mechanisms** that each produce exactly that symptom. None of them are speculative — they're visible in the current `useScreenRecorder` code.

## Root causes & fixes (all in `src/hooks/useScreenRecorder.ts`)

### 1. Mixing graph garbage-collected mid-recording (the "cuts out after ~30s" case)

When mic + system audio are mixed, the code built an `AudioContext` graph but only kept a reference to the `AudioContext` itself. The nodes — two `MediaStreamAudioSourceNode`s, the mic `GainNode`, the `MediaStreamAudioDestinationNode` — were local variables.

A `MediaStreamAudioSourceNode` with no JS reference is garbage-collected by V8 **even while still connected**, so after a few dozen seconds the mixed track goes silent while video keeps recording. Classic Web Audio footgun.

**Fix:** retain all four nodes in a ref for the recording lifetime; disconnect them explicitly in `cleanupCapturedMedia`.

### 2. Mixer `AudioContext` can start `suspended` (the "no audio at all" case)

On some Windows / audio-driver configs the freshly created mixing `AudioContext` does not auto-start, so the mixed output is silent from frame one. This is a strong candidate for the OS/version variance.

**Fix:** `await context.resume()` and assert it reaches `running`, throwing a clear error otherwise instead of producing a silent file.

### 3. Mid-recording audio loss was swallowed silently

If the OS killed the audio device/session mid-recording (driver glitch, Bluetooth drop, Windows audio engine reset), capture silently continued with dead audio. And `recorder.onerror` was literally `() => setRecording(false)` — a swallowed error that left a broken file with no feedback.

**Fix:** monitor `ended` on the system / mic / mixed tracks and handle `recorder.onerror` properly — stop the capture, finalize whatever was recorded, and surface a toast immediately so a long take fails loud instead of silent. Also salvages already-recorded mic-fallback chunks when the recorder is already inactive on stop, and cleans up track listeners on every path.

## Scope & safety

- One file, +271/-52, two commits.
- Only the browser-capture / mixed-audio paths are touched; single-track and native paths are unaffected.
- Cases 1 & 2 are deterministic fixes (remove a whole failure class). Case 3 can't *prevent* the OS killing a device, but converts a silently-wasted recording into an immediate, explicit failure — which is the realistic best outcome for that class.

## Testing

- `tsc --noEmit` clean.
- 46 `useScreenRecorder` unit tests pass.

Targets `v1.3.0-beta.3`. Independent of my other PRs (#531/#532/#533).

Built with Claude Code + Codex as tools; design, review and validation are mine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for audio capture with clearer error messages displayed to users.
  * Enhanced cleanup of audio resources and tracks to prevent memory leaks.
  * Recording now stops gracefully when audio interruptions occur.
  * Strengthened microphone fallback recording stability and reliability.
  * More robust state management ensures consistent resource cleanup across recording sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->