### PR TITLE
Add Nix flake install support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist-ssr
 *.sln
 *.sw?
 release/**
+/result
 *.kiro/
 # npx electron-builder --mac --win
 .tmp/

--- a/README.md
+++ b/README.md
@@ -177,6 +177,45 @@ https://github.com/webadderallorg/Recordly/releases
 
 ---
 
+## Nix (flakes)
+
+Install the stable release packaged by this flake:
+
+```bash
+nix profile install github:webadderallorg/Recordly#recordly
+```
+
+Or launch it directly:
+
+```bash
+nix run github:webadderallorg/Recordly#recordly
+```
+
+The flake currently packages Recordly `v1.2.1` from release artifacts and provides packages for `aarch64-darwin`, `x86_64-darwin`, and `x86_64-linux`.
+
+For nix-darwin, add Recordly as an input and include the package in your system packages:
+
+```nix
+{
+  inputs.recordly.url = "github:webadderallorg/Recordly";
+
+  outputs = { recordly, ... }@inputs: {
+    darwinConfigurations.your-host = inputs.nix-darwin.lib.darwinSystem {
+      system = "aarch64-darwin";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            recordly.packages.${pkgs.stdenv.hostPlatform.system}.default
+          ];
+        })
+      ];
+    };
+  };
+}
+```
+
+---
+
 ## Arch Linux / Manjaro (yay)
 
 Install from the AUR ([recordly-bin](https://aur.archlinux.org/packages/recordly-bin)):

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+{
+  description = "Recordly Nix packages";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      version = "1.2.1";
+
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      releaseHashes = {
+        aarch64-darwin = {
+          arch = "arm64";
+          extension = "zip";
+          hash = "sha256-0Mk+ha3n2RA9LtwdoCele82666a4NCLylMruTFGS7C4=";
+        };
+        x86_64-darwin = {
+          arch = "x64";
+          extension = "zip";
+          hash = "sha256-PRG1DOX9sy9AJCC1/haEWlcNGkBiO9zicf9ng6Ix8fw=";
+        };
+        x86_64-linux = {
+          arch = "linux-x64";
+          extension = "AppImage";
+          hash = "sha256-r+yUa1XuDnNQISSXE8AyFPC8uWlYkzPL+w85O0XaVPM=";
+        };
+      };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          recordly = pkgs.callPackage ./nix/package.nix {
+            inherit version releaseHashes;
+          };
+          default = self.packages.${system}.recordly;
+        }
+      );
+
+      apps = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          recordly = self.packages.${system}.recordly;
+        in
+        {
+          recordly = {
+            type = "app";
+            program =
+              if pkgs.stdenvNoCC.hostPlatform.isDarwin then
+                "${pkgs.writeShellScript "recordly" ''
+                  exec /usr/bin/open ${recordly}/Applications/Recordly.app --args "$@"
+                ''}"
+              else
+                "${recordly}/bin/recordly";
+            meta.description = "Launch Recordly";
+          };
+          default = self.apps.${system}.recordly;
+        }
+      );
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  appimageTools,
+  version,
+  releaseHashes,
+}:
+let
+  source =
+    releaseHashes.${stdenvNoCC.hostPlatform.system}
+      or (throw "Recordly is packaged for aarch64-darwin, x86_64-darwin, and x86_64-linux");
+
+  src = fetchurl {
+    url = "https://github.com/webadderallorg/Recordly/releases/download/v${version}/Recordly-${source.arch}.${source.extension}";
+    hash = source.hash;
+  };
+
+  meta = {
+    description = "Open-source screen recorder and editor for polished product demos";
+    homepage = "https://www.recordly.dev";
+    changelog = "https://github.com/webadderallorg/Recordly/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+in
+if stdenvNoCC.hostPlatform.isDarwin then
+  stdenvNoCC.mkDerivation {
+    pname = "recordly";
+    inherit version src meta;
+
+    nativeBuildInputs = [
+      unzip
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    unpackPhase = ''
+      runHook preUnpack
+      unzip -q "$src"
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/Applications"
+      cp -R Recordly.app "$out/Applications/"
+      runHook postInstall
+    '';
+  }
+else
+  appimageTools.wrapType2 {
+    pname = "recordly";
+    inherit version src meta;
+  }


### PR DESCRIPTION
## Description
Adds Nix flake support for installing Recordly from pinned release artifacts.

## Motivation
This lets Nix users install or run Recordly directly from the upstream repository with:
- `nix profile install github:webadderallorg/Recordly#recordly`
- `nix run github:webadderallorg/Recordly#recordly`

It also documents nix-darwin usage for declarative macOS installs.

## Type of Change
- [x] New Feature
- [x] Documentation Update

## Testing Guide
- `nix flake check --all-systems`
- `nix build .#recordly --no-link`
- `codesign --verify --deep --strict result/Applications/Recordly.app`

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Nix package support for installing and running Recordly.

* **Documentation**
  * Updated README with Nix (flakes) installation instructions, including profile install, direct run, and `nix-darwin` configuration examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->