### PR TITLE
Update Homebrew cask to 1.2.1

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -10,7 +10,7 @@ on:
       tap_repo:
         description: "Tap repository in owner/repo format"
         required: false
-        default: "webadderall/homebrew-tap"
+        default: "webadderallorg/homebrew-tap"
         type: string
 
 permissions:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-      TAP_REPO: ${{ github.event.inputs.tap_repo || vars.HOMEBREW_TAP_REPO || 'webadderall/homebrew-tap' }}
+      TAP_REPO: ${{ github.event.inputs.tap_repo || vars.HOMEBREW_TAP_REPO || 'webadderallorg/homebrew-tap' }}
       AUTO_MERGE_TAP_PR: ${{ vars.HOMEBREW_TAP_AUTO_MERGE || 'true' }}
     steps:
       - name: Validate token

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,6 +68,8 @@ Optional repository variables:
 - `HOMEBREW_TAP_REPO`
 - `HOMEBREW_TAP_AUTO_MERGE`
 
+If `HOMEBREW_TAP_REPO` is not set, the workflow defaults to `webadderallorg/homebrew-tap`.
+
 ## Release flow
 
 1. Bump `package.json` to the version you want to ship.

--- a/recordly.rb
+++ b/recordly.rb
@@ -1,9 +1,9 @@
 cask "recordly" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.2.1"
-  sha256 arm:   "f9d1c5874ec009725a93338edce3fe511537ec0348113914b92577c01214d07b",
-         intel: "aa89cf4fc6338dcb22eb6b1d2fc920a1cf6e5066742687463a426f1ac31bde84"
+  version "1.3.3"
+  sha256 arm:   "7fa8f4116e870d40fd78bb36d2ad20af364c945023b7b5ec3e72b568b6bbdee5",
+         intel: "35e49a0bf7afbca771b12fc99a834a287cbcb2e47bc9be07c4e56cbdd2923f85"
 
   url "https://github.com/webadderallorg/Recordly/releases/download/v#{version}/Recordly-#{arch}.dmg"
   name "Recordly"

--- a/recordly.rb
+++ b/recordly.rb
@@ -1,9 +1,9 @@
 cask "recordly" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.1.14"
-  sha256 arm:   "e669ab7c8bdd4596211937183ee2374545da5482702cab0dfe477c1466422b0f",
-         intel: "85f5183219de0b656400625797ff9299893bd8fbda8455b0f745878b2c729526"
+  version "1.2.1"
+  sha256 arm:   "f9d1c5874ec009725a93338edce3fe511537ec0348113914b92577c01214d07b",
+         intel: "aa89cf4fc6338dcb22eb6b1d2fc920a1cf6e5066742687463a426f1ac31bde84"
 
   url "https://github.com/webadderallorg/Recordly/releases/download/v#{version}/Recordly-#{arch}.dmg"
   name "Recordly"


### PR DESCRIPTION
## Description
Updates the bundled Homebrew cask to the current stable Recordly release and aligns the Homebrew tap workflow default with the `webadderallorg` GitHub organization.

## Motivation
The checked-in `recordly.rb` was still pinned to `1.1.14`, while the latest stable release is `v1.2.1`. Updating the cask keeps the release artifact URLs and SHA-256 checksums current.

This also changes the default tap repo from `webadderall/homebrew-tap` to `webadderallorg/homebrew-tap`, matching this repository's organization. I could not resolve either tap repo publicly while testing, so an owner/admin may still need to create or expose the official tap repository and set `HOMEBREW_TAP_TOKEN` before the workflow can publish there.

## Type of Change
- [x] Bug Fix
- [x] Documentation Update

## Testing Guide
- `ruby -c recordly.rb`
- `curl -fsSIL https://github.com/webadderallorg/Recordly/releases/download/v1.2.1/Recordly-arm64.dmg`
- `curl -fsSIL https://github.com/webadderallorg/Recordly/releases/download/v1.2.1/Recordly-x64.dmg`
- Verified cask checksums against `SHA256SUMS.txt` from the `v1.2.1` release
- `git diff --check`

Note: I attempted `brew audit --cask --strict --online ./recordly.rb`, but this machine's Homebrew is managed by Nix and the audit command failed while trying to write a vendor marker inside the read-only Nix store.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Homebrew tap default repository owner/name in the GitHub Actions workflow and aligned the `TAP_REPO` environment variable accordingly
  * Updated Homebrew tap automation documentation in `RELEASING.md` to reflect the new default behavior when `HOMEBREW_TAP_REPO` is unset
  * Bumped the `recordly` Homebrew cask version to **1.3.3** and refreshed `sha256` checksums for **ARM64** and **Intel** binaries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->