### PR TITLE
fix(hud): restore click-through at original bar position after drag

### DIFF
--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -442,12 +442,13 @@ function LaunchWindowContent() {
 					className="flex items-center overflow-visible flex-col-reverse pointer-events-none"
 				>
 					<div
-						className="flex flex-col items-center pointer-events-auto p-2"
-						onMouseEnter={handleHudMouseEnter}
-						onMouseLeave={handleHudMouseLeave}
+						className="flex flex-col items-center pointer-events-none p-2"
 					>
 						<div
 							ref={hudBarTransformRef}
+							className="pointer-events-auto"
+							onMouseEnter={handleHudMouseEnter}
+							onMouseLeave={handleHudMouseLeave}
 							style={{
 								transform: `translate3d(${recordingHudOffset.x}px, ${recordingHudOffset.y}px, 0)`,
 							}}


### PR DESCRIPTION
Fixes #535

## Problem
The HUD overlay wrapper kept `pointer-events: auto` at its layout-original position. When the floating bar is dragged, only the inner `hudBarTransformRef` div shifts visually via CSS `translate3d` — the outer wrapper stays put. Any `mouseenter` on that stale area still triggers `handleHudMouseEnter` → `setIgnoreMouseEvents(false)` on the full-screen HUD window, which then swallows clicks intended for the underlying app (Excel, browser, etc.).

## Fix
Move `pointer-events: auto` and the mouse enter/leave handlers from the static wrapper onto the transformed `hudBarTransformRef` div, so the interactive hit area follows the bar's actual rendered position.

## Test plan
- [x] Open Excel (or any app), start recording
- [x] Drag the floating bar to a new location
- [x] Click on a cell at the bar's **original** position → click reaches Excel correctly
- [x] Click on a button on the bar at its **new** position → bar still interactive
- [x] Webcam preview continues to receive its own pointer events (separate sibling with own handlers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD bar hover behavior by refining which element receives pointer events and hover handlers. This makes hover targets more precise, reduces accidental triggers, and yields smoother, more responsive mouse interactions over the HUD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->