### PR TITLE
refactor(editor): extract history state model

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -127,6 +127,14 @@ import {
 	saveEditorPresets,
 	serializeEditorPresetSnapshot,
 } from "./editorPreferences";
+import {
+	createEditorHistoryStack,
+	type EditorHistorySnapshot,
+	recordEditorHistorySnapshot,
+	redoEditorHistoryStack,
+	resetEditorHistoryStack,
+	undoEditorHistoryStack,
+} from "./editorHistory";
 import ProjectBrowserDialog, { type ProjectLibraryEntry } from "./ProjectBrowserDialog";
 import {
 	createProjectData,
@@ -205,19 +213,6 @@ import {
 	buildLoopedCursorTelemetry,
 	getDisplayedTimelineWindowMs,
 } from "./videoPlayback/cursorLoopTelemetry";
-
-type EditorHistorySnapshot = {
-	zoomRegions: ZoomRegion[];
-	clipRegions: ClipRegion[];
-	speedRegions: SpeedRegion[];
-	annotationRegions: AnnotationRegion[];
-	audioRegions: AudioRegion[];
-	autoCaptions: CaptionCue[];
-	selectedZoomId: string | null;
-	selectedClipId: string | null;
-	selectedAnnotationId: string | null;
-	selectedAudioId: string | null;
-};
 
 type PendingExportSave = {
 	fileName: string;
@@ -769,9 +764,7 @@ export default function VideoEditor() {
 	const exporterRef = useRef<CancelableExporter | null>(null);
 	const autoSuggestedVideoPathRef = useRef<string | null>(null);
 	const pendingFreshRecordingAutoZoomPathRef = useRef<string | null>(null);
-	const historyPastRef = useRef<EditorHistorySnapshot[]>([]);
-	const historyFutureRef = useRef<EditorHistorySnapshot[]>([]);
-	const historyCurrentRef = useRef<EditorHistorySnapshot | null>(null);
+	const editorHistoryRef = useRef(createEditorHistoryStack());
 	const applyingHistoryRef = useRef(false);
 	const pendingExportSaveRef = useRef<PendingExportSave | null>(null);
 	const pendingTelemetryRetryTimeoutRef = useRef<number | null>(null);
@@ -1513,14 +1506,10 @@ export default function VideoEditor() {
 		void refreshProjectLibrary();
 	}, [refreshProjectLibrary]);
 
-	const canUndo = historyPastRef.current.length > 0;
-	const canRedo = historyFutureRef.current.length > 0;
+	const canUndo = editorHistoryRef.current.past.length > 0;
+	const canRedo = editorHistoryRef.current.future.length > 0;
 
 	void historyVersion;
-
-	const cloneSnapshot = useCallback((snapshot: EditorHistorySnapshot): EditorHistorySnapshot => {
-		return cloneStructured(snapshot);
-	}, []);
 
 	const gifOutputDimensions = useMemo(
 		() =>
@@ -1970,7 +1959,7 @@ export default function VideoEditor() {
 	const applyHistorySnapshot = useCallback(
 		(snapshot: EditorHistorySnapshot) => {
 			applyingHistoryRef.current = true;
-			const cloned = cloneSnapshot(snapshot);
+			const cloned = cloneStructured(snapshot);
 			setZoomRegions(cloned.zoomRegions);
 			setClipRegions(cloned.clipRegions);
 			setSpeedRegions(cloned.speedRegions);
@@ -2002,34 +1991,24 @@ export default function VideoEditor() {
 				cloned.annotationRegions.reduce((max, region) => Math.max(max, region.zIndex), 0) +
 				1;
 		},
-		[cloneSnapshot],
+		[],
 	);
 
 	const handleUndo = useCallback(() => {
-		if (historyPastRef.current.length === 0) return;
-
-		const current = historyCurrentRef.current ?? cloneSnapshot(buildHistorySnapshot());
-		const previous = historyPastRef.current.pop();
+		const previous = undoEditorHistoryStack(editorHistoryRef.current, buildHistorySnapshot());
 		if (!previous) return;
 
-		historyFutureRef.current.push(cloneSnapshot(current));
-		historyCurrentRef.current = cloneSnapshot(previous);
 		applyHistorySnapshot(previous);
 		syncHistoryButtons();
-	}, [applyHistorySnapshot, buildHistorySnapshot, cloneSnapshot, syncHistoryButtons]);
+	}, [applyHistorySnapshot, buildHistorySnapshot, syncHistoryButtons]);
 
 	const handleRedo = useCallback(() => {
-		if (historyFutureRef.current.length === 0) return;
-
-		const current = historyCurrentRef.current ?? cloneSnapshot(buildHistorySnapshot());
-		const next = historyFutureRef.current.pop();
+		const next = redoEditorHistoryStack(editorHistoryRef.current, buildHistorySnapshot());
 		if (!next) return;
 
-		historyPastRef.current.push(cloneSnapshot(current));
-		historyCurrentRef.current = cloneSnapshot(next);
 		applyHistorySnapshot(next);
 		syncHistoryButtons();
-	}, [applyHistorySnapshot, buildHistorySnapshot, cloneSnapshot, syncHistoryButtons]);
+	}, [applyHistorySnapshot, buildHistorySnapshot, syncHistoryButtons]);
 
 	const applyLoadedProject = useCallback(
 		async (candidate: unknown, path?: string | null) => {
@@ -2169,9 +2148,7 @@ export default function VideoEditor() {
 					0,
 				) + 1;
 
-			historyPastRef.current = [];
-			historyFutureRef.current = [];
-			historyCurrentRef.current = null;
+			resetEditorHistoryStack(editorHistoryRef.current);
 			applyingHistoryRef.current = false;
 			syncHistoryButtons();
 
@@ -2285,32 +2262,18 @@ export default function VideoEditor() {
 
 	useEffect(() => {
 		const snapshot = buildHistorySnapshot();
+		const result = recordEditorHistorySnapshot(editorHistoryRef.current, snapshot, {
+			applyingHistory: applyingHistoryRef.current,
+		});
 
-		if (!historyCurrentRef.current) {
-			historyCurrentRef.current = cloneSnapshot(snapshot);
-			syncHistoryButtons();
-			return;
-		}
-
-		if (applyingHistoryRef.current) {
-			historyCurrentRef.current = cloneSnapshot(snapshot);
+		if (result === "applied") {
 			applyingHistoryRef.current = false;
+		}
+
+		if (result !== "unchanged") {
 			syncHistoryButtons();
-			return;
 		}
-
-		if (areDeepEqual(historyCurrentRef.current, snapshot)) {
-			return;
-		}
-
-		historyPastRef.current.push(cloneSnapshot(historyCurrentRef.current));
-		if (historyPastRef.current.length > 100) {
-			historyPastRef.current.shift();
-		}
-		historyCurrentRef.current = cloneSnapshot(snapshot);
-		historyFutureRef.current = [];
-		syncHistoryButtons();
-	}, [buildHistorySnapshot, cloneSnapshot, syncHistoryButtons]);
+	}, [buildHistorySnapshot, syncHistoryButtons]);
 
 	const hasUnsavedChanges = useMemo(
 		() =>

--- a/src/components/video-editor/editorHistory.test.ts
+++ b/src/components/video-editor/editorHistory.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	areEditorHistorySnapshotsEqual,
+	cloneEditorHistorySnapshot,
+	createEditorHistoryStack,
+	type EditorHistorySnapshot,
+	recordEditorHistorySnapshot,
+	redoEditorHistoryStack,
+	resetEditorHistoryStack,
+	undoEditorHistoryStack,
+} from "./editorHistory";
+
+function createSnapshot(id: string | null): EditorHistorySnapshot {
+	return {
+		zoomRegions: [],
+		clipRegions: [],
+		speedRegions: [],
+		annotationRegions: [],
+		audioRegions: [],
+		autoCaptions: [],
+		selectedZoomId: id,
+		selectedClipId: id ? `clip-${id}` : null,
+		selectedAnnotationId: null,
+		selectedAudioId: null,
+	};
+}
+
+describe("editorHistory", () => {
+	it("initializes without adding undo history", () => {
+		const stack = createEditorHistoryStack();
+		const snapshot = createSnapshot("first");
+
+		expect(recordEditorHistorySnapshot(stack, snapshot)).toBe("initialized");
+
+		expect(stack.current).toEqual(snapshot);
+		expect(stack.past).toEqual([]);
+		expect(stack.future).toEqual([]);
+	});
+
+	it("does not record unchanged snapshots", () => {
+		const stack = createEditorHistoryStack();
+		const snapshot = createSnapshot("same");
+
+		recordEditorHistorySnapshot(stack, snapshot);
+		expect(recordEditorHistorySnapshot(stack, createSnapshot("same"))).toBe("unchanged");
+
+		expect(stack.past).toEqual([]);
+		expect(stack.future).toEqual([]);
+	});
+
+	it("records changes and clears redo history", () => {
+		const stack = createEditorHistoryStack();
+
+		recordEditorHistorySnapshot(stack, createSnapshot("first"));
+		recordEditorHistorySnapshot(stack, createSnapshot("second"));
+		stack.future.push(createSnapshot("future"));
+
+		expect(recordEditorHistorySnapshot(stack, createSnapshot("third"))).toBe("recorded");
+
+		expect(stack.past.map((snapshot) => snapshot.selectedZoomId)).toEqual(["first", "second"]);
+		expect(stack.current?.selectedZoomId).toBe("third");
+		expect(stack.future).toEqual([]);
+	});
+
+	it("moves snapshots through undo and redo stacks", () => {
+		const stack = createEditorHistoryStack();
+		const first = createSnapshot("first");
+		const second = createSnapshot("second");
+
+		recordEditorHistorySnapshot(stack, first);
+		recordEditorHistorySnapshot(stack, second);
+
+		expect(undoEditorHistoryStack(stack, second)?.selectedZoomId).toBe("first");
+		expect(stack.current?.selectedZoomId).toBe("first");
+		expect(stack.future.map((snapshot) => snapshot.selectedZoomId)).toEqual(["second"]);
+
+		expect(redoEditorHistoryStack(stack, first)?.selectedZoomId).toBe("second");
+		expect(stack.current?.selectedZoomId).toBe("second");
+		expect(stack.past.map((snapshot) => snapshot.selectedZoomId)).toEqual(["first"]);
+	});
+
+	it("updates the current snapshot while applying history without recording a new entry", () => {
+		const stack = createEditorHistoryStack();
+
+		recordEditorHistorySnapshot(stack, createSnapshot("first"));
+		expect(
+			recordEditorHistorySnapshot(stack, createSnapshot("applied"), {
+				applyingHistory: true,
+			}),
+		).toBe("applied");
+
+		expect(stack.current?.selectedZoomId).toBe("applied");
+		expect(stack.past).toEqual([]);
+	});
+
+	it("caps the past stack at the configured history depth", () => {
+		const stack = createEditorHistoryStack();
+
+		recordEditorHistorySnapshot(stack, createSnapshot("0"));
+		recordEditorHistorySnapshot(stack, createSnapshot("1"), { maxEntries: 2 });
+		recordEditorHistorySnapshot(stack, createSnapshot("2"), { maxEntries: 2 });
+		recordEditorHistorySnapshot(stack, createSnapshot("3"), { maxEntries: 2 });
+
+		expect(stack.past.map((snapshot) => snapshot.selectedZoomId)).toEqual(["1", "2"]);
+	});
+
+	it("resets all history stacks", () => {
+		const stack = createEditorHistoryStack();
+
+		recordEditorHistorySnapshot(stack, createSnapshot("first"));
+		recordEditorHistorySnapshot(stack, createSnapshot("second"));
+		undoEditorHistoryStack(stack, createSnapshot("second"));
+		resetEditorHistoryStack(stack);
+
+		expect(stack).toEqual(createEditorHistoryStack());
+	});
+
+	it("clones snapshots before storing them", () => {
+		const snapshot = createSnapshot("first");
+		const cloned = cloneEditorHistorySnapshot(snapshot);
+
+		cloned.selectedZoomId = "changed";
+
+		expect(snapshot.selectedZoomId).toBe("first");
+		expect(areEditorHistorySnapshotsEqual(snapshot, createSnapshot("first"))).toBe(true);
+	});
+});

--- a/src/components/video-editor/editorHistory.ts
+++ b/src/components/video-editor/editorHistory.ts
@@ -1,0 +1,161 @@
+import type {
+	AnnotationRegion,
+	AudioRegion,
+	CaptionCue,
+	ClipRegion,
+	SpeedRegion,
+	ZoomRegion,
+} from "./types";
+
+export type EditorHistorySnapshot = {
+	zoomRegions: ZoomRegion[];
+	clipRegions: ClipRegion[];
+	speedRegions: SpeedRegion[];
+	annotationRegions: AnnotationRegion[];
+	audioRegions: AudioRegion[];
+	autoCaptions: CaptionCue[];
+	selectedZoomId: string | null;
+	selectedClipId: string | null;
+	selectedAnnotationId: string | null;
+	selectedAudioId: string | null;
+};
+
+export type EditorHistoryStack = {
+	past: EditorHistorySnapshot[];
+	current: EditorHistorySnapshot | null;
+	future: EditorHistorySnapshot[];
+};
+
+export type EditorHistoryRecordResult = "initialized" | "applied" | "recorded" | "unchanged";
+
+export const MAX_EDITOR_HISTORY_ENTRIES = 100;
+
+export function createEditorHistoryStack(): EditorHistoryStack {
+	return {
+		past: [],
+		current: null,
+		future: [],
+	};
+}
+
+export function resetEditorHistoryStack(stack: EditorHistoryStack): void {
+	stack.past = [];
+	stack.current = null;
+	stack.future = [];
+}
+
+export function cloneEditorHistorySnapshot(
+	snapshot: EditorHistorySnapshot,
+): EditorHistorySnapshot {
+	return globalThis.structuredClone(snapshot);
+}
+
+function isComparableObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function areDeepEqual(left: unknown, right: unknown): boolean {
+	if (Object.is(left, right)) {
+		return true;
+	}
+
+	if (Array.isArray(left) || Array.isArray(right)) {
+		if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+			return false;
+		}
+
+		return left.every((value, index) => areDeepEqual(value, right[index]));
+	}
+
+	if (!isComparableObject(left) || !isComparableObject(right)) {
+		return false;
+	}
+
+	const leftKeys = Object.keys(left);
+	const rightKeys = Object.keys(right);
+	if (leftKeys.length !== rightKeys.length) {
+		return false;
+	}
+
+	return leftKeys.every((key) => key in right && areDeepEqual(left[key], right[key]));
+}
+
+export function areEditorHistorySnapshotsEqual(
+	left: EditorHistorySnapshot,
+	right: EditorHistorySnapshot,
+): boolean {
+	return areDeepEqual(left, right);
+}
+
+export function recordEditorHistorySnapshot(
+	stack: EditorHistoryStack,
+	snapshot: EditorHistorySnapshot,
+	options: {
+		applyingHistory?: boolean;
+		maxEntries?: number;
+	} = {},
+): EditorHistoryRecordResult {
+	const clonedSnapshot = cloneEditorHistorySnapshot(snapshot);
+
+	if (!stack.current) {
+		stack.current = clonedSnapshot;
+		return "initialized";
+	}
+
+	if (options.applyingHistory) {
+		stack.current = clonedSnapshot;
+		return "applied";
+	}
+
+	if (areEditorHistorySnapshotsEqual(stack.current, snapshot)) {
+		return "unchanged";
+	}
+
+	stack.past.push(cloneEditorHistorySnapshot(stack.current));
+	const maxEntries = options.maxEntries ?? MAX_EDITOR_HISTORY_ENTRIES;
+	if (stack.past.length > maxEntries) {
+		stack.past.shift();
+	}
+
+	stack.current = clonedSnapshot;
+	stack.future = [];
+	return "recorded";
+}
+
+export function undoEditorHistoryStack(
+	stack: EditorHistoryStack,
+	fallbackCurrent: EditorHistorySnapshot,
+): EditorHistorySnapshot | null {
+	if (stack.past.length === 0) {
+		return null;
+	}
+
+	const current = stack.current ?? cloneEditorHistorySnapshot(fallbackCurrent);
+	const previous = stack.past.pop();
+	if (!previous) {
+		return null;
+	}
+
+	stack.future.push(cloneEditorHistorySnapshot(current));
+	stack.current = cloneEditorHistorySnapshot(previous);
+	return cloneEditorHistorySnapshot(previous);
+}
+
+export function redoEditorHistoryStack(
+	stack: EditorHistoryStack,
+	fallbackCurrent: EditorHistorySnapshot,
+): EditorHistorySnapshot | null {
+	if (stack.future.length === 0) {
+		return null;
+	}
+
+	const current = stack.current ?? cloneEditorHistorySnapshot(fallbackCurrent);
+	const next = stack.future.pop();
+	if (!next) {
+		return null;
+	}
+
+	stack.past.push(cloneEditorHistorySnapshot(current));
+	stack.current = cloneEditorHistorySnapshot(next);
+	return cloneEditorHistorySnapshot(next);
+}


### PR DESCRIPTION
## Description

Extracts the editor undo/redo history stack out of `VideoEditor.tsx` into a pure state-transition module with focused unit coverage.

## Motivation

This is the next small editor architecture slice. Before introducing any external state library, this PR separates the editor history model from React rendering/orchestration so the state boundary is explicit, tested, and reviewable.

## Type of Change

- Refactor
- Tests

## Related Issue(s)

None.

## Changes Made

- Added `src/components/video-editor/editorHistory.ts` with the editor history snapshot type, stack creation/reset, record, undo, and redo transitions.
- Added `src/components/video-editor/editorHistory.test.ts` covering initialization, unchanged snapshots, record/redo clearing, undo/redo movement, applying-history updates, max-depth trimming, reset, and cloning behavior.
- Updated `VideoEditor.tsx` to delegate history stack mutations to the extracted model while keeping UI state application local to the component.

## Scope Note

No UI behavior, timeline behavior, export behavior, keyboard shortcut mapping, persistence format, or native/runtime path is intentionally changed. This PR does not introduce Zustand, Redux, or another state dependency; it first carves out a tested pure state boundary.

## Testing Guide

Review the new history model and verify that `VideoEditor.tsx` still owns applying snapshots to React state, while `editorHistory.ts` owns only stack transitions.

## Checklist

- [x] One focused architecture slice
- [x] Behavior-preserving refactor
- [x] Unit coverage added for moved state logic
- [x] Typecheck passed
- [x] Scoped Biome completed
- [x] Branch diff excludes unrelated generated/local files

## Local Checks

- `npm test -- src/components/video-editor/editorHistory.test.ts` (8 tests passed)
- `npm test -- src/components/video-editor/editorHistory.test.ts src/components/video-editor/types.test.ts` (25 tests passed)
- `npx tsc --noEmit --pretty false` (passed)
- `npx biome check --formatter-enabled=false --assist-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/editorHistory.ts src/components/video-editor/editorHistory.test.ts` (exit 0; existing unrelated `VideoEditor.tsx` exhaustive-deps warning remains)
- `git diff --check main...HEAD` (passed)

## Runtime/Repro Evidence

Not run. This PR moves pure editor history stack transitions into a tested module; no Electron, preview rendering, export, or native runtime path changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for editor history and undo/redo functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->