### PR TITLE
refactor(editor): extract project dirty state

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -147,6 +147,7 @@ import {
 	toFileUrl,
 	validateProjectData,
 } from "./projectPersistence";
+import { hasUnsavedProjectChanges } from "./projectDirtyState";
 import { SettingsPanel } from "./SettingsPanel";
 import { useVideoEditorAudio } from "./audio/useVideoEditorAudio";
 import {
@@ -461,48 +462,6 @@ function getDevOpenRecordingConfig(search: string): DevOpenRecordingConfig {
 		inputPath: params.get("devOpenInput"),
 		webcamInputPath: params.get("devOpenWebcam"),
 	};
-}
-
-function isComparableObject(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-function areDeepEqual(left: unknown, right: unknown): boolean {
-	if (Object.is(left, right)) {
-		return true;
-	}
-
-	if (Array.isArray(left) || Array.isArray(right)) {
-		if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
-			return false;
-		}
-
-		for (let index = 0; index < left.length; index += 1) {
-			if (!areDeepEqual(left[index], right[index])) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	if (!isComparableObject(left) || !isComparableObject(right)) {
-		return false;
-	}
-
-	const leftKeys = Object.keys(left);
-	const rightKeys = Object.keys(right);
-	if (leftKeys.length !== rightKeys.length) {
-		return false;
-	}
-
-	for (const key of leftKeys) {
-		if (!(key in right) || !areDeepEqual(left[key], right[key])) {
-			return false;
-		}
-	}
-
-	return true;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -2276,12 +2235,7 @@ export default function VideoEditor() {
 	}, [buildHistorySnapshot, syncHistoryButtons]);
 
 	const hasUnsavedChanges = useMemo(
-		() =>
-			Boolean(
-				currentProjectSnapshot &&
-					(!lastSavedSnapshot ||
-						!areDeepEqual(currentProjectSnapshot, lastSavedSnapshot)),
-			),
+		() => hasUnsavedProjectChanges(currentProjectSnapshot, lastSavedSnapshot),
 		[currentProjectSnapshot, lastSavedSnapshot],
 	);
 

--- a/src/components/video-editor/projectDirtyState.test.ts
+++ b/src/components/video-editor/projectDirtyState.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { hasUnsavedProjectChanges } from "./projectDirtyState";
+import type { EditorProjectData } from "./projectPersistence";
+
+function createProjectData(overrides: Partial<EditorProjectData> = {}): EditorProjectData {
+	return {
+		version: 1,
+		projectId: "project-1",
+		videoPath: "file:///recording.mp4",
+		editor: {
+			wallpaper: "#ffffff",
+			zoomRegions: [],
+			trimRegions: [],
+			clipRegions: [],
+			speedRegions: [],
+			annotationRegions: [],
+			audioRegions: [],
+			autoCaptions: [],
+		},
+		...overrides,
+	};
+}
+
+describe("hasUnsavedProjectChanges", () => {
+	it("does not report changes before a project snapshot exists", () => {
+		expect(hasUnsavedProjectChanges(null, createProjectData())).toBe(false);
+	});
+
+	it("reports changes when there is no saved baseline", () => {
+		expect(hasUnsavedProjectChanges(createProjectData(), null)).toBe(true);
+	});
+
+	it("treats deeply equal snapshots as unchanged", () => {
+		expect(hasUnsavedProjectChanges(createProjectData(), createProjectData())).toBe(false);
+	});
+
+	it("detects nested editor changes", () => {
+		const current = createProjectData({
+			editor: {
+				...createProjectData().editor,
+				zoomRegions: [
+					{
+						id: "zoom-1",
+						startMs: 100,
+						endMs: 500,
+						focus: { cx: 0.4, cy: 0.6 },
+						depth: 2,
+					},
+				],
+			},
+		});
+
+		expect(hasUnsavedProjectChanges(current, createProjectData())).toBe(true);
+	});
+
+	it("detects array length changes", () => {
+		const current = createProjectData({
+			editor: {
+				...createProjectData().editor,
+				autoCaptions: [{ id: "caption-1", startMs: 0, endMs: 1_000, text: "hello" }],
+			},
+		});
+
+		expect(hasUnsavedProjectChanges(current, createProjectData())).toBe(true);
+	});
+});

--- a/src/components/video-editor/projectDirtyState.ts
+++ b/src/components/video-editor/projectDirtyState.ts
@@ -1,0 +1,53 @@
+import type { EditorProjectData } from "./projectPersistence";
+
+function isComparableObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function areDeepEqual(left: unknown, right: unknown): boolean {
+	if (Object.is(left, right)) {
+		return true;
+	}
+
+	if (Array.isArray(left) || Array.isArray(right)) {
+		if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+			return false;
+		}
+
+		for (let index = 0; index < left.length; index += 1) {
+			if (!areDeepEqual(left[index], right[index])) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	if (!isComparableObject(left) || !isComparableObject(right)) {
+		return false;
+	}
+
+	const leftKeys = Object.keys(left);
+	const rightKeys = Object.keys(right);
+	if (leftKeys.length !== rightKeys.length) {
+		return false;
+	}
+
+	for (const key of leftKeys) {
+		if (!(key in right) || !areDeepEqual(left[key], right[key])) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+export function hasUnsavedProjectChanges(
+	currentProjectSnapshot: EditorProjectData | null,
+	lastSavedSnapshot: EditorProjectData | null,
+): boolean {
+	return Boolean(
+		currentProjectSnapshot &&
+			(!lastSavedSnapshot || !areDeepEqual(currentProjectSnapshot, lastSavedSnapshot)),
+	);
+}


### PR DESCRIPTION
## Description

Extracts the unsaved-project dirty-state comparison out of `VideoEditor.tsx` into a small pure module with focused coverage.

## Motivation

This continues the editor architecture refactor by moving another self-contained state decision out of the god component. The slice is intentionally stacked on `#544` because it builds on the editor history model branch and should be reviewed after that PR.

## Type of Change

- Refactor
- Tests

## Related Issue(s)

Stacked after #544.

## Changes Made

- Added `src/components/video-editor/projectDirtyState.ts` with `hasUnsavedProjectChanges`.
- Added unit coverage for missing snapshots, no saved baseline, deeply equal snapshots, nested editor changes, and array length changes.
- Updated `VideoEditor.tsx` to delegate `hasUnsavedChanges` to the extracted dirty-state model.

## Scope Note

No UI behavior, persistence format, project save/load behavior, export behavior, native helper behavior, or runtime path is intentionally changed. This PR is a stacked draft PR based on `refactor/editor-history-model-slice`; it should not be merged before #544.

## Testing Guide

Review only the diff against #544: `projectDirtyState.ts`, its test, and the small `VideoEditor.tsx` call-site replacement.

## Checklist

- [x] One focused architecture slice
- [x] Behavior-preserving refactor
- [x] Unit coverage added for moved dirty-state logic
- [x] Typecheck passed
- [x] Scoped Biome completed
- [x] Branch diff excludes unrelated generated/local files

## Local Checks

- `npm test -- src/components/video-editor/projectDirtyState.test.ts` (5 tests passed)
- `npm test -- src/components/video-editor/projectDirtyState.test.ts src/components/video-editor/editorHistory.test.ts src/components/video-editor/types.test.ts` (30 tests passed)
- `npx tsc --noEmit --pretty false` (passed)
- `npx biome check --formatter-enabled=false --assist-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/projectDirtyState.ts src/components/video-editor/projectDirtyState.test.ts` (exit 0; existing unrelated `VideoEditor.tsx` exhaustive-deps warning remains)
- `git diff --check refactor/editor-history-model-slice...HEAD` (passed)

## Runtime/Repro Evidence

Not run. This PR moves pure project dirty-state comparison into a tested module; no Electron, preview rendering, export, or native runtime path changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated unsaved-project change detection into a shared utility, replacing redundant inline deep-equality checks to centralize and simplify change detection logic.

* **Tests**
  * Added comprehensive test coverage for the new detection logic, including cases for missing snapshots, deep-equality of complex structures, and detection of nested/editor-state changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->