### PR TITLE
fix(editor): redact session paths in debug log

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -2291,10 +2291,11 @@ export default function VideoEditor() {
 
 		return window.electronAPI.onRecordingSessionChanged((session) => {
 			console.log("[VideoEditor] onRecordingSessionChanged received!", {
-				sessionVideoPath: session?.videoPath,
-				videoSourcePath: videoSourcePath,
+				hasSession: Boolean(session),
+				hasSessionVideoPath: Boolean(session?.videoPath),
+				hasVideoSourcePath: Boolean(videoSourcePath),
 				match: session?.videoPath === videoSourcePath,
-				webcamPath: session?.webcamPath,
+				hasWebcamPath: Boolean(session?.webcamPath),
 			});
 
 			if (!session || session.videoPath !== videoSourcePath) {


### PR DESCRIPTION
## Summary
- Redact recording session file paths from the `onRecordingSessionChanged` debug log.
- Keep the useful debug signal as booleans and the existing path match result.

## Why
CodeRabbit flagged that logging raw recording/webcam paths can expose user-identifying local filesystem details in app logs.

## Verification
- `npx tsc --noEmit --pretty false`
- `git diff --check`
- `npx biome lint src/components/video-editor/VideoEditor.tsx` (passes with the existing `clipRegions` exhaustive-deps warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic logging in video recording sessions to use presence indicators instead of raw path information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->