### PR TITLE
fix(editor): include clip regions in export callback deps

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -4503,6 +4503,7 @@ export default function VideoEditor() {
 			cursorClickBounceDuration,
 			cursorSway,
 			audioRegions,
+			clipRegions,
 			audio.sourceAudioFallbackPaths,
 			audio.sourceAudioFallbackStartDelayMsByPath,
 			audio.activeSourceAudioTrackSettings,


### PR DESCRIPTION
## Description
Adds `clipRegions` to the `handleExport` `useCallback` dependency list in `VideoEditor.tsx`.

## Motivation
`handleExport` passes `clipRegions` into the MP4 exporter config. Without `clipRegions` in the dependency list, React can keep an older callback closure after clip edits, which risks exporting with stale clip timeline regions.

## Type of Change
- [x] Bug fix
- [ ] Refactor
- [ ] Feature
- [ ] Documentation

## Related Issues
None.

## Scope
This is a one-line dependency fix only. No export pipeline behavior, rendering logic, or state model changes.

## Testing Guide
1. Edit clip regions in the editor.
2. Open export settings and export MP4.
3. Confirm the export callback sees the latest clip regions instead of a stale closure.

## Verification
- `npx biome lint src/components/video-editor/VideoEditor.tsx`
- `npx tsc --noEmit --pretty false`
- `git diff --check`