### PR TITLE
fix(recording): avoid duplicate system audio fallback

### DIFF
--- a/electron/ipc/recording/diagnostics.ts
+++ b/electron/ipc/recording/diagnostics.ts
@@ -512,8 +512,7 @@ export async function getCompanionAudioFallbackInfo(videoPath: string) {
 			new Set(
 				companionCandidates.flatMap((candidate) =>
 					candidate.usablePaths.filter(
-						(companionPath) =>
-							companionPath === candidate.micPath || companionPath === candidate.systemPath,
+						(companionPath) => companionPath === candidate.micPath,
 					),
 				),
 			),


### PR DESCRIPTION
﻿## Summary

- When a recording MP4 already has an embedded audio stream, only include microphone companion audio in the fallback path list.
- Avoid adding `recording.system.wav` next to the embedded video audio, which duplicates source/system audio candidates.

## Why

`getCompanionAudioFallbackInfo()` was still returning both `recording.system.wav` and `recording.mic.wav` when the video itself already contained an audio stream. That contradicted the existing test expectation and can make downstream audio fallback/mux planning consider duplicate system audio.

This is a small extraction from the broader #504 work, separated so we do not merge the stale NVIDIA/export route planner PR as one large change.

## Validation

- `npm test -- electron/ipc/recording/diagnostics.test.ts` (11 passed)
- `npx tsc --noEmit`
- `npx biome check --formatter-enabled=false electron/ipc/recording/diagnostics.ts electron/ipc/recording/diagnostics.test.ts`
- `git diff --check`

Note: `npx biome check` with formatter enabled wants to rewrite existing CRLF line endings across these files, so I used formatter-disabled scoped Biome to avoid unrelated formatting churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved companion audio fallback path selection when embedded audio streams are detected, ensuring the correct fallback option is used during recording.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->