### PR TITLE
fix(export): keep mic sidecar in native audio mix

### DIFF
--- a/src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts
+++ b/src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts
@@ -149,6 +149,21 @@ describe("ModernVideoExporter native static-layout eligibility", () => {
 		});
 	});
 
+	it("mixes companion sidecar audio when the source MP4 also has an audio track", () => {
+		const videoPath = "C:\\recordly\\recording.mp4";
+		const micPath = "C:\\recordly\\recording.mic.wav";
+		const exporter = createExporter({
+			videoUrl: `file:///${videoPath.replace(/\\/g, "/")}`,
+			sourceAudioFallbackPaths: [micPath],
+		});
+
+		expect(exporter.buildNativeAudioPlan(videoInfo)).toMatchObject({
+			audioMode: "edited-track",
+			strategy: "offline-render-fallback",
+			sourceAudioFallbackPaths: [expect.stringMatching(/recording\.mp4$/), micPath],
+		});
+	});
+
 	it("keeps timed companion audio on the offline render path", () => {
 		const audioPath = "C:\\recordly\\recording.system.wav";
 		const speedRegions: SpeedRegion[] = [
@@ -167,9 +182,10 @@ describe("ModernVideoExporter native static-layout eligibility", () => {
 				audioCodec: undefined,
 				audioSampleRate: undefined,
 			}),
-		).toEqual({
+		).toMatchObject({
 			audioMode: "edited-track",
 			strategy: "offline-render-fallback",
+			sourceAudioFallbackPaths: [audioPath],
 		});
 	});
 

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -78,6 +78,7 @@ import {
 import { VideoMuxer } from "./muxer";
 import { roundNativeStaticLayoutContentSize } from "./nativeStaticLayoutGeometry";
 import { buildNativeStaticLayoutCursorTelemetry } from "./nativeStaticLayoutTelemetry";
+import { resolveSourceAudioFallbackPaths } from "./sourceAudioFallback";
 import { type DecodedVideoInfo, StreamingVideoDecoder } from "./streamingDecoder";
 import type {
 	ExportConfig,
@@ -164,6 +165,7 @@ type NativeAudioPlan =
 	| {
 			audioMode: "edited-track";
 			strategy: "offline-render-fallback";
+			sourceAudioFallbackPaths?: string[];
 	  }
 	| {
 			audioMode: "edited-track";
@@ -1224,6 +1226,26 @@ export class ModernVideoExporter {
 		return buildNativeStaticLayoutTimelineSegments(sourceSegments);
 	}
 
+	private getNativeAudioFallbackPaths(videoInfo: DecodedVideoInfo): string[] {
+		const sourceAudioFallbackPaths = (this.config.sourceAudioFallbackPaths ?? []).filter(
+			(audioPath) => typeof audioPath === "string" && audioPath.trim().length > 0,
+		);
+		const localVideoSourcePath = this.getNativeVideoSourcePath();
+		if (!videoInfo.hasAudio || !localVideoSourcePath) {
+			return sourceAudioFallbackPaths;
+		}
+
+		const { externalAudioPaths } = resolveSourceAudioFallbackPaths(
+			localVideoSourcePath,
+			sourceAudioFallbackPaths,
+		);
+		if (externalAudioPaths.length === 0) {
+			return sourceAudioFallbackPaths;
+		}
+
+		return [localVideoSourcePath, ...externalAudioPaths];
+	}
+
 	private shouldUseNativeStaticLayoutTimelineMap(
 		videoInfo: DecodedVideoInfo,
 		effectiveDurationSec: number,
@@ -1243,9 +1265,7 @@ export class ModernVideoExporter {
 	private buildNativeAudioPlan(videoInfo: DecodedVideoInfo): NativeAudioPlan {
 		const speedRegions = this.config.speedRegions ?? [];
 		const audioRegions = this.config.audioRegions ?? [];
-		const sourceAudioFallbackPaths = (this.config.sourceAudioFallbackPaths ?? []).filter(
-			(audioPath) => typeof audioPath === "string" && audioPath.trim().length > 0,
-		);
+		const sourceAudioFallbackPaths = this.getNativeAudioFallbackPaths(videoInfo);
 		const hasTimedSourceAudioFallback = sourceAudioFallbackPaths.some(
 			(audioPath) =>
 				(this.config.sourceAudioFallbackStartDelayMsByPath?.[audioPath] ?? 0) > 0,
@@ -1338,6 +1358,7 @@ export class ModernVideoExporter {
 			return {
 				audioMode: "edited-track",
 				strategy: "offline-render-fallback",
+				sourceAudioFallbackPaths,
 			};
 		}
 
@@ -1345,6 +1366,7 @@ export class ModernVideoExporter {
 			return {
 				audioMode: "edited-track",
 				strategy: "offline-render-fallback",
+				sourceAudioFallbackPaths,
 			};
 		}
 
@@ -1892,6 +1914,7 @@ export class ModernVideoExporter {
 	private async renderEditedAudioForNativeMux(
 		description: string,
 		onProgress: (progress: number) => void,
+		sourceAudioFallbackPaths = this.config.sourceAudioFallbackPaths,
 	) {
 		this.audioProcessor = new AudioProcessor();
 		this.audioProcessor.setOnProgress(onProgress);
@@ -1902,7 +1925,7 @@ export class ModernVideoExporter {
 					this.config.trimRegions,
 					this.config.speedRegions,
 					this.config.audioRegions,
-					this.config.sourceAudioFallbackPaths,
+					sourceAudioFallbackPaths,
 					this.config.sourceAudioFallbackStartDelayMsByPath,
 					this.config.sourceAudioTrackSettings,
 					this.config.clipRegions,
@@ -1950,6 +1973,7 @@ export class ModernVideoExporter {
 					"Native static-layout edited audio rendering",
 					(progress) =>
 						this.reportProgress(0, totalFrames, "preparing", undefined, progress),
+					audioPlan.sourceAudioFallbackPaths,
 				);
 
 				return {
@@ -2738,6 +2762,7 @@ export class ModernVideoExporter {
 			const renderedAudio = await this.renderEditedAudioForNativeMux(
 				`${NATIVE_EXPORT_ENGINE_NAME} edited audio rendering`,
 				(progress) => this.reportFinalizingProgress(this.processedFrameCount, 99, progress),
+				audioPlan.sourceAudioFallbackPaths,
 			);
 			editedAudioBuffer = renderedAudio.editedAudioData;
 			editedAudioMimeType = renderedAudio.editedAudioMimeType;
@@ -2835,6 +2860,7 @@ export class ModernVideoExporter {
 			const renderedAudio = await this.renderEditedAudioForNativeMux(
 				"FFmpeg edited audio rendering",
 				(progress) => this.reportFinalizingProgress(this.processedFrameCount, 99, progress),
+				audioPlan.sourceAudioFallbackPaths,
 			);
 			editedAudioBuffer = renderedAudio.editedAudioData;
 			editedAudioMimeType = renderedAudio.editedAudioMimeType;


### PR DESCRIPTION
## Summary
- Keep companion mic/system sidecar audio in the native/static export audio plan when the source MP4 also has an embedded audio track.
- Thread the resolved fallback path list into offline audio rendering so the edited-track mix uses both embedded source audio and external sidecars.
- Add regression coverage for the #504-style case where the native exporter previously saw only the sidecar fallback.

## Why
A latest beta user reported that a one-minute recording exported with voice suddenly gone. This matches a #504 audio-continuity slice: when native/static export selects an offline audio render, the exporter can drop the mic sidecar if it only treats the embedded source track as the audio source.

This PR is intentionally narrow. It does not claim to fix capture-path failures where the mic sidecar itself is blank or missing.

## Verification
- npm test -- src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts src/lib/exporter/sourceAudioFallback.test.ts src/lib/exporter/sourceTrackRoutingPolicy.test.ts electron/ipc/recording/diagnostics.test.ts
- npx tsc --noEmit
- npx biome check --formatter-enabled=false src/lib/exporter/modernVideoExporter.ts src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts src/lib/exporter/sourceAudioFallback.ts src/lib/exporter/sourceTrackRoutingPolicy.ts electron/ipc/recording/diagnostics.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for companion audio (microphone) mixing with native video exports when source MP4 already contains audio.

* **Improvements**
  * Enhanced audio fallback path resolution for native video exports to properly handle mixed companion audio scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->