### PR TITLE
fix(export): reject silent cuda inline audio

### DIFF
--- a/electron/ipc/export/native-video.test.ts
+++ b/electron/ipc/export/native-video.test.ts
@@ -1078,6 +1078,47 @@ describe("validateNvidiaCudaExportSummary", () => {
 		expect(issues).toEqual([]);
 	});
 
+	it("rejects inline-audio CUDA output when the helper does not produce audio", () => {
+		const issues = validateNvidiaCudaExportSummary(
+			{
+				success: true,
+				targetFrames: 300,
+				durationSec: 10,
+				nativeSummary: {
+					success: true,
+					frames: 300,
+					sourceTimestampMode: "pts",
+					selectionStage: "timestamp-mapped-callback",
+				},
+				outputVideo: { duration: "9.999900", nb_frames: "300" },
+			},
+			{ durationSec: 10, targetFrames: 300, requiresTimelineSync: true },
+		);
+
+		expect(issues).toEqual(["missing output audio stream"]);
+	});
+
+	it("rejects inline-audio CUDA output when the probed audio stream is empty", () => {
+		const issues = validateNvidiaCudaExportSummary(
+			{
+				success: true,
+				targetFrames: 300,
+				durationSec: 10,
+				nativeSummary: {
+					success: true,
+					frames: 300,
+					sourceTimestampMode: "pts",
+					selectionStage: "timestamp-mapped-callback",
+				},
+				outputVideo: { duration: "9.999900", nb_frames: "300" },
+				outputAudio: { duration: "0.000000" },
+			},
+			{ durationSec: 10, targetFrames: 300, requiresTimelineSync: true },
+		);
+
+		expect(issues).toEqual(["output audio duration is not positive"]);
+	});
+
 	it("accepts audio CUDA output when the helper reports PTS-aligned selection", () => {
 		const issues = validateNvidiaCudaExportSummary(
 			{

--- a/electron/ipc/export/native-video.ts
+++ b/electron/ipc/export/native-video.ts
@@ -433,6 +433,13 @@ export function validateNvidiaCudaExportSummary(
 	if (expected.requiresTimelineSync && !isNvidiaCudaTimestampAlignedSummary(summary)) {
 		issues.push("CUDA timeline mode is not timestamp-aligned for audio export");
 	}
+	if (expected.requiresTimelineSync) {
+		if (!summary.outputAudio) {
+			issues.push("missing output audio stream");
+		} else if (outputAudioDurationSec !== null && outputAudioDurationSec <= 0) {
+			issues.push("output audio duration is not positive");
+		}
+	}
 	if (nativeFrames === null) {
 		issues.push("missing native frame count");
 	} else if (nativeFrames < minimumFrames) {
@@ -455,6 +462,7 @@ export function validateNvidiaCudaExportSummary(
 	}
 	if (
 		outputAudioDurationSec !== null &&
+		outputAudioDurationSec > 0 &&
 		Math.abs(outputAudioDurationSec - expectedDurationSec) > durationToleranceSec
 	) {
 		issues.push(


### PR DESCRIPTION
## Summary
- Reject CUDA inline-audio export summaries when the helper output has no audio stream.
- Reject CUDA inline-audio summaries when the probed audio stream duration is zero.
- Add regression coverage around `validateNvidiaCudaExportSummary`.

## Why
This is a small slice from #504 that directly protects against silent native/CUDA outputs. If the CUDA helper is trusted to mux audio inline, the validator must not accept a video-only or empty-audio MP4 and skip the shared mux/fallback path.

This PR intentionally does not include the broader #504 route planner, CUDA compositor binary, or dev launcher changes.

## Verification
- npm test -- electron/ipc/export/native-video.test.ts
- npx tsc --noEmit
- npx biome check --formatter-enabled=false electron/ipc/export/native-video.ts electron/ipc/export/native-video.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for NVIDIA CUDA video exports to properly detect and report issues with missing or invalid audio streams during export operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->