### PR TITLE
fix(export): gate packaged cuda audio fallback

### DIFF
--- a/electron/ipc/export/native-video.test.ts
+++ b/electron/ipc/export/native-video.test.ts
@@ -449,6 +449,49 @@ describe("getExperimentalNvidiaCudaExportSkipReason", () => {
 		}
 	});
 
+	it("does not use packaged auto-candidate audio bypass when CUDA is explicitly enabled", async () => {
+		const exportEnvName = "RECORDLY_EXPERIMENTAL_NVIDIA_CUDA_EXPORT";
+		const forceEnvName = "RECORDLY_NVIDIA_CUDA_FORCE_VIDEO_ONLY";
+		const allowAudioEnvName = "RECORDLY_NVIDIA_CUDA_ALLOW_AUDIO_EXPORT";
+		const originalExportEnv = process.env[exportEnvName];
+		const originalForceEnv = process.env[forceEnvName];
+		const originalAllowAudioEnv = process.env[allowAudioEnvName];
+		const originalIsPackaged = electronAppMock.isPackaged;
+		electronAppMock.isPackaged = true;
+		process.env[exportEnvName] = "1";
+		delete process.env[forceEnvName];
+		delete process.env[allowAudioEnvName];
+
+		try {
+			const reason = await getExperimentalNvidiaCudaExportSkipReason(
+				createNvidiaCudaSkipOptions({
+					audioOptions: { audioMode: "copy-source", audioSourcePath: "input.mp4" },
+				}),
+			);
+
+			expect(reason).toBe(
+				process.platform === "win32" ? "audio-mode:copy-source" : "not-windows",
+			);
+		} finally {
+			if (originalExportEnv === undefined) {
+				delete process.env[exportEnvName];
+			} else {
+				process.env[exportEnvName] = originalExportEnv;
+			}
+			if (originalForceEnv === undefined) {
+				delete process.env[forceEnvName];
+			} else {
+				process.env[forceEnvName] = originalForceEnv;
+			}
+			if (originalAllowAudioEnv === undefined) {
+				delete process.env[allowAudioEnvName];
+			} else {
+				process.env[allowAudioEnvName] = originalAllowAudioEnv;
+			}
+			electronAppMock.isPackaged = originalIsPackaged;
+		}
+	});
+
 	it("skips packaged CUDA auto-candidates when Electron reports no NVIDIA GPU", async () => {
 		const reason = await withPackagedCudaCandidate(
 			{ gpuDevice: [{ vendorId: 0x8086, deviceString: "Intel UHD Graphics" }] },

--- a/electron/ipc/export/native-video.ts
+++ b/electron/ipc/export/native-video.ts
@@ -2010,15 +2010,16 @@ export async function getExperimentalNvidiaCudaExportSkipReason(
 		return "not-windows";
 	}
 	const explicitCuda = isExplicitNvidiaCudaExportEnabled();
-	const packagedAutoCandidate = isPackagedNvidiaCudaExportAutoCandidateEnabled();
-	if (!explicitCuda && !packagedAutoCandidate) {
+	const packagedAutoCandidateEnabled = isPackagedNvidiaCudaExportAutoCandidateEnabled();
+	const packagedAutoCandidateActive = isPackagedNvidiaCudaExportAutoCandidateActive();
+	if (!explicitCuda && !packagedAutoCandidateEnabled) {
 		return "env-disabled";
 	}
 	if (!options.experimentalWindowsGpuCompositor) {
 		return "windows-gpu-compositor-disabled";
 	}
 
-	if (packagedAutoCandidate && !explicitCuda) {
+	if (packagedAutoCandidateActive) {
 		if (!(await resolveExperimentalNvidiaCudaExportScriptPath())) {
 			return "cuda-wrapper-unavailable";
 		}
@@ -2029,7 +2030,7 @@ export async function getExperimentalNvidiaCudaExportSkipReason(
 
 	return getNvidiaCudaAudioExportSkipReason(options.audioOptions?.audioMode, {
 		allowValidatedFallbackCandidate:
-			packagedAutoCandidate || isNvidiaCudaForceVideoOnlyEnabled(),
+			packagedAutoCandidateActive || isNvidiaCudaForceVideoOnlyEnabled(),
 	});
 }
 


### PR DESCRIPTION
## Summary
- Use the packaged CUDA auto-candidate **active** state, not just the enabled state, when allowing validated audio fallback candidates.
- Keep explicit CUDA audio guarded unless `RECORDLY_NVIDIA_CUDA_FORCE_VIDEO_ONLY` or the explicit audio override is set.
- Add regression coverage for packaged app + explicit CUDA + copy-source audio.

## Why
This is a small #504 follow-up. In packaged builds, the auto-candidate path can safely try CUDA with shared mux fallback, but explicit CUDA should not inherit that audio bypass merely because the app is packaged. This keeps packaged `.exe` behavior narrower and less likely to accept an unsafe CUDA audio route.

This PR intentionally avoids the broader #504 route planner and CUDA compositor changes.

## Verification
- npm test -- electron/ipc/export/native-video.test.ts
- npx tsc --noEmit
- npx biome check --formatter-enabled=false electron/ipc/export/native-video.ts electron/ipc/export/native-video.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for experimental NVIDIA CUDA export functionality across different platform and environment configurations.

* **Bug Fixes**
  * Improved handling of NVIDIA CUDA audio export validation logic to correctly distinguish between enabled and active states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->