### PR TITLE
fix(export): tighten native audio safety guards

### DIFF
--- a/electron/ipc/export/native-video.test.ts
+++ b/electron/ipc/export/native-video.test.ts
@@ -856,6 +856,16 @@ describe("buildNativeVideoAudioMuxArgs", () => {
 		expect(args.join(";")).not.toContain("-c:a;copy");
 	});
 
+	it("transcodes unknown source audio instead of copying unsafe codecs into MP4", () => {
+		const args = buildNativeVideoAudioMuxArgs("video.mp4", "source.wav", "out.mp4", {
+			audioMode: "copy-source",
+			outputDurationSec: 60,
+		});
+
+		expect(args).toEqual(expect.arrayContaining(["-c:a", "aac", "-b:a", "192k"]));
+		expect(args.join(";")).not.toContain("-c:a;copy");
+	});
+
 	it("keeps filtered audio on the AAC encode path", () => {
 		const args = buildNativeVideoAudioMuxArgs("video.mp4", "source.mp4", "out.mp4", {
 			audioMode: "trim-source",
@@ -905,6 +915,11 @@ describe("canCopyAudioCodecIntoMp4", () => {
 
 	it("blocks Opus so native exports transcode it to AAC for MP4", () => {
 		expect(canCopyAudioCodecIntoMp4("opus")).toBe(false);
+	});
+
+	it("blocks unknown codecs so sidecar WAV/PCM audio is encoded for MP4", () => {
+		expect(canCopyAudioCodecIntoMp4(undefined)).toBe(false);
+		expect(canCopyAudioCodecIntoMp4("")).toBe(false);
 	});
 });
 
@@ -1160,6 +1175,27 @@ describe("validateNvidiaCudaExportSummary", () => {
 		);
 
 		expect(issues).toEqual(["output audio duration is not positive"]);
+	});
+
+	it("rejects inline-audio CUDA output when the audio duration is missing", () => {
+		const issues = validateNvidiaCudaExportSummary(
+			{
+				success: true,
+				targetFrames: 300,
+				durationSec: 10,
+				nativeSummary: {
+					success: true,
+					frames: 300,
+					sourceTimestampMode: "pts",
+					selectionStage: "timestamp-mapped-callback",
+				},
+				outputVideo: { duration: "9.999900", nb_frames: "300" },
+				outputAudio: {},
+			},
+			{ durationSec: 10, targetFrames: 300, requiresTimelineSync: true },
+		);
+
+		expect(issues).toEqual(["missing output audio duration"]);
 	});
 
 	it("accepts audio CUDA output when the helper reports PTS-aligned selection", () => {

--- a/electron/ipc/export/native-video.ts
+++ b/electron/ipc/export/native-video.ts
@@ -436,7 +436,9 @@ export function validateNvidiaCudaExportSummary(
 	if (expected.requiresTimelineSync) {
 		if (!summary.outputAudio) {
 			issues.push("missing output audio stream");
-		} else if (outputAudioDurationSec !== null && outputAudioDurationSec <= 0) {
+		} else if (outputAudioDurationSec === null) {
+			issues.push("missing output audio duration");
+		} else if (outputAudioDurationSec <= 0) {
 			issues.push("output audio duration is not positive");
 		}
 	}
@@ -3903,7 +3905,7 @@ export async function resolveNativeVideoEncoder(
 export function canCopyAudioCodecIntoMp4(codec?: string | null) {
 	const normalized = (codec ?? "").trim().toLowerCase();
 	if (!normalized) {
-		return true;
+		return false;
 	}
 
 	return (


### PR DESCRIPTION
## Summary
- Reject CUDA inline-audio summaries when an audio stream exists but has no duration metadata.
- Avoid stream-copying unknown source audio codecs into MP4; transcode to AAC instead.
- Add regression coverage for both native audio safety guards.

## Why
This is a final small audio-safety slice from #504. Native export should only trust CUDA inline audio when the output audio stream can be validated, and MP4 muxing should not copy unknown sidecar/WAV/PCM-like codecs blindly.

This PR intentionally avoids route planner, CUDA compositor binary, and dev launcher changes.

## Verification
- npm test -- electron/ipc/export/native-video.test.ts
- npx tsc --noEmit
- npx biome check --formatter-enabled=false electron/ipc/export/native-video.ts electron/ipc/export/native-video.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed audio codec handling during MP4 exports—unknown audio codecs are now properly transcoded to AAC instead of causing potential issues.
* Improved validation for NVIDIA CUDA exports to properly detect missing audio duration data, preventing invalid export configurations.
* Enhanced edge-case handling for missing or unspecified audio codec information during video export operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->