### PR TITLE
fix(recording): abort prune on unreadable project

### DIFF
--- a/electron/ipc/recording/prune.ts
+++ b/electron/ipc/recording/prune.ts
@@ -82,11 +82,11 @@ async function loadSavedProjectMediaPaths() {
 						editor?: { webcam?: { sourcePath?: unknown } };
 					}>(await fs.readFile(projectPath, "utf-8"));
 				} catch (error) {
-					console.warn("[prune] Skipping unreadable project while pruning recordings", {
+					console.warn("[prune] Aborting recording prune because a saved project is unreadable", {
 						projectPath,
 						error,
 					});
-					return;
+					throw error;
 				}
 				const candidatePaths = [
 					rawProject.videoPath,


### PR DESCRIPTION
## Summary
- Abort auto-recording prune when a saved project cannot be read or parsed.
- Preserve the existing warning, but make the prune path fail closed instead of skipping the unreadable project.

## Type of Change
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Test

## Related Issue(s)
- Related to #504

## Why
This is a small #504 extraction. If a saved project is unreadable, pruning cannot safely know which recording paths are still protected by that project. Failing closed avoids deleting recordings that may still be referenced.

This PR intentionally does not include the broader #504 native route, CUDA compositor, binary manifest, or dev launcher changes.

## Verification
- `npm test -- electron/ipc/recording/prune.test.ts`
- `npx tsc --noEmit`
- `npx biome check --formatter-enabled=false electron/ipc/recording/prune.ts electron/ipc/recording/prune.test.ts`
- `git diff --check`