### PR TITLE
refactor(editor): extract NVIDIA export opt-in hook

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -52,7 +52,6 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Toaster } from "@/components/ui/sonner";
 import { useI18n } from "@/contexts/I18nContext";
 import { useShortcuts } from "@/contexts/ShortcutsContext";
-import { loadAppSetting, saveAppSetting } from "@/lib/appSettings";
 import {
 	calculateOutputDimensions,
 	DEFAULT_MP4_CODEC,
@@ -89,6 +88,7 @@ import {
 } from "@/utils/aspectRatioUtils";
 import { ExtensionIcon } from "./ExtensionIcon";
 import { calculateMp4ExportDimensions, calculateMp4SourceDimensions } from "./exportDimensions";
+import { useNvidiaCudaExportOptIn } from "./useNvidiaCudaExportOptIn";
 
 const PhCursorFill = (props: { className?: string; weight?: "fill" | "regular" }) => (
 	<Cursor weight="fill" className={props.className} />
@@ -108,8 +108,6 @@ const PhSparkle = (props: { className?: string; weight?: "fill" | "regular" }) =
 const PhSettings = (props: { className?: string; weight?: "fill" | "regular" }) => (
 	<Gear weight={props.weight ?? "regular"} className={props.className} />
 );
-
-const NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY = "recordly.export.experimentalNvidiaCuda";
 
 import type { SourceAudioTrackSettings } from "@/components/video-editor/audio/audioTypes";
 import { extensionHost } from "@/lib/extensions";
@@ -554,10 +552,16 @@ export default function VideoEditor() {
 	const [exportPipelineModel, setExportPipelineModel] = useState<ExportPipelineModel>(
 		initialEditorPreferences.exportPipelineModel,
 	);
-	const [nvidiaCudaExportAvailable, setNvidiaCudaExportAvailable] = useState(false);
-	const [experimentalNvidiaCudaExport, setExperimentalNvidiaCudaExportState] = useState(
-		() => loadAppSetting<boolean>(NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY) === true,
-	);
+	const enableModernExportPipeline = useCallback(() => {
+		setExportPipelineModel("modern");
+	}, []);
+	const {
+		nvidiaCudaExportAvailable,
+		experimentalNvidiaCudaExport,
+		setExperimentalNvidiaCudaExport,
+	} = useNvidiaCudaExportOptIn({
+		onEnabled: enableModernExportPipeline,
+	});
 	const [mp4FrameRate, setMp4FrameRate] = useState<ExportMp4FrameRate>(
 		initialEditorPreferences.mp4FrameRate ?? DEFAULT_MP4_EXPORT_FRAME_RATE,
 	);
@@ -627,48 +631,6 @@ export default function VideoEditor() {
 			setAppPlatform(platform);
 		});
 	}, []);
-
-	useEffect(() => {
-		let cancelled = false;
-
-		void (async () => {
-			try {
-				const result = await window.electronAPI?.getNativeExportCapabilities?.();
-				if (cancelled) {
-					return;
-				}
-
-				const available = result?.capabilities?.nvidiaCuda.available === true;
-				setNvidiaCudaExportAvailable(available);
-				if (!available) {
-					setExperimentalNvidiaCudaExportState(false);
-				}
-			} catch (error) {
-				if (cancelled) {
-					return;
-				}
-				console.warn("[export] Failed to load native export capabilities", error);
-				setNvidiaCudaExportAvailable(false);
-				setExperimentalNvidiaCudaExportState(false);
-			}
-		})();
-
-		return () => {
-			cancelled = true;
-		};
-	}, []);
-
-	const setExperimentalNvidiaCudaExport = useCallback(
-		(enabled: boolean) => {
-			const nextEnabled = Boolean(enabled && nvidiaCudaExportAvailable);
-			setExperimentalNvidiaCudaExportState(nextEnabled);
-			saveAppSetting(NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY, nextEnabled);
-			if (nextEnabled) {
-				setExportPipelineModel("modern");
-			}
-		},
-		[nvidiaCudaExportAvailable],
-	);
 
 	useEffect(() => {
 		autoSuggestedVideoPathRef.current = null;

--- a/src/components/video-editor/useNvidiaCudaExportOptIn.test.ts
+++ b/src/components/video-editor/useNvidiaCudaExportOptIn.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	isNvidiaCudaExportAvailable,
+	loadInitialNvidiaCudaExportOptIn,
+	NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY,
+	resolveNvidiaCudaExportOptIn,
+	saveNvidiaCudaExportOptIn,
+} from "./useNvidiaCudaExportOptIn";
+
+function stubElectronSettings(initialValues: Record<string, unknown> = {}) {
+	const store = new Map(Object.entries(initialValues));
+
+	Object.defineProperty(globalThis, "electronAPI", {
+		configurable: true,
+		value: {
+			getAppSetting: (key: string) => (store.has(key) ? store.get(key) : null),
+			setAppSetting: (key: string, value: unknown) => {
+				store.set(key, value);
+				return true;
+			},
+		} as Pick<Window["electronAPI"], "getAppSetting" | "setAppSetting">,
+	});
+
+	return store;
+}
+
+describe("nvidiaCudaExportOptIn", () => {
+	afterEach(() => {
+		Reflect.deleteProperty(globalThis, "electronAPI");
+	});
+
+	it("only treats explicit native CUDA availability as available", () => {
+		expect(
+			isNvidiaCudaExportAvailable({
+				capabilities: { nvidiaCuda: { available: true } },
+			}),
+		).toBe(true);
+		expect(
+			isNvidiaCudaExportAvailable({
+				capabilities: { nvidiaCuda: { available: false } },
+			}),
+		).toBe(false);
+		expect(isNvidiaCudaExportAvailable({ capabilities: {} })).toBe(false);
+		expect(isNvidiaCudaExportAvailable(null)).toBe(false);
+	});
+
+	it("requires both user request and runtime availability before enabling", () => {
+		expect(resolveNvidiaCudaExportOptIn(true, true)).toBe(true);
+		expect(resolveNvidiaCudaExportOptIn(true, false)).toBe(false);
+		expect(resolveNvidiaCudaExportOptIn(false, true)).toBe(false);
+		expect(resolveNvidiaCudaExportOptIn(false, false)).toBe(false);
+	});
+
+	it("loads and saves the local opt-in flag through app settings", () => {
+		const store = stubElectronSettings({
+			[NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY]: true,
+		});
+
+		expect(loadInitialNvidiaCudaExportOptIn()).toBe(true);
+		expect(saveNvidiaCudaExportOptIn(false)).toBe(true);
+		expect(store.get(NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY)).toBe(false);
+	});
+
+	it("defaults to disabled when the app setting is unavailable", () => {
+		expect(loadInitialNvidiaCudaExportOptIn()).toBe(false);
+	});
+});

--- a/src/components/video-editor/useNvidiaCudaExportOptIn.ts
+++ b/src/components/video-editor/useNvidiaCudaExportOptIn.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from "react";
+import { loadAppSetting, saveAppSetting } from "@/lib/appSettings";
+
+export const NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY =
+	"recordly.export.experimentalNvidiaCuda";
+
+type NativeExportCapabilitiesResult = {
+	capabilities?: {
+		nvidiaCuda?: {
+			available?: boolean;
+		};
+	};
+} | null;
+
+export function isNvidiaCudaExportAvailable(
+	result: NativeExportCapabilitiesResult | undefined,
+) {
+	return result?.capabilities?.nvidiaCuda?.available === true;
+}
+
+export function resolveNvidiaCudaExportOptIn(
+	requested: boolean,
+	nvidiaCudaExportAvailable: boolean,
+) {
+	return Boolean(requested && nvidiaCudaExportAvailable);
+}
+
+export function loadInitialNvidiaCudaExportOptIn() {
+	return loadAppSetting<boolean>(NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY) === true;
+}
+
+export function saveNvidiaCudaExportOptIn(enabled: boolean) {
+	return saveAppSetting(NVIDIA_CUDA_EXPORT_OPT_IN_SETTING_KEY, enabled);
+}
+
+export function useNvidiaCudaExportOptIn({
+	onEnabled,
+}: {
+	onEnabled?: () => void;
+} = {}) {
+	const [nvidiaCudaExportAvailable, setNvidiaCudaExportAvailable] = useState(false);
+	const [experimentalNvidiaCudaExport, setExperimentalNvidiaCudaExportState] = useState(
+		loadInitialNvidiaCudaExportOptIn,
+	);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		void (async () => {
+			try {
+				const result = await window.electronAPI?.getNativeExportCapabilities?.();
+				if (cancelled) {
+					return;
+				}
+
+				const available = isNvidiaCudaExportAvailable(result);
+				setNvidiaCudaExportAvailable(available);
+				if (!available) {
+					setExperimentalNvidiaCudaExportState(false);
+				}
+			} catch (error) {
+				if (cancelled) {
+					return;
+				}
+				console.warn("[export] Failed to load native export capabilities", error);
+				setNvidiaCudaExportAvailable(false);
+				setExperimentalNvidiaCudaExportState(false);
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const setExperimentalNvidiaCudaExport = useCallback(
+		(enabled: boolean) => {
+			const nextEnabled = resolveNvidiaCudaExportOptIn(
+				enabled,
+				nvidiaCudaExportAvailable,
+			);
+			setExperimentalNvidiaCudaExportState(nextEnabled);
+			saveNvidiaCudaExportOptIn(nextEnabled);
+			if (nextEnabled) {
+				onEnabled?.();
+			}
+		},
+		[nvidiaCudaExportAvailable, onEnabled],
+	);
+
+	return {
+		nvidiaCudaExportAvailable,
+		experimentalNvidiaCudaExport,
+		setExperimentalNvidiaCudaExport,
+	};
+}


### PR DESCRIPTION
﻿## Description
Extract the NVIDIA CUDA export opt-in runtime state from `VideoEditor.tsx` into a focused `useNvidiaCudaExportOptIn` hook.

## Motivation
`VideoEditor.tsx` should not own device capability probing, app-local opt-in persistence, and the toggle enable guard inline. This keeps the editor component closer to UI/export orchestration while the hook owns the native capability side effect boundary introduced by #562.

## Type of Change
- Refactor
- Tests

## Related Issue(s)
- Follow-up to #562

## Changes Made
- Added `src/components/video-editor/useNvidiaCudaExportOptIn.ts` for NVIDIA CUDA availability probing, local setting persistence, and opt-in gating.
- Added focused tests for availability parsing, opt-in gating, and persisted app setting behavior.
- Replaced the inline `VideoEditor.tsx` state/effect/callback block with the hook return values.

## Scope Note
- No UI copy or layout changes.
- No exporter behavior changes.
- No native helper, preload, IPC, or packaging changes.
- No Linux NVIDIA support is added here. Linux/other OS NVIDIA support remains a separate future slice requiring helper packaging, platform probing, packaged smoke, and real-device QA.
- No Zustand/Redux/global store added; this remains a small controller hook.

## Testing Guide
1. Open MP4 export settings on a non-NVIDIA or unsupported device and confirm the CUDA switch stays hidden.
2. On a supported Windows NVIDIA packaged/dev setup, confirm the switch still appears under Lightning MP4 export and enabling it still selects the modern pipeline.
3. Export with the switch off and confirm the normal Lightning fallback path is unchanged.

## Checklist
- [x] One small architectural slice only
- [x] Behavior-preserving extraction
- [x] Focused test coverage for moved decisions
- [x] No generated binaries or local probes included
- [x] Ready for architecture review

## Local Checks
- `npm test -- src/components/video-editor/useNvidiaCudaExportOptIn.test.ts`
- `npm test -- electron/ipc/export/native-video.test.ts`
- `npm test -- src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/useNvidiaCudaExportOptIn.ts src/components/video-editor/useNvidiaCudaExportOptIn.test.ts`
- `git diff --check`

## Runtime/Repro Evidence
Not run. This is a renderer hook extraction with no native/preload/IPC contract change. Hardware runtime behavior remains covered by the #562 validation path and should be smoke-tested on Windows NVIDIA before any release claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved organization of NVIDIA CUDA export settings management.

* **Tests**
  * Added comprehensive test coverage for NVIDIA CUDA export opt-in functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->