### PR TITLE
refactor(editor): extract MP4 export routing

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -88,6 +88,7 @@ import {
 } from "@/utils/aspectRatioUtils";
 import { ExtensionIcon } from "./ExtensionIcon";
 import { calculateMp4ExportDimensions, calculateMp4SourceDimensions } from "./exportDimensions";
+import { resolveMp4ExportRouting } from "./mp4ExportRouting";
 import { useNvidiaCudaExportOptIn } from "./useNvidiaCudaExportOptIn";
 
 const PhCursorFill = (props: { className?: string; weight?: "fill" | "regular" }) => (
@@ -4135,25 +4136,24 @@ export default function VideoEditor() {
 					const selectedMp4FrameRate = smokeExportConfig.enabled
 						? (smokeExportConfig.fps ?? settings.mp4FrameRate ?? mp4FrameRate)
 						: (settings.mp4FrameRate ?? mp4FrameRate);
-					const pipelineModel = smokeExportConfig.enabled
-						? (smokeExportConfig.pipelineModel ?? "modern")
-						: (settings.pipelineModel ?? exportPipelineModel);
-					const useExperimentalNativeExport =
-						pipelineModel === "modern" &&
-						(smokeExportConfig.enabled ? smokeExportConfig.useNativeExport : true);
-					const useExperimentalNvidiaCudaExport =
-						useExperimentalNativeExport &&
-						experimentalNvidiaCudaExport &&
-						nvidiaCudaExportAvailable;
-					const backendPreference =
-						pipelineModel === "legacy"
-							? "webcodecs"
-							: smokeExportConfig.enabled
-								? (smokeExportConfig.backendPreference ??
-									(smokeExportConfig.useNativeExport ? "breeze" : "webcodecs"))
-								: useExperimentalNativeExport
-									? "auto"
-									: (settings.backendPreference ?? exportBackendPreference);
+					const {
+						pipelineModel,
+						useExperimentalNativeExport,
+						useExperimentalNvidiaCudaExport,
+						backendPreference,
+					} = resolveMp4ExportRouting({
+						smokeExportConfig: {
+							enabled: smokeExportConfig.enabled,
+							pipelineModel: smokeExportConfig.pipelineModel,
+							useNativeExport: smokeExportConfig.useNativeExport,
+							backendPreference: smokeExportConfig.backendPreference,
+						},
+						settings,
+						exportPipelineModel,
+						exportBackendPreference,
+						experimentalNvidiaCudaExport,
+						nvidiaCudaExportAvailable,
+					});
 					const supportedSourceDimensions =
 						await ensureSupportedMp4SourceDimensions(selectedMp4FrameRate);
 					const { width: exportWidth, height: exportHeight } =

--- a/src/components/video-editor/mp4ExportRouting.test.ts
+++ b/src/components/video-editor/mp4ExportRouting.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveMp4ExportRouting } from "./mp4ExportRouting";
+
+const baseOptions = {
+	smokeExportConfig: {
+		enabled: false,
+		useNativeExport: false,
+	},
+	settings: {},
+	exportPipelineModel: "modern" as const,
+	exportBackendPreference: "breeze" as const,
+	experimentalNvidiaCudaExport: false,
+	nvidiaCudaExportAvailable: false,
+};
+
+describe("resolveMp4ExportRouting", () => {
+	it("uses the modern native auto route for normal MP4 exports by default", () => {
+		expect(resolveMp4ExportRouting(baseOptions)).toEqual({
+			pipelineModel: "modern",
+			useExperimentalNativeExport: true,
+			useExperimentalNvidiaCudaExport: false,
+			backendPreference: "auto",
+		});
+	});
+
+	it("forces WebCodecs and disables native export for the legacy pipeline", () => {
+		expect(
+			resolveMp4ExportRouting({
+				...baseOptions,
+				settings: { pipelineModel: "legacy", backendPreference: "breeze" },
+			}),
+		).toEqual({
+			pipelineModel: "legacy",
+			useExperimentalNativeExport: false,
+			useExperimentalNvidiaCudaExport: false,
+			backendPreference: "webcodecs",
+		});
+	});
+
+	it("keeps smoke exports on WebCodecs unless smoke native export is requested", () => {
+		expect(
+			resolveMp4ExportRouting({
+				...baseOptions,
+				smokeExportConfig: {
+					enabled: true,
+					useNativeExport: false,
+				},
+			}),
+		).toEqual({
+			pipelineModel: "modern",
+			useExperimentalNativeExport: false,
+			useExperimentalNvidiaCudaExport: false,
+			backendPreference: "webcodecs",
+		});
+
+		expect(
+			resolveMp4ExportRouting({
+				...baseOptions,
+				smokeExportConfig: {
+					enabled: true,
+					useNativeExport: true,
+				},
+			}),
+		).toEqual({
+			pipelineModel: "modern",
+			useExperimentalNativeExport: true,
+			useExperimentalNvidiaCudaExport: false,
+			backendPreference: "breeze",
+		});
+	});
+
+	it("only enables NVIDIA CUDA when native export is active and the device is available", () => {
+		expect(
+			resolveMp4ExportRouting({
+				...baseOptions,
+				experimentalNvidiaCudaExport: true,
+				nvidiaCudaExportAvailable: true,
+			}).useExperimentalNvidiaCudaExport,
+		).toBe(true);
+
+		expect(
+			resolveMp4ExportRouting({
+				...baseOptions,
+				settings: { pipelineModel: "legacy" },
+				experimentalNvidiaCudaExport: true,
+				nvidiaCudaExportAvailable: true,
+			}).useExperimentalNvidiaCudaExport,
+		).toBe(false);
+
+		expect(
+			resolveMp4ExportRouting({
+				...baseOptions,
+				experimentalNvidiaCudaExport: true,
+				nvidiaCudaExportAvailable: false,
+			}).useExperimentalNvidiaCudaExport,
+		).toBe(false);
+	});
+});

--- a/src/components/video-editor/mp4ExportRouting.ts
+++ b/src/components/video-editor/mp4ExportRouting.ts
@@ -1,0 +1,57 @@
+import type {
+	ExportBackendPreference,
+	ExportPipelineModel,
+	ExportSettings,
+} from "@/lib/exporter";
+import type { SmokeExportConfig } from "./smokeExportConfig";
+
+export type Mp4ExportRouting = {
+	pipelineModel: ExportPipelineModel;
+	useExperimentalNativeExport: boolean;
+	useExperimentalNvidiaCudaExport: boolean;
+	backendPreference: ExportBackendPreference;
+};
+
+export function resolveMp4ExportRouting({
+	smokeExportConfig,
+	settings,
+	exportPipelineModel,
+	exportBackendPreference,
+	experimentalNvidiaCudaExport,
+	nvidiaCudaExportAvailable,
+}: {
+	smokeExportConfig: Pick<
+		SmokeExportConfig,
+		"enabled" | "pipelineModel" | "useNativeExport" | "backendPreference"
+	>;
+	settings: Pick<ExportSettings, "pipelineModel" | "backendPreference">;
+	exportPipelineModel: ExportPipelineModel;
+	exportBackendPreference: ExportBackendPreference;
+	experimentalNvidiaCudaExport: boolean;
+	nvidiaCudaExportAvailable: boolean;
+}): Mp4ExportRouting {
+	const pipelineModel = smokeExportConfig.enabled
+		? (smokeExportConfig.pipelineModel ?? "modern")
+		: (settings.pipelineModel ?? exportPipelineModel);
+	const useExperimentalNativeExport =
+		pipelineModel === "modern" &&
+		(smokeExportConfig.enabled ? smokeExportConfig.useNativeExport : true);
+	const useExperimentalNvidiaCudaExport =
+		useExperimentalNativeExport && experimentalNvidiaCudaExport && nvidiaCudaExportAvailable;
+	const backendPreference =
+		pipelineModel === "legacy"
+			? "webcodecs"
+			: smokeExportConfig.enabled
+				? (smokeExportConfig.backendPreference ??
+					(smokeExportConfig.useNativeExport ? "breeze" : "webcodecs"))
+				: useExperimentalNativeExport
+					? "auto"
+					: (settings.backendPreference ?? exportBackendPreference);
+
+	return {
+		pipelineModel,
+		useExperimentalNativeExport,
+		useExperimentalNvidiaCudaExport,
+		backendPreference,
+	};
+}


### PR DESCRIPTION
﻿## Description
Extract the MP4 export route decision from `VideoEditor.tsx` into a small pure `resolveMp4ExportRouting` module.

## Motivation
`VideoEditor.tsx` still owns too much export orchestration inline. This slice moves the MP4 pipeline/backend/NVIDIA gate decision into a named domain helper so the editor component can assemble export config without embedding routing policy details.

## Type of Change
- Refactor
- Tests

## Related Issue(s)
- Follow-up to #562 and #563

## Changes Made
- Added `src/components/video-editor/mp4ExportRouting.ts` with a pure `resolveMp4ExportRouting` helper.
- Added focused tests covering normal modern exports, legacy exports, smoke export native on/off behavior, and NVIDIA CUDA gating.
- Replaced the inline MP4 routing block in `VideoEditor.tsx` with the helper result.

## Scope Note
- No UI changes.
- No exporter implementation changes.
- No native helper, preload, IPC, packaging, or Linux NVIDIA behavior changes.
- No Zustand/Redux/global store added.
- This only names and tests an existing decision boundary.

## Testing Guide
1. Export MP4 with the default Lightning pipeline and confirm behavior is unchanged.
2. Export MP4 with Legacy selected and confirm WebCodecs path remains selected.
3. For smoke export URLs, verify `smokeUseNativeExport=1` still chooses the native-capable smoke route while omitted/false stays WebCodecs.
4. On Windows NVIDIA test hardware, #562's CUDA switch behavior should remain unchanged.

## Checklist
- [x] One small architectural slice only
- [x] Behavior-preserving extraction
- [x] Focused tests for moved routing decisions
- [x] No generated binaries or local probes included
- [x] Ready for review

## Local Checks
- `npm test -- src/components/video-editor/mp4ExportRouting.test.ts`
- `npm test -- src/components/video-editor/useNvidiaCudaExportOptIn.test.ts src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts`
- `npm test -- electron/ipc/export/native-video.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/mp4ExportRouting.ts src/components/video-editor/mp4ExportRouting.test.ts`
- `git diff --check`

## Runtime/Repro Evidence
Not run. This is a pure renderer-side routing-policy extraction with no native/preload/IPC contract change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized MP4 export configuration logic to centralize the determination of pipeline models, experimental native export toggles, NVIDIA CUDA export capabilities, and backend preferences across all export operations.

* **Tests**
  * Added comprehensive test suite for MP4 export routing with detailed coverage of default behavior, legacy pipeline fallbacks, smoke export modes, and NVIDIA CUDA feature scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->