### PR TITLE
refactor(editor): extract MP4 export settings

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -89,6 +89,7 @@ import {
 import { ExtensionIcon } from "./ExtensionIcon";
 import { calculateMp4ExportDimensions, calculateMp4SourceDimensions } from "./exportDimensions";
 import { resolveMp4ExportRouting } from "./mp4ExportRouting";
+import { resolveMp4ExportSettings } from "./mp4ExportSettings";
 import { useNvidiaCudaExportOptIn } from "./useNvidiaCudaExportOptIn";
 
 const PhCursorFill = (props: { className?: string; weight?: "fill" | "regular" }) => (
@@ -4125,17 +4126,19 @@ export default function VideoEditor() {
 					}
 				} else {
 					// MP4 Export
-					const quality = smokeExportConfig.enabled
-						? (smokeExportConfig.quality ?? settings.quality ?? exportQuality)
-						: (settings.quality ?? exportQuality);
-					const encodingMode = smokeExportConfig.enabled
-						? (smokeExportConfig.encodingMode ??
-							settings.encodingMode ??
-							exportEncodingMode)
-						: (settings.encodingMode ?? exportEncodingMode);
-					const selectedMp4FrameRate = smokeExportConfig.enabled
-						? (smokeExportConfig.fps ?? settings.mp4FrameRate ?? mp4FrameRate)
-						: (settings.mp4FrameRate ?? mp4FrameRate);
+					const { quality, encodingMode, selectedMp4FrameRate } =
+						resolveMp4ExportSettings({
+							smokeExportConfig: {
+								enabled: smokeExportConfig.enabled,
+								quality: smokeExportConfig.quality,
+								encodingMode: smokeExportConfig.encodingMode,
+								fps: smokeExportConfig.fps,
+							},
+							settings,
+							exportQuality,
+							exportEncodingMode,
+							mp4FrameRate,
+						});
 					const {
 						pipelineModel,
 						useExperimentalNativeExport,

--- a/src/components/video-editor/mp4ExportSettings.test.ts
+++ b/src/components/video-editor/mp4ExportSettings.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveMp4ExportSettings } from "./mp4ExportSettings";
+
+const baseOptions = {
+	smokeExportConfig: {
+		enabled: false,
+	},
+	settings: {},
+	exportQuality: "high" as const,
+	exportEncodingMode: "balanced" as const,
+	mp4FrameRate: 30 as const,
+};
+
+describe("resolveMp4ExportSettings", () => {
+	it("uses editor defaults when neither menu settings nor smoke settings override them", () => {
+		expect(resolveMp4ExportSettings(baseOptions)).toEqual({
+			quality: "high",
+			encodingMode: "balanced",
+			selectedMp4FrameRate: 30,
+		});
+	});
+
+	it("prefers explicit menu settings over editor defaults for normal exports", () => {
+		expect(
+			resolveMp4ExportSettings({
+				...baseOptions,
+				settings: {
+					quality: "source",
+					encodingMode: "quality",
+					mp4FrameRate: 60,
+				},
+			}),
+		).toEqual({
+			quality: "source",
+			encodingMode: "quality",
+			selectedMp4FrameRate: 60,
+		});
+	});
+
+	it("prefers smoke URL settings over menu settings when smoke export is enabled", () => {
+		expect(
+			resolveMp4ExportSettings({
+				...baseOptions,
+				smokeExportConfig: {
+					enabled: true,
+					quality: "medium",
+					encodingMode: "fast",
+					fps: 24,
+				},
+				settings: {
+					quality: "source",
+					encodingMode: "quality",
+					mp4FrameRate: 60,
+				},
+			}),
+		).toEqual({
+			quality: "medium",
+			encodingMode: "fast",
+			selectedMp4FrameRate: 24,
+		});
+	});
+
+	it("falls back from incomplete smoke settings to menu settings and editor defaults", () => {
+		expect(
+			resolveMp4ExportSettings({
+				...baseOptions,
+				smokeExportConfig: {
+					enabled: true,
+					quality: "good",
+				},
+				settings: {
+					encodingMode: "quality",
+				},
+			}),
+		).toEqual({
+			quality: "good",
+			encodingMode: "quality",
+			selectedMp4FrameRate: 30,
+		});
+	});
+});

--- a/src/components/video-editor/mp4ExportSettings.ts
+++ b/src/components/video-editor/mp4ExportSettings.ts
@@ -1,0 +1,42 @@
+import type {
+	ExportEncodingMode,
+	ExportMp4FrameRate,
+	ExportQuality,
+	ExportSettings,
+} from "@/lib/exporter";
+import type { SmokeExportConfig } from "./smokeExportConfig";
+
+export type ResolvedMp4ExportSettings = {
+	quality: ExportQuality;
+	encodingMode: ExportEncodingMode;
+	selectedMp4FrameRate: ExportMp4FrameRate;
+};
+
+export function resolveMp4ExportSettings({
+	smokeExportConfig,
+	settings,
+	exportQuality,
+	exportEncodingMode,
+	mp4FrameRate,
+}: {
+	smokeExportConfig: Pick<
+		SmokeExportConfig,
+		"enabled" | "quality" | "encodingMode" | "fps"
+	>;
+	settings: Pick<ExportSettings, "quality" | "encodingMode" | "mp4FrameRate">;
+	exportQuality: ExportQuality;
+	exportEncodingMode: ExportEncodingMode;
+	mp4FrameRate: ExportMp4FrameRate;
+}): ResolvedMp4ExportSettings {
+	return {
+		quality: smokeExportConfig.enabled
+			? (smokeExportConfig.quality ?? settings.quality ?? exportQuality)
+			: (settings.quality ?? exportQuality),
+		encodingMode: smokeExportConfig.enabled
+			? (smokeExportConfig.encodingMode ?? settings.encodingMode ?? exportEncodingMode)
+			: (settings.encodingMode ?? exportEncodingMode),
+		selectedMp4FrameRate: smokeExportConfig.enabled
+			? (smokeExportConfig.fps ?? settings.mp4FrameRate ?? mp4FrameRate)
+			: (settings.mp4FrameRate ?? mp4FrameRate),
+	};
+}


### PR DESCRIPTION
﻿## Description
Extract MP4 export setting precedence from `VideoEditor.tsx` into a pure `resolveMp4ExportSettings` helper.

## Motivation
The editor component should not inline the precedence rules for smoke export URL settings, one-off export menu settings, and persisted editor defaults. Naming this decision boundary makes the MP4 export orchestration easier to test and keeps `VideoEditor.tsx` moving toward smaller responsibilities.

## Type of Change
- Refactor
- Tests

## Related Issue(s)
- Follow-up to #564

## Changes Made
- Added `src/components/video-editor/mp4ExportSettings.ts` with a pure resolver for MP4 quality, encoding mode, and frame rate.
- Added tests covering editor defaults, normal export settings, smoke export overrides, and partial smoke fallback behavior.
- Replaced the inline MP4 settings selection block in `VideoEditor.tsx` with the resolver.

## Scope Note
- No UI changes.
- No exporter implementation changes.
- No route/backend/native helper/preload/IPC changes.
- No Linux NVIDIA behavior changes.
- This only names and tests an existing precedence rule.

## Testing Guide
1. Export MP4 with existing editor defaults and confirm quality/encoding/FPS behavior is unchanged.
2. Export MP4 after changing the export menu quality, encoding mode, and FPS and confirm those one-off settings still apply.
3. For smoke export URLs, confirm `smokeQuality`, `smokeEncodingMode`, and `smokeFps` still override menu/default settings.

## Checklist
- [x] One small architectural slice only
- [x] Behavior-preserving extraction
- [x] Focused tests for moved precedence rules
- [x] No generated binaries or local probes included
- [x] Ready for review

## Local Checks
- `npm test -- src/components/video-editor/mp4ExportSettings.test.ts`
- `npm test -- src/components/video-editor/mp4ExportRouting.test.ts src/components/video-editor/useNvidiaCudaExportOptIn.test.ts`
- `npm test -- src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts electron/ipc/export/native-video.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/mp4ExportSettings.ts src/components/video-editor/mp4ExportSettings.test.ts`
- `git diff --check`

## Runtime/Repro Evidence
Not run. This is a pure renderer-side settings precedence extraction with no native/preload/IPC contract change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for MP4 export settings resolution to enhance maintainability.

* **Tests**
  * Added comprehensive test coverage for MP4 export settings resolution across multiple scenarios.

---

**Note:** This release contains internal code improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->