### PR TITLE
refactor(editor): extract export start settings

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -88,6 +88,7 @@ import {
 } from "@/utils/aspectRatioUtils";
 import { ExtensionIcon } from "./ExtensionIcon";
 import { calculateMp4ExportDimensions, calculateMp4SourceDimensions } from "./exportDimensions";
+import { resolveExportStartSettings } from "./exportStartSettings";
 import { resolveExportStatusModel } from "./exportStatusModel";
 import { resolveMp4ExportRouting } from "./mp4ExportRouting";
 import { resolveMp4ExportSettings } from "./mp4ExportSettings";
@@ -4666,31 +4667,19 @@ export default function VideoEditor() {
 
 		const sourceWidth = video.videoWidth || 1920;
 		const sourceHeight = video.videoHeight || 1080;
-		const gifDimensions = calculateOutputDimensions(
+		const settings = resolveExportStartSettings({
 			sourceWidth,
 			sourceHeight,
+			exportFormat,
+			exportEncodingMode,
+			exportQuality,
+			mp4FrameRate,
+			exportBackendPreference,
+			exportPipelineModel,
+			gifFrameRate,
+			gifLoop,
 			gifSizePreset,
-			GIF_SIZE_PRESETS,
-		);
-
-		const settings: ExportSettings = {
-			format: exportFormat,
-			encodingMode: exportFormat === "mp4" ? exportEncodingMode : undefined,
-			mp4FrameRate: exportFormat === "mp4" ? mp4FrameRate : undefined,
-			backendPreference: exportFormat === "mp4" ? exportBackendPreference : undefined,
-			pipelineModel: exportFormat === "mp4" ? exportPipelineModel : undefined,
-			quality: exportFormat === "mp4" ? exportQuality : undefined,
-			gifConfig:
-				exportFormat === "gif"
-					? {
-							frameRate: gifFrameRate,
-							loop: gifLoop,
-							sizePreset: gifSizePreset,
-							width: gifDimensions.width,
-							height: gifDimensions.height,
-						}
-					: undefined,
-		};
+		});
 
 		setExportError(null);
 		setExportedFilePath(undefined);

--- a/src/components/video-editor/exportStartSettings.test.ts
+++ b/src/components/video-editor/exportStartSettings.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { resolveExportStartSettings } from "./exportStartSettings";
+
+const baseOptions = {
+	sourceWidth: 1920,
+	sourceHeight: 1080,
+	exportFormat: "mp4" as const,
+	exportEncodingMode: "balanced" as const,
+	exportQuality: "good" as const,
+	mp4FrameRate: 30 as const,
+	exportBackendPreference: "auto" as const,
+	exportPipelineModel: "modern" as const,
+	gifFrameRate: 20 as const,
+	gifLoop: true,
+	gifSizePreset: "medium" as const,
+};
+
+describe("resolveExportStartSettings", () => {
+	it("preserves MP4 dropdown settings", () => {
+		expect(resolveExportStartSettings(baseOptions)).toEqual({
+			format: "mp4",
+			encodingMode: "balanced",
+			mp4FrameRate: 30,
+			backendPreference: "auto",
+			pipelineModel: "modern",
+			quality: "good",
+			gifConfig: undefined,
+		});
+	});
+
+	it("omits MP4-only fields and resolves GIF dimensions for GIF exports", () => {
+		expect(
+			resolveExportStartSettings({
+				...baseOptions,
+				sourceWidth: 2560,
+				sourceHeight: 1440,
+				exportFormat: "gif",
+				gifFrameRate: 15,
+				gifLoop: false,
+				gifSizePreset: "medium",
+			}),
+		).toEqual({
+			format: "gif",
+			encodingMode: undefined,
+			mp4FrameRate: undefined,
+			backendPreference: undefined,
+			pipelineModel: undefined,
+			quality: undefined,
+			gifConfig: {
+				frameRate: 15,
+				loop: false,
+				sizePreset: "medium",
+				width: 1280,
+				height: 720,
+			},
+		});
+	});
+
+	it("keeps original GIF dimensions when the original preset is selected", () => {
+		expect(
+			resolveExportStartSettings({
+				...baseOptions,
+				sourceWidth: 1234,
+				sourceHeight: 678,
+				exportFormat: "gif",
+				gifSizePreset: "original",
+			}).gifConfig,
+		).toMatchObject({
+			sizePreset: "original",
+			width: 1234,
+			height: 678,
+		});
+	});
+});

--- a/src/components/video-editor/exportStartSettings.ts
+++ b/src/components/video-editor/exportStartSettings.ts
@@ -1,0 +1,63 @@
+import {
+	calculateOutputDimensions,
+	type ExportBackendPreference,
+	type ExportEncodingMode,
+	type ExportFormat,
+	type ExportMp4FrameRate,
+	type ExportPipelineModel,
+	type ExportQuality,
+	type ExportSettings,
+	GIF_SIZE_PRESETS,
+	type GifFrameRate,
+	type GifSizePreset,
+} from "@/lib/exporter";
+
+export function resolveExportStartSettings({
+	sourceWidth,
+	sourceHeight,
+	exportFormat,
+	exportEncodingMode,
+	exportQuality,
+	mp4FrameRate,
+	exportBackendPreference,
+	exportPipelineModel,
+	gifFrameRate,
+	gifLoop,
+	gifSizePreset,
+}: {
+	sourceWidth: number;
+	sourceHeight: number;
+	exportFormat: ExportFormat;
+	exportEncodingMode: ExportEncodingMode;
+	exportQuality: ExportQuality;
+	mp4FrameRate: ExportMp4FrameRate;
+	exportBackendPreference: ExportBackendPreference;
+	exportPipelineModel: ExportPipelineModel;
+	gifFrameRate: GifFrameRate;
+	gifLoop: boolean;
+	gifSizePreset: GifSizePreset;
+}): ExportSettings {
+	const gifDimensions =
+		exportFormat === "gif"
+			? calculateOutputDimensions(sourceWidth, sourceHeight, gifSizePreset, GIF_SIZE_PRESETS)
+			: null;
+
+	return {
+		format: exportFormat,
+		encodingMode: exportFormat === "mp4" ? exportEncodingMode : undefined,
+		mp4FrameRate: exportFormat === "mp4" ? mp4FrameRate : undefined,
+		backendPreference: exportFormat === "mp4" ? exportBackendPreference : undefined,
+		pipelineModel: exportFormat === "mp4" ? exportPipelineModel : undefined,
+		quality: exportFormat === "mp4" ? exportQuality : undefined,
+		gifConfig:
+			exportFormat === "gif" && gifDimensions
+				? {
+						frameRate: gifFrameRate,
+						loop: gifLoop,
+						sizePreset: gifSizePreset,
+						width: gifDimensions.width,
+						height: gifDimensions.height,
+					}
+				: undefined,
+	};
+}


### PR DESCRIPTION
## Description

Extracts the export-start settings builder from `VideoEditor.tsx` into a small pure module, `exportStartSettings.ts`.

## Motivation

`VideoEditor.tsx` should coordinate user intent, not own every export request-building detail. This slice moves the dropdown-to-`ExportSettings` mapping into a focused, tested function while preserving existing MP4/GIF settings behavior.

## Type of Change

- Refactor
- Tests

## Related Issue(s)

None.

## Changes Made

- Added `resolveExportStartSettings` for constructing `ExportSettings` from dropdown state and source dimensions.
- Preserved MP4 settings mapping for quality, encoding mode, FPS, backend preference, and pipeline model.
- Preserved GIF settings mapping, including GIF preset dimension resolution via `calculateOutputDimensions` and `GIF_SIZE_PRESETS`.
- Updated `VideoEditor.tsx` to call the resolver when starting an export from the dropdown.
- Added focused unit tests for MP4 settings, GIF resized dimensions, and original GIF dimensions.

## Scope Note

This PR does not change export execution, export routing, native/NVIDIA behavior, save/finalize behavior, UI copy, project persistence, or packaged build settings. It only extracts the existing dropdown settings construction into a tested pure function.

## Testing Guide

1. Open the editor.
2. Start an MP4 export from the dropdown and confirm the selected MP4 settings are still applied.
3. Switch to GIF, choose a size preset, and confirm export still uses the expected GIF dimensions/settings.

## Checklist

- [x] Focused branch from latest `main`
- [x] Small architecture slice only
- [x] Added focused tests
- [x] Typecheck passes
- [x] Scoped Biome passes
- [x] No runtime/export behavior intentionally changed

## Local Checks

- `npm test -- src/components/video-editor/exportStartSettings.test.ts src/components/video-editor/exportStatusModel.test.ts src/components/video-editor/mp4ExportSettings.test.ts src/components/video-editor/mp4ExportRouting.test.ts src/components/video-editor/useNvidiaCudaExportOptIn.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/exportStartSettings.ts src/components/video-editor/exportStartSettings.test.ts`
- `git diff --check`

## Runtime/Repro Evidence

Not run. This is a pure settings-construction extraction with no exporter/native/runtime path changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video export settings now correctly preserve MP4-specific values and GIF-specific configurations without data loss.
  * GIF exports properly compute output dimensions based on selected presets and clear format-incompatible fields.
  * The GIF original preset now accurately maintains user-provided source dimensions.

* **Tests**
  * Added comprehensive test coverage for export settings initialization across all format and preset combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->