### PR TITLE
refactor(editor): extract export progress state

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -88,6 +88,7 @@ import {
 } from "@/utils/aspectRatioUtils";
 import { ExtensionIcon } from "./ExtensionIcon";
 import { calculateMp4ExportDimensions, calculateMp4SourceDimensions } from "./exportDimensions";
+import { resolveSavingExportProgress } from "./exportProgressState";
 import { resolveExportStartSettings } from "./exportStartSettings";
 import { resolveExportStatusModel } from "./exportStatusModel";
 import { resolveMp4ExportRouting } from "./mp4ExportRouting";
@@ -1213,17 +1214,7 @@ export default function VideoEditor() {
 	]);
 
 	const markExportAsSaving = useCallback(() => {
-		setExportProgress((previous) => ({
-			currentFrame: previous?.totalFrames ?? previous?.currentFrame ?? 1,
-			totalFrames: previous?.totalFrames ?? previous?.currentFrame ?? 1,
-			percentage: 100,
-			estimatedTimeRemaining: 0,
-			renderFps: previous?.renderFps,
-			renderBackend: previous?.renderBackend,
-			encodeBackend: previous?.encodeBackend,
-			encoderName: previous?.encoderName,
-			phase: "saving",
-		}));
+		setExportProgress(resolveSavingExportProgress);
 	}, []);
 
 	const handleShowCursorChange = useCallback((nextShowCursor: boolean) => {

--- a/src/components/video-editor/exportProgressState.test.ts
+++ b/src/components/video-editor/exportProgressState.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { ExportProgress } from "@/lib/exporter";
+import { resolveSavingExportProgress } from "./exportProgressState";
+
+function progress(overrides: Partial<ExportProgress> = {}): ExportProgress {
+	return {
+		currentFrame: 24,
+		totalFrames: 120,
+		percentage: 20,
+		estimatedTimeRemaining: 12,
+		...overrides,
+	};
+}
+
+describe("resolveSavingExportProgress", () => {
+	it("marks progress as saving while preserving runtime diagnostics", () => {
+		expect(
+			resolveSavingExportProgress(
+				progress({
+					renderFps: 144.25,
+					renderBackend: "webgpu",
+					encodeBackend: "ffmpeg",
+					encoderName: "h264_nvenc",
+				}),
+			),
+		).toEqual({
+			currentFrame: 120,
+			totalFrames: 120,
+			percentage: 100,
+			estimatedTimeRemaining: 0,
+			renderFps: 144.25,
+			renderBackend: "webgpu",
+			encodeBackend: "ffmpeg",
+			encoderName: "h264_nvenc",
+			phase: "saving",
+		});
+	});
+
+	it("preserves the existing zero-total-frame behavior", () => {
+		expect(
+			resolveSavingExportProgress(
+				progress({
+					currentFrame: 36,
+					totalFrames: 0,
+				}),
+			),
+		).toMatchObject({
+			currentFrame: 0,
+			totalFrames: 0,
+			phase: "saving",
+		});
+	});
+
+	it("uses a minimal fallback when there is no previous progress", () => {
+		expect(resolveSavingExportProgress(null)).toEqual({
+			currentFrame: 1,
+			totalFrames: 1,
+			percentage: 100,
+			estimatedTimeRemaining: 0,
+			renderFps: undefined,
+			renderBackend: undefined,
+			encodeBackend: undefined,
+			encoderName: undefined,
+			phase: "saving",
+		});
+	});
+});

--- a/src/components/video-editor/exportProgressState.ts
+++ b/src/components/video-editor/exportProgressState.ts
@@ -1,0 +1,15 @@
+import type { ExportProgress } from "@/lib/exporter";
+
+export function resolveSavingExportProgress(previous: ExportProgress | null): ExportProgress {
+	return {
+		currentFrame: previous?.totalFrames ?? previous?.currentFrame ?? 1,
+		totalFrames: previous?.totalFrames ?? previous?.currentFrame ?? 1,
+		percentage: 100,
+		estimatedTimeRemaining: 0,
+		renderFps: previous?.renderFps,
+		renderBackend: previous?.renderBackend,
+		encodeBackend: previous?.encodeBackend,
+		encoderName: previous?.encoderName,
+		phase: "saving",
+	};
+}


### PR DESCRIPTION
## Description

Extracts the export saving-progress state transition from `VideoEditor.tsx` into a small pure module, `exportProgressState.ts`.

## Motivation

`VideoEditor.tsx` still owns export orchestration and UI state transitions. This slice moves one pure transition out of the component without touching exporter construction, Electron save APIs, native routing, smoke reports, or UI copy.

## Type of Change

- Refactor
- Tests

## Related Issue(s)

None.

## Changes Made

- Added `resolveSavingExportProgress` for deriving the progress state shown while the save dialog/finalize path is active.
- Updated `markExportAsSaving` to call the pure transition through `setExportProgress`.
- Added unit tests for preserving runtime diagnostics, existing frame fallback behavior, and the no-previous-progress fallback.

## Scope Note

This PR does not change export execution, save/finalize behavior, native/NVIDIA routing, smoke export reports, UI copy, project persistence, or packaged build settings. It only extracts the existing saving-progress state transition into a tested pure function.

## Testing Guide

1. Start an export and reach the save/finalize step.
2. Confirm the export dropdown still shows the save/saving state as before.
3. Optional: cancel the save dialog and retry save to confirm pending-save behavior is unchanged.

## Checklist

- [x] Focused branch from latest `main`
- [x] Small architecture slice only
- [x] Added focused tests
- [x] Typecheck passes
- [x] Scoped Biome passes
- [x] No runtime/export behavior intentionally changed

## Local Checks

- `npm test -- src/components/video-editor/exportProgressState.test.ts src/components/video-editor/exportStatusModel.test.ts src/components/video-editor/exportStartSettings.test.ts`
- `npm test -- src/components/video-editor/exportProgressState.test.ts src/components/video-editor/exportStartSettings.test.ts src/components/video-editor/exportStatusModel.test.ts src/components/video-editor/mp4ExportSettings.test.ts src/components/video-editor/mp4ExportRouting.test.ts src/components/video-editor/useNvidiaCudaExportOptIn.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/exportProgressState.ts src/components/video-editor/exportProgressState.test.ts`
- `npx biome check --formatter-enabled=false src/components/video-editor/VideoEditor.tsx src/components/video-editor/exportProgressState.ts src/components/video-editor/exportProgressState.test.ts src/components/video-editor/exportStartSettings.ts src/components/video-editor/exportStatusModel.ts src/components/video-editor/mp4ExportSettings.ts src/components/video-editor/mp4ExportRouting.ts src/components/video-editor/useNvidiaCudaExportOptIn.ts`
- `git diff --check`

## Runtime/Repro Evidence

Not run. This is a pure progress-state extraction with no exporter/native/save path changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved export progress state handling during the video saving phase.

* **Tests**
  * Added test coverage for export progress saving functionality to ensure accurate frame tracking and completion metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->