### PR TITLE
fix(hud): keep overlay visible when target enters fullscreen

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -375,6 +375,9 @@ export function createHudOverlayWindow(): BrowserWindow {
 		hasShadow: false,
 		show: false,
 		focusable: false,
+		// On macOS, `type: 'panel'` lets a transparent, always-on-top window
+		// float over apps that enter native fullscreen on their own Space.
+		...(process.platform === "darwin" ? ({ type: "panel" } as const) : {}),
 		webPreferences: {
 			preload: path.join(electronWindowsDir, "preload.mjs"),
 			nodeIntegration: false,


### PR DESCRIPTION
## Summary
- Add `type: 'panel'` to the HUD BrowserWindow on darwin so the overlay floats over fullscreen Spaces.
- No changes to recording pipeline, IPC, or Windows/Linux paths.

## Why
On macOS, when the recorded app enters native fullscreen via the green title-bar button or `cmd+ctrl+F`, the HUD overlay disappears from view. Fullscreen apps live on their own Space, and a transparent alwaysOnTop window without a window type does not follow. The tray icon remains as a fallback, but the primary recording controls — pause, stop, drag — are unreachable until the user exits fullscreen.

`type: 'panel'` is the documented Electron path for floating over fullscreen Spaces. `setVisibleOnAllWorkspaces({ visibleOnFullScreen: true })` was considered, but it requires the window to be focusable per electron#36364; the HUD is created with `focusable: false`. `createUpdateToastWindow()` already uses `setVisibleOnAllWorkspaces` successfully — that window is `focusable: true`, consistent with the electron#36364 constraint.

This PR intentionally does not include the area-selector or sourceRect changes from #126 — those are separate, larger PRs.

## Verification
- Manual run on macOS 14, single display:
  - HUD remains visible when another window enters native fullscreen via the green title-bar button.
  - Drag, click-through passthrough, popover buttons, and `setContentProtection` HUD-exclusion from screenshots observed normal during the session.
  - Recording start → stop produces a valid file; editor opens on stop.
- `npx tsc --noEmit` passes.

## Related Issue(s)
- Closes #569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HUD overlay window to properly display over fullscreen applications on macOS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->