### PR TITLE
fix(recording): preserve browser cursor after WGC fallback

### DIFF
--- a/src/hooks/useScreenRecorder.test.ts
+++ b/src/hooks/useScreenRecorder.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createProcessedMicrophoneConstraints,
 	normalizeBrowserMicrophoneProfile,
+	resolveBrowserCaptureCursorPolicy,
 } from "./useScreenRecorder";
 
 type RecordingState = "inactive" | "recording" | "paused";
@@ -105,6 +106,26 @@ describe("createProcessedMicrophoneConstraints", () => {
 		expect(normalizeBrowserMicrophoneProfile("RAW")).toBe("raw");
 		expect(normalizeBrowserMicrophoneProfile("unknown")).toBe("no-agc");
 		expect(normalizeBrowserMicrophoneProfile(null)).toBe("no-agc");
+	});
+});
+
+describe("resolveBrowserCaptureCursorPolicy", () => {
+	it("preserves the existing hidden-cursor browser policy by default", () => {
+		expect(resolveBrowserCaptureCursorPolicy()).toEqual({
+			streamCursor: "never",
+			hideOsCursorBeforeRecording: true,
+			hideEditorOverlayCursorByDefault: true,
+		});
+	});
+
+	it("uses the browser captured cursor after native Windows capture fails to start", () => {
+		expect(
+			resolveBrowserCaptureCursorPolicy({ nativeWindowsCaptureStartFailed: true }),
+		).toEqual({
+			streamCursor: "always",
+			hideOsCursorBeforeRecording: false,
+			hideEditorOverlayCursorByDefault: true,
+		});
 	});
 });
 

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1544,7 +1544,10 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 
 			if (browserCursorPolicy.hideOsCursorBeforeRecording) {
 				try {
-					await window.electronAPI.hideOsCursor?.();
+					const hideCursorResult = await window.electronAPI.hideOsCursor?.();
+					if (hideCursorResult && !hideCursorResult.success) {
+						console.warn("Could not hide OS cursor before recording.", hideCursorResult);
+					}
 				} catch {
 					console.warn("Could not hide OS cursor before recording.");
 				}

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -46,6 +46,12 @@ export type BrowserMicrophoneProfile =
 	| "no-echo"
 	| "no-noise-suppression"
 	| "raw";
+type BrowserCaptureCursorMode = "always" | "never";
+export type BrowserCaptureCursorPolicy = {
+	streamCursor: BrowserCaptureCursorMode;
+	hideOsCursorBeforeRecording: boolean;
+	hideEditorOverlayCursorByDefault: boolean;
+};
 const DEFAULT_BROWSER_MICROPHONE_PROFILE: BrowserMicrophoneProfile = "no-agc";
 const BROWSER_MICROPHONE_PROFILES = new Set<BrowserMicrophoneProfile>([
 	"processed",
@@ -181,6 +187,28 @@ export function normalizeBrowserMicrophoneProfile(value?: string | null): Browse
 	return normalized && BROWSER_MICROPHONE_PROFILES.has(normalized as BrowserMicrophoneProfile)
 		? (normalized as BrowserMicrophoneProfile)
 		: DEFAULT_BROWSER_MICROPHONE_PROFILE;
+}
+
+export function resolveBrowserCaptureCursorPolicy({
+	nativeWindowsCaptureStartFailed = false,
+}: {
+	nativeWindowsCaptureStartFailed?: boolean;
+} = {}): BrowserCaptureCursorPolicy {
+	if (nativeWindowsCaptureStartFailed) {
+		// If WGC already failed, avoid the telemetry overlay path that can lag on
+		// constrained Windows systems; keep the browser-captured cursor instead.
+		return {
+			streamCursor: "always",
+			hideOsCursorBeforeRecording: false,
+			hideEditorOverlayCursorByDefault: true,
+		};
+	}
+
+	return {
+		streamCursor: "never",
+		hideOsCursorBeforeRecording: true,
+		hideEditorOverlayCursorByDefault: true,
+	};
 }
 
 export function createProcessedMicrophoneConstraints(
@@ -1331,6 +1359,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				typeof window.electronAPI.startNativeScreenRecording === "function";
 
 			let useNativeWindowsCapture = false;
+			let nativeWindowsCaptureStartFailed = false;
 			if (
 				platform === "win32" &&
 				(selectedSource.id?.startsWith("screen:") ||
@@ -1385,7 +1414,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				);
 				if (!nativeResult.success) {
 					if (useNativeWindowsCapture) {
-						hideEditorOverlayCursorByDefault.current = true;
+						nativeWindowsCaptureStartFailed = true;
 						console.warn(
 							"Native Windows capture failed, falling back to browser capture:",
 							nativeResult.error ?? nativeResult.message,
@@ -1495,7 +1524,11 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				}
 			}
 
-			hideEditorOverlayCursorByDefault.current = true;
+			const browserCursorPolicy = resolveBrowserCaptureCursorPolicy({
+				nativeWindowsCaptureStartFailed,
+			});
+			hideEditorOverlayCursorByDefault.current =
+				browserCursorPolicy.hideEditorOverlayCursorByDefault;
 
 			const wantsAudioCapture = microphoneEnabled || systemAudioEnabled;
 			const browserCaptureSource = await resolveBrowserCaptureSource(selectedSource);
@@ -1509,10 +1542,12 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 				);
 			}
 
-			try {
-				await window.electronAPI.hideOsCursor?.();
-			} catch {
-				console.warn("Could not hide OS cursor before recording.");
+			if (browserCursorPolicy.hideOsCursorBeforeRecording) {
+				try {
+					await window.electronAPI.hideOsCursor?.();
+				} catch {
+					console.warn("Could not hide OS cursor before recording.");
+				}
 			}
 
 			let videoTrack: MediaStreamTrack | undefined;
@@ -1527,9 +1562,9 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					maxHeight: TARGET_HEIGHT,
 					maxFrameRate: TARGET_FRAME_RATE,
 					minFrameRate: MIN_FRAME_RATE,
-					googCaptureCursor: false,
+					googCaptureCursor: browserCursorPolicy.streamCursor === "always",
 				},
-				cursor: "never" as const,
+				cursor: browserCursorPolicy.streamCursor,
 			};
 
 			if (wantsAudioCapture) {
@@ -1542,7 +1577,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 							width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
 							height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
 							frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
-							cursor: "never",
+							cursor: browserCursorPolicy.streamCursor,
 						},
 						selfBrowserSurface: "exclude",
 						surfaceSwitching: "exclude",
@@ -1653,7 +1688,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 								width: { ideal: TARGET_WIDTH, max: TARGET_WIDTH },
 								height: { ideal: TARGET_HEIGHT, max: TARGET_HEIGHT },
 								frameRate: { ideal: TARGET_FRAME_RATE, max: TARGET_FRAME_RATE },
-								cursor: "never",
+								cursor: browserCursorPolicy.streamCursor,
 							},
 							selfBrowserSurface: "exclude",
 							surfaceSwitching: "exclude",


### PR DESCRIPTION
## Summary
- Detect the path where Windows WGC is available but fails to start, then fall back to browser-captured cursor instead of the telemetry overlay path.
- Skip OS cursor hiding only for that WGC-start-failed browser fallback.
- Keep the existing browser hidden-cursor policy for regular browser capture.

## Motivation
Follow-up for #393 and the v1.3.0 Discord report where native Windows capture fails to start, browser fallback records, and the cursor appears left behind or delayed.

## Testing
- npm test -- src/hooks/useScreenRecorder.test.ts
- npx tsc --noEmit --pretty false
- npx biome check --formatter-enabled=false src/hooks/useScreenRecorder.ts src/hooks/useScreenRecorder.test.ts
- git diff --check

## Notes
This does not change successful WGC capture or the native helper. It still needs runtime smoke on a Windows machine where WGC fails and browser fallback is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cursor handling during screen recordings: when native Windows capture fails, the recorder falls back to keeping the browser's visible cursor and disables automatic OS-cursor hiding; otherwise the OS cursor is hidden and browser stream omits the cursor. This behavior is applied consistently across recording paths.

* **Tests**
  * Added unit tests verifying cursor policy and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->