### PR TITLE
fix(recording): compact HUD fallback on Windows 10

### DIFF
--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getHudOverlayWindowBounds } from "./hudOverlayBounds";
+import {
+	getHudOverlayWindowBounds,
+	resizeHudOverlayFallbackBounds,
+} from "./hudOverlayBounds";
 
 describe("getHudOverlayWindowBounds", () => {
 	const workArea = {
@@ -68,6 +71,75 @@ describe("getHudOverlayWindowBounds", () => {
 			y: 20,
 			width: 640,
 			height: 420,
+		});
+	});
+});
+
+describe("resizeHudOverlayFallbackBounds", () => {
+	const workArea = {
+		x: 0,
+		y: 0,
+		width: 1920,
+		height: 1080,
+	};
+
+	it("preserves the dragged bottom edge when expanding", () => {
+		expect(
+			resizeHudOverlayFallbackBounds(
+				workArea,
+				{
+					x: 420,
+					y: 700,
+					width: 860,
+					height: 160,
+				},
+				true,
+			),
+		).toEqual({
+			x: 420,
+			y: 320,
+			width: 860,
+			height: 540,
+		});
+	});
+
+	it("preserves the dragged bottom edge when compacting", () => {
+		expect(
+			resizeHudOverlayFallbackBounds(
+				workArea,
+				{
+					x: 420,
+					y: 320,
+					width: 860,
+					height: 540,
+				},
+				false,
+			),
+		).toEqual({
+			x: 420,
+			y: 700,
+			width: 860,
+			height: 160,
+		});
+	});
+
+	it("keeps resized fallback bounds inside the display work area", () => {
+		expect(
+			resizeHudOverlayFallbackBounds(
+				workArea,
+				{
+					x: 1500,
+					y: 900,
+					width: 860,
+					height: 160,
+				},
+				true,
+			),
+		).toEqual({
+			x: 1060,
+			y: 520,
+			width: 860,
+			height: 540,
 		});
 	});
 });

--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { getHudOverlayWindowBounds } from "./hudOverlayBounds";
+
+describe("getHudOverlayWindowBounds", () => {
+	const workArea = {
+		x: 120,
+		y: 40,
+		width: 1920,
+		height: 1040,
+	};
+
+	it("uses the full work area when mouse passthrough is supported", () => {
+		expect(getHudOverlayWindowBounds(workArea, true)).toEqual(workArea);
+	});
+
+	it("uses a bottom-centered compact fallback when mouse passthrough is unavailable", () => {
+		expect(getHudOverlayWindowBounds(workArea, false)).toEqual({
+			x: 650,
+			y: 920,
+			width: 860,
+			height: 160,
+		});
+	});
+
+	it("expands the non-passthrough fallback for HUD menus and hover interaction", () => {
+		expect(getHudOverlayWindowBounds(workArea, false, true)).toEqual({
+			x: 650,
+			y: 540,
+			width: 860,
+			height: 540,
+		});
+	});
+
+	it("keeps the compact fallback inside small displays", () => {
+		expect(
+			getHudOverlayWindowBounds(
+				{
+					x: -100,
+					y: 20,
+					width: 640,
+					height: 420,
+				},
+				false,
+			),
+		).toEqual({
+			x: -100,
+			y: 280,
+			width: 640,
+			height: 160,
+		});
+	});
+
+	it("fits the expanded fallback inside small displays", () => {
+		expect(
+			getHudOverlayWindowBounds(
+				{
+					x: -100,
+					y: 20,
+					width: 640,
+					height: 420,
+				},
+				false,
+				true,
+			),
+		).toEqual({
+			x: -100,
+			y: 20,
+			width: 640,
+			height: 420,
+		});
+	});
+});

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -9,6 +9,10 @@ const NON_PASSTHROUGH_HUD_WIDTH_DIP = 860;
 const NON_PASSTHROUGH_HUD_COMPACT_HEIGHT_DIP = 160;
 const NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP = 540;
 
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
+}
+
 export function getHudOverlayWindowBounds(
 	workArea: HudOverlayWorkArea,
 	mousePassthroughSupported: boolean,
@@ -31,5 +35,21 @@ export function getHudOverlayWindowBounds(
 		y: Math.round(workArea.y + workArea.height - height),
 		width,
 		height,
+	};
+}
+
+export function resizeHudOverlayFallbackBounds(
+	workArea: HudOverlayWorkArea,
+	currentBounds: HudOverlayWorkArea,
+	fallbackExpanded: boolean,
+): HudOverlayWorkArea {
+	const nextBounds = getHudOverlayWindowBounds(workArea, false, fallbackExpanded);
+	const maxX = workArea.x + workArea.width - nextBounds.width;
+	const maxY = workArea.y + workArea.height - nextBounds.height;
+
+	return {
+		...nextBounds,
+		x: clamp(currentBounds.x, workArea.x, maxX),
+		y: clamp(currentBounds.y + currentBounds.height - nextBounds.height, workArea.y, maxY),
 	};
 }

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -1,0 +1,35 @@
+export interface HudOverlayWorkArea {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+const NON_PASSTHROUGH_HUD_WIDTH_DIP = 860;
+const NON_PASSTHROUGH_HUD_COMPACT_HEIGHT_DIP = 160;
+const NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP = 540;
+
+export function getHudOverlayWindowBounds(
+	workArea: HudOverlayWorkArea,
+	mousePassthroughSupported: boolean,
+	fallbackExpanded = false,
+): HudOverlayWorkArea {
+	if (mousePassthroughSupported) {
+		return { ...workArea };
+	}
+
+	const width = Math.min(workArea.width, NON_PASSTHROUGH_HUD_WIDTH_DIP);
+	const height = Math.min(
+		workArea.height,
+		fallbackExpanded
+			? NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP
+			: NON_PASSTHROUGH_HUD_COMPACT_HEIGHT_DIP,
+	);
+
+	return {
+		x: Math.round(workArea.x + (workArea.width - width) / 2),
+		y: Math.round(workArea.y + workArea.height - height),
+		width,
+		height,
+	};
+}

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app, BrowserWindow, ipcMain } from "electron";
 import { USER_DATA_PATH } from "./appPaths";
-import { getHudOverlayWindowBounds } from "./hudOverlayBounds";
+import {
+	getHudOverlayWindowBounds,
+	resizeHudOverlayFallbackBounds,
+} from "./hudOverlayBounds";
 import { getPackagedRendererBaseUrl } from "./rendererServer";
 
 const electronWindowsDir = path.dirname(fileURLToPath(import.meta.url));
@@ -253,7 +256,13 @@ function setHudOverlayFallbackExpanded(expanded: boolean) {
 		return;
 	}
 
-	hudOverlayWindow.setBounds(getHudOverlayBounds(), false);
+	const { workArea } = getHudOverlayDisplay();
+	const nextBounds = resizeHudOverlayFallbackBounds(
+		workArea,
+		hudOverlayWindow.getBounds(),
+		expanded,
+	);
+	hudOverlayWindow.setBounds(nextBounds, false);
 	positionUpdateToastWindow();
 	if (hudOverlayWindow.isVisible()) {
 		hudOverlayWindow.moveTop();

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app, BrowserWindow, ipcMain } from "electron";
 import { USER_DATA_PATH } from "./appPaths";
+import { getHudOverlayWindowBounds } from "./hudOverlayBounds";
 import { getPackagedRendererBaseUrl } from "./rendererServer";
 
 const electronWindowsDir = path.dirname(fileURLToPath(import.meta.url));
@@ -23,6 +24,7 @@ const WINDOW_ICON_PATH = path.join(
 let hudOverlayWindow: BrowserWindow | null = null;
 let hudOverlayHiddenFromCapture = true;
 let hudOverlayCaptureProtectionLoaded = false;
+let hudOverlayFallbackExpanded = false;
 let countdownWindow: BrowserWindow | null = null;
 let updateToastWindow: BrowserWindow | null = null;
 
@@ -183,12 +185,11 @@ function getHudOverlayDisplay() {
 
 function getHudOverlayBounds() {
 	const { workArea } = getHudOverlayDisplay();
-	return {
-		x: workArea.x,
-		y: workArea.y,
-		width: workArea.width,
-		height: workArea.height,
-	};
+	return getHudOverlayWindowBounds(
+		workArea,
+		isHudOverlayMousePassthroughSupported(),
+		hudOverlayFallbackExpanded,
+	);
 }
 
 function applyHudOverlayBounds() {
@@ -242,9 +243,27 @@ function positionUpdateToastWindow() {
 	updateToastWindow.moveTop();
 }
 
+function setHudOverlayFallbackExpanded(expanded: boolean) {
+	hudOverlayFallbackExpanded = expanded;
+	if (
+		!hudOverlayWindow ||
+		hudOverlayWindow.isDestroyed() ||
+		isHudOverlayMousePassthroughSupported()
+	) {
+		return;
+	}
+
+	hudOverlayWindow.setBounds(getHudOverlayBounds(), false);
+	positionUpdateToastWindow();
+	if (hudOverlayWindow.isVisible()) {
+		hudOverlayWindow.moveTop();
+	}
+}
+
 ipcMain.on("hud-overlay-set-ignore-mouse", (_event, ignore: boolean) => {
 	if (hudOverlayWindow && !hudOverlayWindow.isDestroyed()) {
 		if (!isHudOverlayMousePassthroughSupported()) {
+			setHudOverlayFallbackExpanded(!ignore);
 			hudOverlayWindow.setIgnoreMouseEvents(false);
 			return;
 		}
@@ -358,6 +377,7 @@ ipcMain.handle("set-hud-overlay-capture-protection", (_event, enabled: boolean) 
 
 export function createHudOverlayWindow(): BrowserWindow {
 	loadHudOverlayCaptureProtectionSetting();
+	hudOverlayFallbackExpanded = false;
 	const initialBounds = getHudOverlayBounds();
 	let hasShownHudWindow = false;
 

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -1,46 +1,45 @@
 import {
+	ArrowClockwiseIcon,
 	CaretUpIcon,
+	DotsThreeVerticalIcon,
 	MicrophoneIcon,
 	MicrophoneSlashIcon,
 	MinusIcon,
 	MonitorIcon,
-	DotsThreeVerticalIcon,
 	TimerIcon,
 	VideoCameraIcon,
 	VideoCameraSlashIcon,
 	XIcon,
-	ArrowClockwiseIcon,
 } from "@phosphor-icons/react";
 import { AnimatePresence, motion } from "motion/react";
+import { useEffect, useRef } from "react";
 import { RxDragHandleDots2 } from "react-icons/rx";
+import { Separator } from "@/components/ui/separator";
 import { useScopedT } from "../../contexts/I18nContext";
-import { useHudBarDrag } from "./hooks/useHudBarDrag";
 import { useMicrophoneDevices } from "../../hooks/useMicrophoneDevices";
-import { useLaunchWindowSystemState } from "./hooks/useLaunchWindowSystemState";
-import { useLaunchHudInteractionState } from "./hooks/useLaunchHudInteractionState";
-import { useLaunchWindowActions } from "./hooks/useLaunchWindowActions";
-import { useRecordingTimer } from "./hooks/useRecordingTimer";
 import { useScreenRecorder } from "../../hooks/useScreenRecorder";
 import { useVideoDevices } from "../../hooks/useVideoDevices";
-import { useWebcamPreviewOverlay } from "./hooks/useWebcamPreviewOverlay";
+import { Button } from "../ui/button";
+import { HudInteractionContext } from "./contexts/HudInteractionContext";
 import {
 	canToggleFloatingWebcamPreview,
 } from "./floatingWebcamPreview";
-import { LaunchPopoverCoordinatorProvider, useLaunchPopoverCoordinator } from "./popovers/LaunchPopoverCoordinator";
+import { useHudBarDrag } from "./hooks/useHudBarDrag";
+import { useLaunchHudInteractionState } from "./hooks/useLaunchHudInteractionState";
+import { useLaunchWindowActions } from "./hooks/useLaunchWindowActions";
+import { useLaunchWindowSystemState } from "./hooks/useLaunchWindowSystemState";
+import { useRecordingTimer } from "./hooks/useRecordingTimer";
+import { useWebcamPreviewOverlay } from "./hooks/useWebcamPreviewOverlay";
+import styles from "./LaunchWindow.module.css";
 import { CountdownPopover } from "./popovers/CountdownPopover";
+import { LaunchPopoverCoordinatorProvider, useLaunchPopoverCoordinator } from "./popovers/LaunchPopoverCoordinator";
 import { MicPopover } from "./popovers/MicPopover";
 import { MorePopover } from "./popovers/MorePopover";
 import { ProjectPopover } from "./popovers/ProjectPopover";
 import { SourcePopover } from "./popovers/SourcePopover";
 import { WebcamPopover } from "./popovers/WebcamPopover";
-import { HudInteractionContext } from "./contexts/HudInteractionContext";
-import { MarqueeText } from "./SourceSelector";
-import styles from "./LaunchWindow.module.css";
-
-import { Separator } from "@/components/ui/separator";
-import { Button } from "../ui/button";
 import { RecordingControls } from "./RecordingControls";
-import { useEffect, useRef } from "react";
+import { MarqueeText } from "./SourceSelector";
 
 const SHOW_DEV_UPDATE_PREVIEW = import.meta.env.DEV;
 
@@ -427,6 +426,9 @@ function LaunchWindowContent() {
 	);
 
 	const hudMode = finalizing ? "finalizing" : recording ? "recording" : "idle";
+	const useNativeHudBarDrag =
+		(platform === "linux" || hudOverlayMousePassthroughSupported === false) &&
+		!showRecordingWebcamPreview;
 
 	return (
 		<HudInteractionContext.Provider value={{ onMouseEnter: handleHudMouseEnter, onMouseLeave: handleHudMouseLeave }}>
@@ -456,16 +458,11 @@ function LaunchWindowContent() {
 							className={`${styles.bar} launch-theme mb-2`}
 						>
 							<div
-								// On Linux (especially Wayland) the compositor owns window
-								// placement, so BrowserWindow.setBounds() is silently ignored.
-								// Fall back to a native OS drag via -webkit-app-region on the
-								// handle.  We still need JS pointer handlers in webcam-preview
-								// mode (which translates via CSS inside the window), so only
-								// mark the handle as a native drag region for the IPC path.
+								// Linux compositors and non-passthrough Windows fallback windows
+								// need native window dragging; the JS drag path only translates
+								// content inside the HUD window.
 								className={`flex items-center px-0.5 cursor-grab active:cursor-grabbing ${
-									platform === "linux" && !showRecordingWebcamPreview
-										? styles.electronDrag
-										: ""
+									useNativeHudBarDrag ? styles.electronDrag : ""
 								}`}
 								onPointerDown={handleHudBarPointerDown}
 								onPointerMove={handleHudBarPointerMove}

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -427,8 +427,7 @@ function LaunchWindowContent() {
 
 	const hudMode = finalizing ? "finalizing" : recording ? "recording" : "idle";
 	const useNativeHudBarDrag =
-		(platform === "linux" || hudOverlayMousePassthroughSupported === false) &&
-		!showRecordingWebcamPreview;
+		platform === "linux" || hudOverlayMousePassthroughSupported === false;
 
 	return (
 		<HudInteractionContext.Provider value={{ onMouseEnter: handleHudMouseEnter, onMouseLeave: handleHudMouseLeave }}>


### PR DESCRIPTION
## Description

Constrain the recorder HUD fallback window on platforms where Electron mouse passthrough is unavailable, especially Windows 10.

Instead of keeping a full-work-area transparent HUD window that must remain mouse-interactive, the fallback now uses:

- a compact bottom-centered HUD window while idle/non-hovered
- an expanded bottom-centered HUD window only while the HUD needs interaction, hover, or menus
- the existing full-work-area overlay on Win11/macOS where passthrough works

## Motivation

Issue #581 reports that on Windows 10 / Recordly 1.3.0 the recorder HUD blocks click and scroll behind Recordly after recording starts, and one reporter also no longer sees the countdown after updating. Current `main` disables HUD mouse passthrough for Windows builds below 22000, but still creates a full-work-area transparent overlay. That means the fallback can swallow the whole screen.

## Type of Change

- [x] Bug fix

## Related Issue(s)

- Part of #581

## Changes Made

- Added a pure `getHudOverlayWindowBounds` helper for full, compact fallback, and expanded fallback bounds.
- Wired the HUD overlay window to use compact/expanded bounds when passthrough is not supported.
- Reused the existing `hud-overlay-set-ignore-mouse` signal to expand the fallback only when the HUD needs interaction.
- Let the HUD drag handle use native window dragging for non-passthrough fallback windows.

## Scope Note

This PR only targets the Windows 10/non-passthrough HUD input blocker. It does not change export routing, WGC capture startup, NVIDIA export, or the timeline speed-overlap report from #581.

## Testing Guide

On Windows 10:

1. Start Recordly 1.3.0/current main with this branch.
2. Start a recording with countdown enabled.
3. Confirm the countdown appears.
4. While recording, move the mouse away from the HUD and verify apps behind Recordly can be clicked and scrolled.
5. Hover/open HUD menus and confirm the HUD remains usable.
6. Drag the HUD using the handle and confirm the window moves normally.

## Checklist

- [x] Focused regression surface only
- [x] Added targeted bounds tests
- [x] Typecheck passes locally
- [x] Scoped Biome passes locally
- [ ] Windows 10 runtime smoke on affected machine

## Local Checks

- `npm test -- electron/hudOverlayBounds.test.ts src/components/launch/hudMousePassthrough.test.ts src/components/launch/floatingWebcamPreview.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check --formatter-enabled=false electron/hudOverlayBounds.ts electron/hudOverlayBounds.test.ts electron/windows.ts src/components/launch/LaunchWindow.tsx`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HUD overlay positioning and resizing so the HUD stays visible and centered across varied display sizes and modes; preserves the dragged bottom edge when resizing.
  * Enhanced HUD bar drag handling on Linux and when advanced display passthrough is unavailable.

* **Tests**
  * Added tests covering overlay bounds, expanded/compact fallback behavior, clamping on small/off-screen work areas, and resize preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->