### PR TITLE
fix: reset cursor state on recording load

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -2074,6 +2074,8 @@ export default function VideoEditor() {
 		setSpeedRegions([]);
 		setAnnotationRegions([]);
 		setAudioRegions([]);
+		setCursorTelemetry([]);
+		setCursorTelemetrySourcePath(null);
 		setSourceAudioTrackSettingsByClip({});
 		setDefaultSourceAudioTrackSettings({});
 		setHasClipSourceAudio(false);
@@ -2088,6 +2090,8 @@ export default function VideoEditor() {
 		nextAudioIdRef.current = 1;
 		nextAnnotationIdRef.current = 1;
 		nextAnnotationZIndexRef.current = 1;
+		pendingFreshRecordingAutoSuggestTelemetryCountRef.current = 0;
+		autoSuggestedVideoPathRef.current = null;
 		resetEditorHistoryStack(editorHistoryRef.current);
 		applyingHistoryRef.current = false;
 		syncHistoryButtons();


### PR DESCRIPTION
## Summary
- Clear cursor telemetry when loading a fresh recording/source.
- Reset fresh-recording auto-suggest guards with the rest of source-scoped editor state.

## Type of Change
- Bug fix

## Related Issue(s) / PRs
- Follow-up to #588 CodeRabbit caution about source-scoped cursor state.

## Motivation
The source-scoped reset added in #588 cleared timeline, audio, and history state, but still left cursor telemetry and auto-suggest guard refs alive across source swaps. This could briefly show/use the previous recording's cursor telemetry or suppress fresh auto-suggest if two recordings had the same telemetry sample count.

## Testing Guide
1. Load one recording with cursor telemetry.
2. Load a different fresh recording.
3. Confirm the editor starts with empty cursor telemetry until the new source telemetry finishes loading.
4. Confirm fresh-recording auto-suggest is not suppressed by the previous source's telemetry count.

## Validation
- [x] npx biome check src/components/video-editor/VideoEditor.tsx --formatter-enabled=false
- [x] npx tsc --noEmit --pretty false
- [x] git diff --check

## Screenshots / Video
Not applicable; state reset only.