### PR TITLE
chore(release): bump version to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recordly",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recordly",
-			"version": "1.3.0",
+			"version": "1.3.1",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/webadderallorg/Recordly/issues"
 	},
 	"private": true,
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --config vite.config.ts",


### PR DESCRIPTION
## Summary
- Bump Recordly package metadata from 1.3.0 to 1.3.1.
- Prepare a patch release for the Windows HUD passthrough fixes now on main.

## Type of Change
- Release

## Related PRs
- #584 patched Windows recorder HUD passthrough fallback behavior.
- #588 stabilized Windows recording preview/export regressions.
- #589 cleared source-scoped cursor state after the recording preview fix.

## Release Note
v1.3.1 patches Windows HUD passthrough behavior during recording and includes the latest Windows recording preview stability fixes from main.

## Validation
- [x] node version metadata check for package.json and package-lock.json
- [x] git diff --check

## Testing Guide
1. Confirm package.json, package-lock.json, and package-lock root package are all 1.3.1.
2. After merge, tag v1.3.1 from main.
3. Publish GitHub release v1.3.1 with the release note above so the release workflow builds signed artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version bump released.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->