### PR TITLE
fix(timeline): make horizontal scroll easier

### DIFF
--- a/src/components/video-editor/KeyboardShortcutsHelp.tsx
+++ b/src/components/video-editor/KeyboardShortcutsHelp.tsx
@@ -10,13 +10,13 @@ export function KeyboardShortcutsHelp() {
 	const t = useScopedT("editor");
 
 	const [scrollLabels, setScrollLabels] = useState({
-		pan: "Shift + Ctrl + Scroll",
+		pan: "Shift + Scroll",
 		zoom: "Ctrl + Scroll",
 	});
 
 	useEffect(() => {
 		Promise.all([
-			formatShortcut(["shift", "mod", "Scroll"]),
+			formatShortcut(["shift", "Scroll"]),
 			formatShortcut(["mod", "Scroll"]),
 		]).then(([pan, zoom]) => setScrollLabels({ pan, zoom }));
 	}, []);

--- a/src/components/video-editor/TutorialHelp.tsx
+++ b/src/components/video-editor/TutorialHelp.tsx
@@ -149,13 +149,13 @@ export function KeyboardShortcutsDialog({
 	const { shortcuts, isMac, openConfig } = useShortcuts();
 	const t = useScopedT("editor");
 	const [scrollLabels, setScrollLabels] = useState({
-		pan: "Shift + Ctrl + Scroll",
+		pan: "Shift + Scroll",
 		zoom: "Ctrl + Scroll",
 	});
 
 	useEffect(() => {
 		Promise.all([
-			formatShortcut(["shift", "mod", "Scroll"]),
+			formatShortcut(["shift", "Scroll"]),
 			formatShortcut(["mod", "Scroll"]),
 		]).then(([pan, zoom]) => setScrollLabels({ pan, zoom }));
 	}, []);

--- a/src/components/video-editor/timeline/hooks/useTimelineRange.test.ts
+++ b/src/components/video-editor/timeline/hooks/useTimelineRange.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTimelineWheelPanDeltaPx } from "./useTimelineRange";
+
+describe("resolveTimelineWheelPanDeltaPx", () => {
+	it("uses trackpad horizontal wheel movement for timeline panning", () => {
+		expect(
+			resolveTimelineWheelPanDeltaPx({
+				deltaX: 24,
+				deltaY: 0,
+				deltaMode: 0,
+			}),
+		).toBe(24);
+	});
+
+	it("uses shifted vertical wheel movement for timeline panning", () => {
+		expect(
+			resolveTimelineWheelPanDeltaPx({
+				deltaX: 0,
+				deltaY: 3,
+				deltaMode: 1,
+				shiftKey: true,
+			}),
+		).toBe(48);
+	});
+
+	it("keeps ctrl wheel available for timeline zoom unless shift is also held", () => {
+		expect(
+			resolveTimelineWheelPanDeltaPx({
+				deltaX: 0,
+				deltaY: 3,
+				deltaMode: 1,
+				ctrlKey: true,
+			}),
+		).toBe(0);
+		expect(
+			resolveTimelineWheelPanDeltaPx({
+				deltaX: 0,
+				deltaY: 3,
+				deltaMode: 1,
+				ctrlKey: true,
+				shiftKey: true,
+			}),
+		).toBe(48);
+	});
+
+	it("uses regular wheel movement when the timeline has no vertical overflow", () => {
+		expect(
+			resolveTimelineWheelPanDeltaPx({
+				deltaX: 0,
+				deltaY: 20,
+				deltaMode: 0,
+				canScrollVertically: false,
+			}),
+		).toBe(20);
+	});
+});

--- a/src/components/video-editor/timeline/hooks/useTimelineRange.ts
+++ b/src/components/video-editor/timeline/hooks/useTimelineRange.ts
@@ -7,6 +7,40 @@ interface UseTimelineRangeParams {
 	timelineContainerRef: RefObject<HTMLDivElement>;
 }
 
+export interface TimelineWheelPanDeltaInput {
+	deltaX: number;
+	deltaY: number;
+	deltaMode: number;
+	shiftKey?: boolean;
+	ctrlKey?: boolean;
+	metaKey?: boolean;
+	canScrollVertically?: boolean;
+}
+
+export function resolveTimelineWheelPanDeltaPx({
+	deltaX,
+	deltaY,
+	deltaMode,
+	shiftKey = false,
+	ctrlKey = false,
+	metaKey = false,
+	canScrollVertically = true,
+}: TimelineWheelPanDeltaInput) {
+	if ((ctrlKey || metaKey) && !shiftKey) {
+		return 0;
+	}
+
+	if (Math.abs(deltaX) > 0) {
+		return normalizeWheelDeltaToPixels(deltaX, deltaMode);
+	}
+
+	if ((shiftKey || !canScrollVertically) && Math.abs(deltaY) > 0) {
+		return normalizeWheelDeltaToPixels(deltaY, deltaMode);
+	}
+
+	return 0;
+}
+
 export function useTimelineRange({ totalMs, timelineContainerRef }: UseTimelineRangeParams) {
 	const [range, setRange] = useState<Range>(() => createInitialRange(totalMs));
 
@@ -42,29 +76,34 @@ export function useTimelineRange({ totalMs, timelineContainerRef }: UseTimelineR
 
 	const handleTimelineWheel = useCallback(
 		(event: WheelEvent<HTMLDivElement>) => {
-			if (event.ctrlKey || event.metaKey || totalMs <= 0) {
+			if (((event.ctrlKey || event.metaKey) && !event.shiftKey) || totalMs <= 0) {
 				return;
 			}
 
-			const rawHorizontalDelta =
-				Math.abs(event.deltaX) > 0
-					? event.deltaX
-					: event.shiftKey && Math.abs(event.deltaY) > 0
-						? event.deltaY
-						: 0;
+			const container = timelineContainerRef.current;
+			const horizontalDeltaPx = resolveTimelineWheelPanDeltaPx({
+				deltaX: event.deltaX,
+				deltaY: event.deltaY,
+				deltaMode: event.deltaMode,
+				shiftKey: event.shiftKey,
+				ctrlKey: event.ctrlKey,
+				metaKey: event.metaKey,
+				canScrollVertically: container
+					? container.scrollHeight > container.clientHeight + 1
+					: true,
+			});
 
-			if (rawHorizontalDelta === 0) {
+			if (horizontalDeltaPx === 0) {
 				return;
 			}
 
-			const containerWidth = timelineContainerRef.current?.clientWidth ?? 0;
+			const containerWidth = container?.clientWidth ?? 0;
 			const visibleRangeMs = clampedRange.end - clampedRange.start;
 			if (containerWidth <= 0 || visibleRangeMs <= 0) {
 				return;
 			}
 
 			event.preventDefault();
-			const horizontalDeltaPx = normalizeWheelDeltaToPixels(rawHorizontalDelta, event.deltaMode);
 			const deltaMs = (horizontalDeltaPx / containerWidth) * visibleRangeMs;
 			panTimelineRange(deltaMs);
 		},

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -37,7 +37,7 @@ export const FIXED_SHORTCUTS: FixedShortcut[] = [
 		display: "Del / ⌫",
 		bindings: [{ key: "delete" }, { key: "backspace" }],
 	},
-	{ label: "Pan Timeline", display: "Shift + Ctrl + Scroll", bindings: [] },
+	{ label: "Pan Timeline", display: "Shift + Scroll", bindings: [] },
 	{ label: "Zoom Timeline", display: "Ctrl + Scroll", bindings: [] },
 ];
 


### PR DESCRIPTION
﻿# Pull Request Template

## Description
Makes horizontal timeline scrolling easier and consistent with the shortcut help:

- Trackpad horizontal scroll still pans the visible timeline range.
- `Shift + Scroll` pans the timeline with a regular mouse wheel.
- `Shift + Ctrl/Cmd + Scroll` also pans, preserving compatibility with the old help text.
- Plain wheel scrolling pans the timeline when there is no vertical timeline overflow to scroll.
- `Ctrl/Cmd + Scroll` without Shift remains reserved for timeline zoom.

## Motivation
A user reported that timeline control is difficult and asked how to scroll the horizontal timeline. The existing behavior supported some pan paths, but the help text advertised `Shift + Ctrl + Scroll` while the wheel handler ignored Ctrl/Cmd wheel events. This made the documented shortcut fail and left mouse-wheel users without an obvious pan path.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Discord/user feedback: it seems very hard to control timeline, how to scroll horizontal timeline?

## Screenshots / Video
Not applicable. This is interaction behavior plus shortcut text.

## Testing Guide
Commands run locally:

```bash
npm test -- src/components/video-editor/timeline/hooks/useTimelineRange.test.ts src/components/video-editor/timeline/core/time.test.ts
npx biome check --formatter-enabled=false --assist-enabled=false src/components/video-editor/timeline/hooks/useTimelineRange.ts src/components/video-editor/timeline/hooks/useTimelineRange.test.ts src/components/video-editor/KeyboardShortcutsHelp.tsx src/components/video-editor/TutorialHelp.tsx src/lib/shortcuts.ts
npx tsc --noEmit
git diff --check
```

Runtime checks for reviewers:

- Zoom into a longer timeline, then use `Shift + mouse wheel` over the timeline and confirm it pans horizontally.
- Use trackpad side-scroll over the timeline and confirm it pans horizontally.
- Use `Ctrl/Cmd + Scroll` without Shift and confirm zoom behavior is not stolen by pan.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added targeted tests for changed behavior.
- [x] I have documented runtime verification steps for the interaction change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified the "pan timeline" keyboard shortcut to use `Shift + Scroll` instead of the previous multi-modifier combination for improved usability.
  * Updated help documentation to reflect the new shortcut.

* **Tests**
  * Added test coverage for timeline scroll panning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->