### PR TITLE
feat: GIF quality and compression preset

### DIFF
--- a/src/components/video-editor/ExportSettingsMenu.test.tsx
+++ b/src/components/video-editor/ExportSettingsMenu.test.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "@/contexts/I18nContext";
+import { ExportSettingsMenu } from "./ExportSettingsMenu";
+
+vi.mock("motion/react", () => ({
+	LayoutGroup: ({ children }: { children: ReactNode }) => children ?? null,
+	motion: {
+		span: ({ children }: { children?: ReactNode }) => children ?? null,
+	},
+}));
+
+describe("ExportSettingsMenu", () => {
+	it("renders the three GIF quality options", () => {
+		const html = renderToStaticMarkup(
+			<I18nProvider>
+				<ExportSettingsMenu
+					exportFormat="gif"
+					exportQuality="source"
+					exportEncodingMode="balanced"
+					mp4FrameRate={30}
+					gifFrameRate={15}
+					gifLoop={true}
+					gifSizePreset="medium"
+					gifQualityPreset="balanced"
+					gifOutputDimensions={{ width: 1280, height: 720 }}
+				/>
+			</I18nProvider>,
+		);
+
+		expect(html).toContain("High");
+		expect(html).toContain("Balanced");
+		expect(html).toContain("Small file");
+	});
+});

--- a/src/components/video-editor/ExportSettingsMenu.tsx
+++ b/src/components/video-editor/ExportSettingsMenu.tsx
@@ -10,9 +10,15 @@ import type {
 	ExportPipelineModel,
 	ExportQuality,
 	GifFrameRate,
+	GifQualityPreset,
 	GifSizePreset,
 } from "@/lib/exporter";
-import { GIF_FRAME_RATES, GIF_SIZE_PRESETS, MP4_FRAME_RATES } from "@/lib/exporter";
+import {
+	GIF_FRAME_RATES,
+	GIF_QUALITY_PRESETS,
+	GIF_SIZE_PRESETS,
+	MP4_FRAME_RATES,
+} from "@/lib/exporter";
 import { cn } from "@/lib/utils";
 
 interface ExportSettingsMenuProps {
@@ -39,6 +45,8 @@ interface ExportSettingsMenuProps {
 	onGifLoopChange?: (loop: boolean) => void;
 	gifSizePreset: GifSizePreset;
 	onGifSizePresetChange?: (preset: GifSizePreset) => void;
+	gifQualityPreset: GifQualityPreset;
+	onGifQualityPresetChange?: (preset: GifQualityPreset) => void;
 	gifOutputDimensions: { width: number; height: number };
 	onExport?: () => void;
 	className?: string;
@@ -68,6 +76,8 @@ export function ExportSettingsMenu({
 	onGifLoopChange,
 	gifSizePreset,
 	onGifSizePresetChange,
+	gifQualityPreset,
+	onGifQualityPresetChange,
 	gifOutputDimensions,
 	onExport,
 	className,
@@ -491,6 +501,55 @@ export function ExportSettingsMenu({
 							</div>
 						</LayoutGroup>
 					</div>
+					<LayoutGroup id="header-gif-quality-toggle">
+						<div className="grid h-8 grid-cols-3 rounded-xl border border-foreground/5 bg-foreground/5 p-0.5">
+							{Object.entries(GIF_QUALITY_PRESETS).map(([key, preset]) => {
+								const typedKey = key as GifQualityPreset;
+								const isActive = gifQualityPreset === typedKey;
+								return (
+									<button
+										key={key}
+										type="button"
+										onClick={() => onGifQualityPresetChange?.(typedKey)}
+										aria-pressed={isActive}
+										className="relative rounded-lg text-[11px] font-medium transition-colors"
+									>
+										{isActive ? (
+											<motion.span
+												layoutId="header-gif-quality-pill"
+												className="absolute inset-0 rounded-lg bg-neutral-800 dark:bg-white"
+												transition={{
+													type: "spring",
+													stiffness: 420,
+													damping: 34,
+												}}
+											/>
+										) : null}
+										<span
+											className={cn(
+												"relative z-10",
+												isActive
+													? "text-white dark:text-black"
+													: "text-muted-foreground hover:text-foreground",
+											)}
+										>
+											{typedKey === "high"
+												? tSettings("export.gifQualityHigh", preset.label)
+												: typedKey === "balanced"
+													? tSettings(
+															"export.gifQualityBalanced",
+															preset.label,
+														)
+													: tSettings(
+															"export.gifQualitySmall",
+															preset.label,
+														)}
+										</span>
+									</button>
+								);
+							})}
+						</div>
+					</LayoutGroup>
 					<div className="flex items-center justify-between px-1">
 						<span className="text-[10px] text-muted-foreground/70">
 							{gifOutputDimensions.width} × {gifOutputDimensions.height}px

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -66,6 +66,7 @@ import {
 	GIF_SIZE_PRESETS,
 	GifExporter,
 	type GifFrameRate,
+	type GifQualityPreset,
 	type GifSizePreset,
 	ModernVideoExporter,
 	probeSupportedMp4Dimensions,
@@ -645,6 +646,9 @@ export default function VideoEditor() {
 	const [gifSizePreset, setGifSizePreset] = useState<GifSizePreset>(
 		initialEditorPreferences.gifSizePreset,
 	);
+	const [gifQualityPreset, setGifQualityPreset] = useState<GifQualityPreset>(
+		initialEditorPreferences.gifQualityPreset,
+	);
 	const hasCaptionsForSidecar = autoCaptionSettings.enabled && autoCaptions.length > 0;
 	const captionSidecarCues = useMemo(
 		() =>
@@ -810,6 +814,7 @@ export default function VideoEditor() {
 			gifFrameRate,
 			gifLoop,
 			gifSizePreset,
+			gifQualityPreset,
 			autoCaptionSettings: { ...autoCaptionSettings },
 			whisperExecutablePath,
 			whisperModelPath,
@@ -867,6 +872,7 @@ export default function VideoEditor() {
 			gifFrameRate,
 			gifLoop,
 			gifSizePreset,
+			gifQualityPreset,
 			autoCaptionSettings,
 			whisperExecutablePath,
 			whisperModelPath,
@@ -965,6 +971,7 @@ export default function VideoEditor() {
 		setGifFrameRate(snapshot.gifFrameRate);
 		setGifLoop(snapshot.gifLoop);
 		setGifSizePreset(snapshot.gifSizePreset);
+		setGifQualityPreset(snapshot.gifQualityPreset);
 		setAutoCaptionSettings({ ...snapshot.autoCaptionSettings });
 		setWhisperExecutablePath(snapshot.whisperExecutablePath);
 		setWhisperModelPath(snapshot.whisperModelPath);
@@ -1755,6 +1762,7 @@ export default function VideoEditor() {
 				gifFrameRate: GifFrameRate;
 				gifLoop: boolean;
 				gifSizePreset: GifSizePreset;
+				gifQualityPreset: GifQualityPreset;
 				sourceAudioTrackSettingsByClip: Record<string, SourceAudioTrackSettings>;
 				defaultSourceAudioTrackSettings: SourceAudioTrackSettings;
 			}>,
@@ -1878,6 +1886,7 @@ export default function VideoEditor() {
 				gifFrameRate,
 				gifLoop,
 				gifSizePreset,
+				gifQualityPreset,
 				sourceAudioTrackSettingsByClip,
 				defaultSourceAudioTrackSettings,
 			}),
@@ -1944,6 +1953,7 @@ export default function VideoEditor() {
 			gifFrameRate,
 			gifLoop,
 			gifSizePreset,
+			gifQualityPreset,
 			frame,
 			sourceAudioTrackSettingsByClip,
 			defaultSourceAudioTrackSettings,
@@ -2143,6 +2153,7 @@ export default function VideoEditor() {
 			setGifFrameRate(normalizedEditor.gifFrameRate);
 			setGifLoop(normalizedEditor.gifLoop);
 			setGifSizePreset(normalizedEditor.gifSizePreset);
+			setGifQualityPreset(normalizedEditor.gifQualityPreset);
 
 			setSelectedZoomId(null);
 			setSelectedClipId(null);
@@ -2497,6 +2508,7 @@ export default function VideoEditor() {
 						setGifFrameRate(initialEditorPreferences.gifFrameRate);
 						setGifLoop(initialEditorPreferences.gifLoop);
 						setGifSizePreset(initialEditorPreferences.gifSizePreset);
+						setGifQualityPreset(initialEditorPreferences.gifQualityPreset);
 						return;
 					}
 				}
@@ -2674,6 +2686,7 @@ export default function VideoEditor() {
 			gifFrameRate,
 			gifLoop,
 			gifSizePreset,
+			gifQualityPreset,
 			whisperExecutablePath,
 			whisperModelPath,
 		});
@@ -2730,6 +2743,7 @@ export default function VideoEditor() {
 		gifFrameRate,
 		gifLoop,
 		gifSizePreset,
+		gifQualityPreset,
 		whisperExecutablePath,
 		whisperModelPath,
 	]);
@@ -4639,6 +4653,7 @@ export default function VideoEditor() {
 						frameRate: settings.gifConfig.frameRate,
 						loop: settings.gifConfig.loop,
 						sizePreset: settings.gifConfig.sizePreset,
+						qualityPreset: settings.gifConfig.qualityPreset,
 						wallpaper,
 						trimRegions,
 						speedRegions: effectiveSpeedRegions,
@@ -5329,6 +5344,7 @@ export default function VideoEditor() {
 			gifFrameRate,
 			gifLoop,
 			gifSizePreset,
+			gifQualityPreset,
 		});
 
 		setExportError(null);
@@ -5344,6 +5360,7 @@ export default function VideoEditor() {
 		gifFrameRate,
 		gifLoop,
 		gifSizePreset,
+		gifQualityPreset,
 		hasCaptionsForSidecar,
 		includeCaptionSidecar,
 		exportBackendPreference,
@@ -6246,6 +6263,8 @@ export default function VideoEditor() {
 									onGifLoopChange={setGifLoop}
 									gifSizePreset={gifSizePreset}
 									onGifSizePresetChange={setGifSizePreset}
+									gifQualityPreset={gifQualityPreset}
+									onGifQualityPresetChange={setGifQualityPreset}
 									showCaptionSidecarOption={
 										hasCaptionsForSidecar && exportFormat === "mp4"
 									}

--- a/src/components/video-editor/editorPreferences.test.ts
+++ b/src/components/video-editor/editorPreferences.test.ts
@@ -87,6 +87,20 @@ describe("editorPreferences", () => {
 		expect(DEFAULT_EDITOR_PREFERENCES.exportQuality).toBe("source");
 	});
 
+	it("defaults GIF quality to balanced and clamps invalid stored presets", () => {
+		vi.stubGlobal(
+			"localStorage",
+			createStorageMock({
+				[EDITOR_PREFERENCES_STORAGE_KEY]: JSON.stringify({
+					gifQualityPreset: "tiny",
+				}),
+			}),
+		);
+
+		expect(DEFAULT_EDITOR_PREFERENCES.gifQualityPreset).toBe("balanced");
+		expect(loadEditorPreferences().gifQualityPreset).toBe("balanced");
+	});
+
 	it("defaults cursor preferences to Tahoe at 2.5x with gentler sway", () => {
 		expect(DEFAULT_EDITOR_PREFERENCES.cursorStyle).toBe("tahoe");
 		expect(DEFAULT_EDITOR_PREFERENCES.cursorSize).toBe(2.5);
@@ -163,6 +177,7 @@ describe("editorPreferences", () => {
 					exportFormat: "gif",
 					gifFrameRate: 30,
 					gifLoop: false,
+					gifQualityPreset: "small",
 					customAspectWidth: "21",
 					customAspectHeight: "9",
 					customWallpapers: ["data:image/jpeg;base64,abc"],
@@ -180,6 +195,7 @@ describe("editorPreferences", () => {
 			exportFormat: "gif",
 			gifFrameRate: 30,
 			gifLoop: false,
+			gifQualityPreset: "small",
 			customAspectWidth: "21",
 			customAspectHeight: "9",
 			customWallpapers: ["data:image/jpeg;base64,abc"],
@@ -277,6 +293,7 @@ describe("editorPreferences", () => {
 			gifFrameRate: 20,
 			gifLoop: false,
 			gifSizePreset: "large",
+			gifQualityPreset: "small",
 			customAspectWidth: "4",
 			customAspectHeight: "5",
 			customWallpapers: ["data:image/jpeg;base64,abc", "data:image/jpeg;base64,abc"],
@@ -307,6 +324,7 @@ describe("editorPreferences", () => {
 			gifFrameRate: 20,
 			gifLoop: false,
 			gifSizePreset: "large",
+			gifQualityPreset: "small",
 			customAspectWidth: "4",
 			customAspectHeight: "5",
 			customWallpapers: ["data:image/jpeg;base64,abc"],

--- a/src/components/video-editor/editorPreferences.ts
+++ b/src/components/video-editor/editorPreferences.ts
@@ -61,6 +61,7 @@ type PersistedEditorControls = Pick<
 	| "gifFrameRate"
 	| "gifLoop"
 	| "gifSizePreset"
+	| "gifQualityPreset"
 >;
 
 type PartialEditorControls = Partial<PersistedEditorControls>;
@@ -149,6 +150,7 @@ export const DEFAULT_EDITOR_PREFERENCES: EditorPreferences = {
 	gifFrameRate: DEFAULT_EDITOR_CONTROLS.gifFrameRate,
 	gifLoop: DEFAULT_EDITOR_CONTROLS.gifLoop,
 	gifSizePreset: DEFAULT_EDITOR_CONTROLS.gifSizePreset,
+	gifQualityPreset: DEFAULT_EDITOR_CONTROLS.gifQualityPreset,
 	customAspectWidth: "16",
 	customAspectHeight: "9",
 	customWallpapers: [],
@@ -357,6 +359,7 @@ function normalizeEditorControls(
 		gifFrameRate: sanitizedRaw.gifFrameRate ?? fallback.gifFrameRate,
 		gifLoop: sanitizedRaw.gifLoop ?? fallback.gifLoop,
 		gifSizePreset: sanitizedRaw.gifSizePreset ?? fallback.gifSizePreset,
+		gifQualityPreset: sanitizedRaw.gifQualityPreset ?? fallback.gifQualityPreset,
 	};
 
 	const normalized = normalizeProjectEditor(candidate);
@@ -413,6 +416,7 @@ function normalizeEditorControls(
 		gifFrameRate: normalized.gifFrameRate,
 		gifLoop: normalized.gifLoop,
 		gifSizePreset: normalized.gifSizePreset,
+		gifQualityPreset: normalized.gifQualityPreset,
 	};
 }
 

--- a/src/components/video-editor/exportStartSettings.test.ts
+++ b/src/components/video-editor/exportStartSettings.test.ts
@@ -14,6 +14,7 @@ const baseOptions = {
 	gifFrameRate: 20 as const,
 	gifLoop: true,
 	gifSizePreset: "medium" as const,
+	gifQualityPreset: "balanced" as const,
 };
 
 describe("resolveExportStartSettings", () => {
@@ -53,6 +54,7 @@ describe("resolveExportStartSettings", () => {
 				frameRate: 15,
 				loop: false,
 				sizePreset: "medium",
+				qualityPreset: "balanced",
 				width: 1280,
 				height: 720,
 			},
@@ -70,6 +72,7 @@ describe("resolveExportStartSettings", () => {
 			}).gifConfig,
 		).toMatchObject({
 			sizePreset: "original",
+			qualityPreset: "balanced",
 			width: 1234,
 			height: 678,
 		});

--- a/src/components/video-editor/exportStartSettings.ts
+++ b/src/components/video-editor/exportStartSettings.ts
@@ -9,6 +9,7 @@ import {
 	type ExportSettings,
 	GIF_SIZE_PRESETS,
 	type GifFrameRate,
+	type GifQualityPreset,
 	type GifSizePreset,
 } from "@/lib/exporter";
 
@@ -25,6 +26,7 @@ export function resolveExportStartSettings({
 	gifFrameRate,
 	gifLoop,
 	gifSizePreset,
+	gifQualityPreset,
 }: {
 	sourceWidth: number;
 	sourceHeight: number;
@@ -38,6 +40,7 @@ export function resolveExportStartSettings({
 	gifFrameRate: GifFrameRate;
 	gifLoop: boolean;
 	gifSizePreset: GifSizePreset;
+	gifQualityPreset: GifQualityPreset;
 }): ExportSettings {
 	const gifDimensions =
 		exportFormat === "gif"
@@ -58,6 +61,7 @@ export function resolveExportStartSettings({
 						frameRate: gifFrameRate,
 						loop: gifLoop,
 						sizePreset: gifSizePreset,
+						qualityPreset: gifQualityPreset,
 						width: gifDimensions.width,
 						height: gifDimensions.height,
 					}

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -7,9 +7,10 @@ import type {
 	ExportPipelineModel,
 	ExportQuality,
 	GifFrameRate,
+	GifQualityPreset,
 	GifSizePreset,
 } from "@/lib/exporter";
-import { isValidMp4FrameRate } from "@/lib/exporter";
+import { isValidGifQualityPreset, isValidMp4FrameRate } from "@/lib/exporter";
 import {
 	TEMPORAL_MOTION_BLUR_DEFAULT_SAMPLE_COUNT,
 	TEMPORAL_MOTION_BLUR_DEFAULT_SHUTTER_FRACTION,
@@ -153,6 +154,7 @@ export interface ProjectEditorState {
 	gifFrameRate: GifFrameRate;
 	gifLoop: boolean;
 	gifSizePreset: GifSizePreset;
+	gifQualityPreset: GifQualityPreset;
 }
 
 export interface EditorProjectData {
@@ -1107,6 +1109,9 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 			editor.gifSizePreset === "original"
 				? editor.gifSizePreset
 				: "medium",
+		gifQualityPreset: isValidGifQualityPreset(editor.gifQualityPreset)
+			? editor.gifQualityPreset
+			: "balanced",
 	};
 }
 

--- a/src/lib/exporter/gifExporter.test.ts
+++ b/src/lib/exporter/gifExporter.test.ts
@@ -1,11 +1,81 @@
 import * as fc from "fast-check";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const gifMockState = vi.hoisted(() => ({
+	constructorOptions: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("gif.js", () => ({
+	default: vi.fn((options: Record<string, unknown>) => {
+		gifMockState.constructorOptions.push(options);
+		const handlers = new Map<string, (value: Blob | number) => void>();
+		const quality = typeof options.quality === "number" ? options.quality : 10;
+
+		return {
+			addFrame: vi.fn(),
+			abort: vi.fn(),
+			on: vi.fn((event: string, handler: (value: Blob | number) => void) => {
+				handlers.set(event, handler);
+			}),
+			render: vi.fn(() => {
+				const size = Math.max(1, 21 - quality);
+				handlers.get("finished")?.(new Blob(["x".repeat(size)], { type: "image/gif" }));
+			}),
+		};
+	}),
+}));
+
+vi.mock("./frameRenderer", () => ({
+	FrameRenderer: vi.fn(() => ({
+		destroy: vi.fn(),
+		getCanvas: vi.fn(() => ({})),
+		initialize: vi.fn(),
+		renderFrame: vi.fn(),
+	})),
+}));
+
+vi.mock("./streamingDecoder", () => ({
+	StreamingVideoDecoder: vi.fn(() => ({
+		cancel: vi.fn(),
+		decodeAll: vi.fn(),
+		destroy: vi.fn(),
+		getEffectiveDuration: vi.fn(() => 0),
+		loadMetadata: vi.fn(() => Promise.resolve({ width: 2, height: 2, duration: 2 })),
+	})),
+}));
+
 import {
 	buildGifFrameRendererConfig,
 	calculateOutputDimensions,
+	getGifQuality,
 	getGifRepeat,
+	GifExporter,
 } from "./gifExporter";
-import { GIF_SIZE_PRESETS, GifSizePreset } from "./types";
+import { GIF_SIZE_PRESETS, type GifSizePreset } from "./types";
+
+type GifExporterTestConfig = ConstructorParameters<typeof GifExporter>[0];
+
+function createGifExporterConfig(
+	overrides: Partial<GifExporterTestConfig> = {},
+): GifExporterTestConfig {
+	return {
+		videoUrl: "file:///test.mp4",
+		width: 2,
+		height: 2,
+		frameRate: 15,
+		loop: true,
+		sizePreset: "medium",
+		wallpaper: "#000000",
+		zoomRegions: [],
+		trimRegions: [],
+		speedRegions: [],
+		showShadow: false,
+		shadowIntensity: 0,
+		backgroundBlur: 0,
+		cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+		...overrides,
+	};
+}
 
 /**
  * Property 2: Loop Encoding Correctness
@@ -19,6 +89,15 @@ import { GIF_SIZE_PRESETS, GifSizePreset } from "./types";
  * Feature: gif-export, Property 2: Loop Encoding Correctness
  */
 describe("GIF Exporter", () => {
+	beforeEach(() => {
+		gifMockState.constructorOptions = [];
+		vi.stubGlobal("navigator", { hardwareConcurrency: 4 });
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
 	describe("Property 2: Loop Encoding Correctness", () => {
 		/**
 		 * Test the loop configuration mapping logic.
@@ -49,6 +128,37 @@ describe("GIF Exporter", () => {
 				}),
 				{ numRuns: 100 },
 			);
+		});
+	});
+
+	describe("GIF quality preset mapping", () => {
+		it("should pass the small preset quality to gif.js", async () => {
+			await new GifExporter(createGifExporterConfig({ qualityPreset: "small" })).export();
+
+			expect(gifMockState.constructorOptions.at(-1)).toMatchObject({ quality: 20 });
+		});
+
+		it("should default to balanced quality when qualityPreset is omitted", async () => {
+			await new GifExporter(createGifExporterConfig()).export();
+
+			expect(gifMockState.constructorOptions.at(-1)).toMatchObject({ quality: 10 });
+		});
+
+		it("should fall back to balanced quality for unknown quality presets", () => {
+			expect(getGifQuality("future")).toBe(10);
+		});
+
+		it("should produce a smaller blob for the small preset than the high preset", async () => {
+			const highResult = await new GifExporter(
+				createGifExporterConfig({ qualityPreset: "high" }),
+			).export();
+			const smallResult = await new GifExporter(
+				createGifExporterConfig({ qualityPreset: "small" }),
+			).export();
+
+			expect(highResult.success).toBe(true);
+			expect(smallResult.success).toBe(true);
+			expect(smallResult.blob?.size).toBeLessThan(highResult.blob?.size ?? 0);
 		});
 	});
 

--- a/src/lib/exporter/gifExporter.ts
+++ b/src/lib/exporter/gifExporter.ts
@@ -22,8 +22,10 @@ import type {
 	ExportResult,
 	GIF_SIZE_PRESETS,
 	GifFrameRate,
+	GifQualityPreset,
 	GifSizePreset,
 } from "./types";
+import { GIF_QUALITY_PRESETS, isValidGifQualityPreset } from "./types";
 
 const GIF_WORKER_URL = new URL("gif.js/dist/gif.worker.js", import.meta.url).toString();
 
@@ -36,6 +38,7 @@ interface GifExporterConfig {
 	frameRate: GifFrameRate;
 	loop: boolean;
 	sizePreset: GifSizePreset;
+	qualityPreset?: GifQualityPreset;
 	wallpaper: string;
 	zoomRegions: ZoomRegion[];
 	trimRegions?: TrimRegion[];
@@ -199,6 +202,11 @@ export function buildGifFrameRendererConfig(
 	};
 }
 
+export function getGifQuality(qualityPreset: unknown): number {
+	const preset = isValidGifQualityPreset(qualityPreset) ? qualityPreset : "balanced";
+	return GIF_QUALITY_PRESETS[preset].quality;
+}
+
 export class GifExporter {
 	private config: GifExporterConfig;
 	private streamingDecoder: StreamingVideoDecoder | null = null;
@@ -242,7 +250,7 @@ export class GifExporter {
 
 			this.gif = new GIF({
 				workers: WORKER_COUNT,
-				quality: 10,
+				quality: getGifQuality(this.config.qualityPreset),
 				width: this.config.width,
 				height: this.config.height,
 				workerScript: GIF_WORKER_URL,

--- a/src/lib/exporter/index.ts
+++ b/src/lib/exporter/index.ts
@@ -29,16 +29,20 @@ export type {
 	ExportSettings,
 	GifExportConfig,
 	GifFrameRate,
+	GifQualityPreset,
 	GifSizePreset,
 	VideoFrameData,
 } from "./types";
 export {
 	GIF_FRAME_RATES,
+	GIF_QUALITY_PRESETS,
 	GIF_SIZE_PRESETS,
 	isValidGifFrameRate,
+	isValidGifQualityPreset,
 	isValidMp4FrameRate,
 	MP4_FRAME_RATES,
 	VALID_GIF_FRAME_RATES,
+	VALID_GIF_QUALITY_PRESETS,
 } from "./types";
 export { VideoFileDecoder } from "./videoDecoder";
 export { VideoExporter } from "./videoExporter";

--- a/src/lib/exporter/types.test.ts
+++ b/src/lib/exporter/types.test.ts
@@ -1,6 +1,14 @@
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import { GifFrameRate, isValidGifFrameRate, VALID_GIF_FRAME_RATES } from "./types";
+import {
+	GIF_QUALITY_PRESETS,
+	GifFrameRate,
+	GifQualityPreset,
+	isValidGifFrameRate,
+	isValidGifQualityPreset,
+	VALID_GIF_FRAME_RATES,
+	VALID_GIF_QUALITY_PRESETS,
+} from "./types";
 
 /**
  * Property 1: Valid Frame Rate Acceptance
@@ -51,6 +59,38 @@ describe("GIF Export Types", () => {
 				}),
 				{ numRuns: 100 },
 			);
+		});
+	});
+
+	describe("GIF quality presets", () => {
+		it("should accept all valid quality presets", () => {
+			fc.assert(
+				fc.property(
+					fc.constantFrom(...VALID_GIF_QUALITY_PRESETS),
+					(qualityPreset: GifQualityPreset) => {
+						expect(isValidGifQualityPreset(qualityPreset)).toBe(true);
+					},
+				),
+				{ numRuns: 100 },
+			);
+		});
+
+		it("should reject unknown quality presets", () => {
+			fc.assert(
+				fc.property(
+					fc.string().filter((value) => !isValidGifQualityPreset(value)),
+					(invalidQualityPreset: string) => {
+						expect(isValidGifQualityPreset(invalidQualityPreset)).toBe(false);
+					},
+				),
+				{ numRuns: 100 },
+			);
+		});
+
+		it("should map high, balanced, and small presets to gif.js quality values", () => {
+			expect(GIF_QUALITY_PRESETS.high.quality).toBe(1);
+			expect(GIF_QUALITY_PRESETS.balanced.quality).toBe(10);
+			expect(GIF_QUALITY_PRESETS.small.quality).toBe(20);
 		});
 	});
 });

--- a/src/lib/exporter/types.ts
+++ b/src/lib/exporter/types.ts
@@ -183,10 +183,13 @@ export type GifFrameRate = 15 | 20 | 25 | 30;
 
 export type GifSizePreset = "medium" | "large" | "original";
 
+export type GifQualityPreset = "high" | "balanced" | "small";
+
 export interface GifExportConfig {
 	frameRate: GifFrameRate;
 	loop: boolean;
 	sizePreset: GifSizePreset;
+	qualityPreset?: GifQualityPreset;
 	width: number;
 	height: number;
 }
@@ -216,6 +219,15 @@ export const GIF_SIZE_PRESETS: Record<GifSizePreset, { maxHeight: number; label:
 	original: { maxHeight: Infinity, label: "Original" },
 };
 
+export const GIF_QUALITY_PRESETS: Record<
+	GifQualityPreset,
+	{ quality: number; label: string }
+> = {
+	high: { quality: 1, label: "High" },
+	balanced: { quality: 10, label: "Balanced" },
+	small: { quality: 20, label: "Small file" },
+};
+
 export const GIF_FRAME_RATES: { value: GifFrameRate; label: string }[] = [
 	{ value: 15, label: "15 FPS - Balanced" },
 	{ value: 20, label: "20 FPS - Smooth" },
@@ -226,6 +238,16 @@ export const GIF_FRAME_RATES: { value: GifFrameRate; label: string }[] = [
 // Valid frame rates for validation
 export const VALID_GIF_FRAME_RATES: readonly GifFrameRate[] = [15, 20, 25, 30] as const;
 
+export const VALID_GIF_QUALITY_PRESETS: readonly GifQualityPreset[] = [
+	"high",
+	"balanced",
+	"small",
+] as const;
+
 export function isValidGifFrameRate(rate: number): rate is GifFrameRate {
 	return VALID_GIF_FRAME_RATES.includes(rate as GifFrameRate);
+}
+
+export function isValidGifQualityPreset(value: unknown): value is GifQualityPreset {
+	return VALID_GIF_QUALITY_PRESETS.includes(value as GifQualityPreset);
 }


### PR DESCRIPTION
## Summary
- Adds GIF quality / compression preset to the ExportSettingsMenu, picking up where @meiiie's draft (#357) left off after she stepped back to reduce PR noise.
- Three presets: `low` (fast, small file), `balanced` (default - current behavior), `high` (slow, larger file).
- Wires through `src/lib/exporter/types.ts` for the typed preset, the ExportSettingsMenu UI, and VideoEditor's invocation path.
- Tests for the type narrowing and component behavior; existing exports continue to use `balanced`.

cc @meiiie - picking up your 2026-05-09 re-up invitation. Happy to adjust the preset boundaries or naming if you'd prefer different defaults.

Closes #336.

AI was used for assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GIF export now includes selectable quality presets: High, Balanced, and Small file. Users can optimize exports based on their desired quality or file size requirements.
  * GIF quality preferences are saved and restored across projects and sessions.

* **Bug Fixes**
  * Invalid or unavailable GIF quality settings now safely fall back to Balanced.

* **Tests**
  * Added test coverage for quality preset selection and GIF export configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->