### PR TITLE
fix(timeline): smooth clip trim resize

### DIFF
--- a/src/components/video-editor/timeline/components/wrapper/TimelineWrapper.tsx
+++ b/src/components/video-editor/timeline/components/wrapper/TimelineWrapper.tsx
@@ -11,11 +11,7 @@ import { TimelineContext } from "dnd-timeline";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
 import { useCallback, useRef } from "react";
 import type { TimelineRegionSpan } from "../../core/timelineTypes";
-import {
-	clampRange,
-	resolveDragEnd,
-	resolveResizeEnd,
-} from "../../dnd/engine";
+import { clampRange, resolveDragEnd, resolveResizeEnd } from "../../dnd/engine";
 
 interface TimelineWrapperProps {
 	children: ReactNode;
@@ -162,9 +158,10 @@ export default function TimelineWrapper({
 					? (event.activatorEvent as PointerEvent).clientX + (event.delta?.x ?? 0)
 					: undefined;
 			if (span) showTooltip(span, screenX);
-			onLiveSpanPreviewChange?.(event.active.id as string, span ?? null);
+			// dnd-timeline mutates the active item's DOM during resize; React preview
+			// renders here can reset that inline width/edge position and make trims stutter.
 		},
-		[onLiveSpanPreviewChange, showTooltip],
+		[showTooltip],
 	);
 
 	const hideTooltip = useCallback(() => showTooltip(null), [showTooltip]);


### PR DESCRIPTION
## Summary
- stop publishing React live-preview state on clip resize moves
- keep the drag/resize tooltip on direct DOM updates
- leave final resize commit behavior unchanged

## Root cause
`dnd-timeline` already mutates the active item's inline width/edge position while resizing. Publishing `liveSpanPreviewById` during every resize move forced React to re-render the timeline mid-drag, which could reset the active item back to its previous span and make left/right clip trimming feel jittery.

## Validation
- `npm test -- src/components/video-editor/timeline/dnd/engine.test.ts src/components/video-editor/timeline/model/timelineModel.test.ts src/components/video-editor/timeline/timelineLayout.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx biome check src/components/video-editor/timeline/components/wrapper/TimelineWrapper.tsx`
- `git diff --check`

## Manual test requested
Please verify in the editor that dragging both the left and right edges of a clip feels smooth, especially with source audio/waveform rows enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internal Improvements**
  * Code organization and documentation enhancements to the video editor timeline component for improved maintainability and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->