### PR TITLE
chore(release): prepare v1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recordly",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recordly",
-			"version": "1.3.1",
+			"version": "1.3.2",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/webadderallorg/Recordly/issues"
 	},
 	"private": true,
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --config vite.config.ts",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -113,6 +113,11 @@
 	"project": {
 		"untitled": "Sans titre"
 	},
+	"nativeCaptureUnavailable": {
+		"title": "Rien n'est cassé, mais nous ne pourrons pas afficher une superposition animée du curseur.",
+		"description": "Votre appareil ne prend pas en charge la capture native. Cela peut arriver pour plusieurs raisons que nous n'avons pas encore identifiées. Recordly continuera de fonctionner, mais le lissage du curseur sera impossible.",
+		"confirm": "D'accord"
+	},
 	"exportStatus": {
 		"exporting": "Exportation",
 		"renderingFile": "Rendu de votre fichier.",

--- a/src/i18n/locales/ko/editor.json
+++ b/src/i18n/locales/ko/editor.json
@@ -114,6 +114,11 @@
 	"project": {
 		"untitled": "제목 없음"
 	},
+	"nativeCaptureUnavailable": {
+		"title": "문제가 생긴 것은 아니지만, 애니메이션 커서 오버레이를 렌더링할 수 없습니다.",
+		"description": "이 장치는 네이티브 캡처를 지원하지 않습니다. 아직 확인하지 못한 여러 이유가 있을 수 있습니다. Recordly는 계속 작동하지만 커서 스무딩은 사용할 수 없습니다.",
+		"confirm": "확인"
+	},
 	"exportStatus": {
 		"exporting": "내보내는 중",
 		"renderingFile": "파일을 렌더링하고 있습니다.",

--- a/src/i18n/locales/nl/editor.json
+++ b/src/i18n/locales/nl/editor.json
@@ -114,6 +114,11 @@
 	"project": {
 		"untitled": "Naamloos"
 	},
+	"nativeCaptureUnavailable": {
+		"title": "Er is niets kapot, maar we kunnen geen geanimeerde cursor-overlay renderen.",
+		"description": "Je apparaat ondersteunt geen native capture. Dit kan verschillende oorzaken hebben die we nog niet hebben achterhaald. Recordly blijft werken, maar cursor smoothing is dan niet mogelijk.",
+		"confirm": "Oké"
+	},
 	"exportStatus": {
 		"exporting": "Exporteren",
 		"renderingFile": "Je bestand wordt gerenderd.",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -113,6 +113,11 @@
 	"project": {
 		"untitled": "Sem título"
 	},
+	"nativeCaptureUnavailable": {
+		"title": "Nada está quebrado, mas não poderemos renderizar uma sobreposição animada do cursor.",
+		"description": "Seu dispositivo não oferece suporte à captura nativa. Isso pode acontecer por vários motivos que ainda não identificamos. O Recordly continuará funcionando, mas a suavização do cursor ficará indisponível.",
+		"confirm": "Entendi"
+	},
 	"exportStatus": {
 		"exporting": "Exportando",
 		"renderingFile": "Renderizando seu arquivo.",

--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -113,6 +113,11 @@
 	"project": {
 		"untitled": "未命名"
 	},
+	"nativeCaptureUnavailable": {
+		"title": "没有出错，但我们无法渲染动画光标叠加层。",
+		"description": "你的设备不支持原生捕获。这可能是由我们尚未确定的多种原因造成的。Recordly 仍可继续运行，但无法进行光标平滑处理。",
+		"confirm": "好的"
+	},
 	"exportStatus": {
 		"exporting": "正在导出",
 		"renderingFile": "正在渲染你的文件。",

--- a/src/i18n/locales/zh-TW/editor.json
+++ b/src/i18n/locales/zh-TW/editor.json
@@ -113,6 +113,11 @@
 	"project": {
 		"untitled": "未命名"
 	},
+	"nativeCaptureUnavailable": {
+		"title": "沒有出錯，但我們無法轉譯動畫游標覆蓋層。",
+		"description": "你的裝置不支援原生擷取。這可能是由我們尚未釐清的多種原因造成的。Recordly 仍可繼續運作，但無法進行游標平滑處理。",
+		"confirm": "好的"
+	},
 	"exportStatus": {
 		"exporting": "正在匯出",
 		"renderingFile": "正在渲染你的檔案。",


### PR DESCRIPTION
﻿## Summary
- Prepare the v1.3.2 stability patch release.
- Bump package metadata from 1.3.1 to 1.3.2.
- Add the missing native-capture warning copy for locales that were missing the recent editor key.

## Release scope since v1.3.1
- Stabilized platform capture/source handling.
- Improved recording audio/video quality and CUDA export canvas sizing.
- Added horizontal timeline scroll affordance.
- Smoothed timeline clip trim resizing.
- Guarded Linux portal cursor overlay when native capture cannot confirm hidden cursor behavior.

## Verification
- PASS: `npx tsc --noEmit`
- PASS: targeted Vitest suite for capture, HUD passthrough, timeline, export routing/dimensions, and native-video IPC: 11 files / 183 tests
- PASS: `npx biome lint package.json package-lock.json src/i18n/locales/fr/editor.json src/i18n/locales/ko/editor.json src/i18n/locales/nl/editor.json src/i18n/locales/pt-BR/editor.json src/i18n/locales/zh-CN/editor.json src/i18n/locales/zh-TW/editor.json`
- PASS: `git diff --check`
- PASS: `npm run smoke:electron-main-cjs`
- NOTE: `npm run smoke:packaged-binaries` requires a packaged `release/.../app.asar.unpacked` tree and is expected to run inside the package/release workflow.
- KNOWN EXISTING: full `npm test` currently fails in pre-existing/unrelated suites (`modernFrameRenderer`, `modernVideoExporter.fallback`, `editorPreferences`, `audioEncoder`). This PR only changes version metadata and locale copy.
- KNOWN EXISTING: `npm run i18n:check` still reports older `settings.json` key drift for motion/caption settings; the new `nativeCaptureUnavailable` editor keys are now present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized messages for a native capture unavailability state across six new languages: French, Korean, Dutch, Portuguese (Brazil), Simplified Chinese, and Traditional Chinese.

* **Chores**
  * Version updated to 1.3.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->