### PR TITLE
fix(recording): preserve webcam preview HUD bounds

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -208,6 +208,7 @@ interface Window {
 		hudOverlayHide: () => void;
 		hudOverlayClose: () => void;
 		hudOverlayRendererReady: () => void;
+		hudOverlaySetWebcamPreviewVisible: (visible: boolean) => void;
 		getHudOverlayCaptureProtection: () => Promise<{ success: boolean; enabled: boolean }>;
 		getHudOverlayMousePassthroughSupported: () => Promise<{
 			success: boolean;

--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	getHudOverlayWindowBounds,
 	resizeHudOverlayFallbackBounds,
+	shouldExpandHudOverlayFallback,
 } from "./hudOverlayBounds";
 
 describe("getHudOverlayWindowBounds", () => {
@@ -141,5 +142,37 @@ describe("resizeHudOverlayFallbackBounds", () => {
 			width: 860,
 			height: 540,
 		});
+	});
+});
+
+describe("shouldExpandHudOverlayFallback", () => {
+	it("expands while recording only when the floating webcam preview is visible", () => {
+		expect(
+			shouldExpandHudOverlayFallback({
+				fallbackExpanded: false,
+				recordingActive: true,
+				webcamPreviewVisible: true,
+			}),
+		).toBe(true);
+	});
+
+	it("keeps the compact recording fallback when there is no webcam preview", () => {
+		expect(
+			shouldExpandHudOverlayFallback({
+				fallbackExpanded: false,
+				recordingActive: true,
+				webcamPreviewVisible: false,
+			}),
+		).toBe(false);
+	});
+
+	it("preserves manual fallback expansion outside recording", () => {
+		expect(
+			shouldExpandHudOverlayFallback({
+				fallbackExpanded: true,
+				recordingActive: false,
+				webcamPreviewVisible: false,
+			}),
+		).toBe(true);
 	});
 });

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -38,6 +38,18 @@ export function getHudOverlayWindowBounds(
 	};
 }
 
+export function shouldExpandHudOverlayFallback({
+	fallbackExpanded,
+	recordingActive,
+	webcamPreviewVisible,
+}: {
+	fallbackExpanded: boolean;
+	recordingActive: boolean;
+	webcamPreviewVisible: boolean;
+}): boolean {
+	return fallbackExpanded || (recordingActive && webcamPreviewVisible);
+}
+
 export function resizeHudOverlayFallbackBounds(
 	workArea: HudOverlayWorkArea,
 	currentBounds: HudOverlayWorkArea,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -179,6 +179,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	hudOverlayRendererReady: () => {
 		ipcRenderer.send("hud-overlay-renderer-ready");
 	},
+	hudOverlaySetWebcamPreviewVisible: (visible: boolean) => {
+		ipcRenderer.send("hud-overlay-set-webcam-preview-visible", visible);
+	},
 	getHudOverlayCaptureProtection: () => {
 		return ipcRenderer.invoke("get-hud-overlay-capture-protection");
 	},

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app, BrowserWindow, ipcMain } from "electron";
 import { USER_DATA_PATH } from "./appPaths";
-import { getHudOverlayWindowBounds, resizeHudOverlayFallbackBounds } from "./hudOverlayBounds";
+import {
+	getHudOverlayWindowBounds,
+	resizeHudOverlayFallbackBounds,
+	shouldExpandHudOverlayFallback,
+} from "./hudOverlayBounds";
 import { getPackagedRendererBaseUrl } from "./rendererServer";
 
 const electronWindowsDir = path.dirname(fileURLToPath(import.meta.url));
@@ -29,6 +33,7 @@ let hudOverlayFallbackExpanded = false;
 let hudOverlayIgnoringMouse = true;
 let hudOverlayMouseReassertTimer: NodeJS.Timeout | null = null;
 let hudOverlayRecordingActive = false;
+let hudOverlayWebcamPreviewVisible = false;
 let countdownWindow: BrowserWindow | null = null;
 let updateToastWindow: BrowserWindow | null = null;
 
@@ -189,10 +194,15 @@ function getHudOverlayDisplay() {
 
 function getHudOverlayBounds() {
 	const { workArea } = getHudOverlayDisplay();
+	const fallbackExpanded = shouldExpandHudOverlayFallback({
+		fallbackExpanded: hudOverlayFallbackExpanded,
+		recordingActive: hudOverlayRecordingActive,
+		webcamPreviewVisible: hudOverlayWebcamPreviewVisible,
+	});
 	return getHudOverlayWindowBounds(
 		workArea,
 		isHudOverlayMousePassthroughSupported() && !hudOverlayRecordingActive,
-		hudOverlayFallbackExpanded,
+		fallbackExpanded,
 	);
 }
 
@@ -393,6 +403,18 @@ ipcMain.handle("get-hud-overlay-mouse-passthrough-supported", () => {
 	};
 });
 
+ipcMain.on("hud-overlay-set-webcam-preview-visible", (_event, visible: boolean) => {
+	const nextVisible = Boolean(visible);
+	if (hudOverlayWebcamPreviewVisible === nextVisible) {
+		return;
+	}
+
+	hudOverlayWebcamPreviewVisible = nextVisible;
+	if (hudOverlayRecordingActive) {
+		applyHudOverlayBounds();
+	}
+});
+
 ipcMain.handle("set-hud-overlay-capture-protection", (_event, enabled: boolean) => {
 	loadHudOverlayCaptureProtectionSetting();
 	hudOverlayHiddenFromCapture = Boolean(enabled);
@@ -415,6 +437,7 @@ ipcMain.handle("set-hud-overlay-capture-protection", (_event, enabled: boolean) 
 export function createHudOverlayWindow(): BrowserWindow {
 	loadHudOverlayCaptureProtectionSetting();
 	hudOverlayFallbackExpanded = false;
+	hudOverlayWebcamPreviewVisible = false;
 	const initialBounds = getHudOverlayBounds();
 	let hasShownHudWindow = false;
 

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -152,6 +152,16 @@ function LaunchWindowContent() {
 		hudOverlayMousePassthroughSupported,
 	});
 
+	useEffect(() => {
+		window.electronAPI?.hudOverlaySetWebcamPreviewVisible?.(showRecordingWebcamPreview);
+	}, [showRecordingWebcamPreview]);
+
+	useEffect(() => {
+		return () => {
+			window.electronAPI?.hudOverlaySetWebcamPreviewVisible?.(false);
+		};
+	}, []);
+
 	const {
 		recordingHudOffset,
 		isHudDragging,


### PR DESCRIPTION
## Summary
- keep the HUD fallback expanded while a floating webcam preview is visible during recording
- let the renderer tell the main process when the recording webcam preview is visible
- add coverage for the fallback expansion decision so the compact HUD still stays compact when there is no webcam preview

## Root cause
On recording start, the main process switched the HUD overlay into the compact non-passthrough fallback bounds. The webcam preview remained positioned as a large floating thumbnail, so the smaller window clipped most of it and made it look like the thumbnail suddenly shrank.

## Validation
- npm run test -- electron/hudOverlayBounds.test.ts src/components/launch/floatingWebcamPreview.test.ts
- npx biome check --formatter-enabled=false electron/windows.ts electron/hudOverlayBounds.ts electron/hudOverlayBounds.test.ts electron/preload.ts electron/electron-env.d.ts src/components/launch/LaunchWindow.tsx
- npx tsc --noEmit
- npm run smoke:electron-main-cjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added control for HUD webcam preview visibility during active recording.
  * Enhanced HUD overlay to dynamically adjust based on recording state and webcam preview visibility.

* **Tests**
  * Added test coverage for HUD overlay expansion behavior with various recording and webcam preview states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->