### PR TITLE
fix(linux): expand HUD fallback for menus

### DIFF
--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	getHudOverlayWindowBounds,
 	resizeHudOverlayFallbackBounds,
+	shouldResizeHudOverlayFallback,
 } from "./hudOverlayBounds";
 
 describe("getHudOverlayWindowBounds", () => {
@@ -141,5 +142,19 @@ describe("resizeHudOverlayFallbackBounds", () => {
 			width: 860,
 			height: 540,
 		});
+	});
+});
+
+describe("shouldResizeHudOverlayFallback", () => {
+	it("allows non-passthrough HUD windows to expand for menus when idle", () => {
+		expect(shouldResizeHudOverlayFallback(false, false)).toBe(true);
+	});
+
+	it("does not resize full passthrough HUD windows", () => {
+		expect(shouldResizeHudOverlayFallback(true, false)).toBe(false);
+	});
+
+	it("keeps the recording HUD compact in non-passthrough mode", () => {
+		expect(shouldResizeHudOverlayFallback(false, true)).toBe(false);
 	});
 });

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -38,6 +38,13 @@ export function getHudOverlayWindowBounds(
 	};
 }
 
+export function shouldResizeHudOverlayFallback(
+	mousePassthroughSupported: boolean,
+	recordingActive: boolean,
+): boolean {
+	return !mousePassthroughSupported && !recordingActive;
+}
+
 export function resizeHudOverlayFallbackBounds(
 	workArea: HudOverlayWorkArea,
 	currentBounds: HudOverlayWorkArea,

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app, BrowserWindow, ipcMain } from "electron";
 import { USER_DATA_PATH } from "./appPaths";
-import { getHudOverlayWindowBounds, resizeHudOverlayFallbackBounds } from "./hudOverlayBounds";
+import {
+	getHudOverlayWindowBounds,
+	resizeHudOverlayFallbackBounds,
+	shouldResizeHudOverlayFallback,
+} from "./hudOverlayBounds";
 import { getPackagedRendererBaseUrl } from "./rendererServer";
 
 const electronWindowsDir = path.dirname(fileURLToPath(import.meta.url));
@@ -294,8 +298,9 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 		return;
 	}
 
-	if (!isHudOverlayMousePassthroughSupported()) {
-		if (process.platform !== "linux") {
+	const mousePassthroughSupported = isHudOverlayMousePassthroughSupported();
+	if (!mousePassthroughSupported) {
+		if (shouldResizeHudOverlayFallback(mousePassthroughSupported, hudOverlayRecordingActive)) {
 			setHudOverlayFallbackExpanded(!ignore);
 		}
 		hudOverlayWindow.setIgnoreMouseEvents(false);


### PR DESCRIPTION
## Summary
- allow non-passthrough HUD fallback windows to expand for launch popovers on Linux
- keep recording mode compact so the fallback window does not block the screen while recording
- add focused tests for the fallback resize decision

## Root cause
On Linux/AppImage the HUD uses the compact non-passthrough fallback window. When a launch popover opened, Linux was excluded from the fallback resize path, so the menu rendered inside a short window and was clipped.

Fixes #608.

## Validation
- npm run test -- electron/hudOverlayBounds.test.ts
- npx biome check --formatter-enabled=false electron/windows.ts electron/hudOverlayBounds.ts electron/hudOverlayBounds.test.ts
- npx tsc --noEmit
- npm run smoke:electron-main-cjs

## Notes
I could not run a Linux AppImage smoke test from this Windows workstation, so this should still be confirmed on Ubuntu/Zorin AppImage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined HUD overlay resizing: overlays may expand for menus only when passthrough isn’t supported and recording is inactive; full-passthrough windows are no longer resized and active recording HUD remains compact.

* **Tests**
  * Added tests covering HUD resizing behavior across passthrough and recording states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->