### PR TITLE
fix(timeline): keep clips visible during analysis

### DIFF
--- a/src/components/video-editor/timeline/components/viewport/TimelineCanvas.tsx
+++ b/src/components/video-editor/timeline/components/viewport/TimelineCanvas.tsx
@@ -251,7 +251,6 @@ interface TimelineCanvasRowsProps {
 	onZoomRowMouseLeave: MouseEventHandler<HTMLDivElement>;
 	onZoomRowMouseDown: MouseEventHandler<HTMLDivElement>;
 	onZoomRowClick: MouseEventHandler<HTMLDivElement>;
-	isLoading?: boolean;
 }
 
 interface AudioItemWithWaveformProps {
@@ -319,7 +318,6 @@ const TimelineCanvasRows = memo(function TimelineCanvasRows({
 	onZoomRowMouseLeave,
 	onZoomRowMouseDown,
 	onZoomRowClick,
-	isLoading = false,
 }: TimelineCanvasRowsProps) {
 	const hiddenIds = useMemo(() => new Set(liveHiddenItemIds ?? []), [liveHiddenItemIds]);
 	const { clipItems, zoomItems, annotationRows, audioRows } = useMemo(() => {
@@ -387,8 +385,6 @@ const TimelineCanvasRows = memo(function TimelineCanvasRows({
 						onSelectId={onSelectClip}
 						variant="clip"
 						speedValue={item.speedValue}
-						isLoading={isLoading}
-						loadingLabel="Analyzing..."
 					>
 						{item.label}
 					</Item>
@@ -783,7 +779,6 @@ export default function TimelineCanvas({
 					onZoomRowMouseLeave={handleZoomRowMouseLeave}
 					onZoomRowMouseDown={handleZoomRowMouseDown}
 					onZoomRowClick={handleZoomRowClick}
-					isLoading={isLoading}
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- Keep timeline clip blocks visible while background audio/cursor analysis is running.
- Leave the loading state on the playhead/analysis indicator instead of replacing clips with an "Analyzing..." skeleton.

## Why
Users reported that enabling Auto-apply fresh recording zooms could leave the timeline looking stuck on "Analyzing" with no usable clip. The clip itself is already available; background analysis should not hide or disable it.

## Verification
- npx biome check --formatter-enabled=false src/components/video-editor/timeline/components/viewport/TimelineCanvas.tsx
- npx tsc --noEmit
- git diff origin/main...HEAD --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the timeline clip interface by removing loading state indicators that appeared during clip analysis, streamlining the component structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->