### PR TITLE
chore(release): prepare v1.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recordly",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recordly",
-			"version": "1.3.2",
+			"version": "1.3.3",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/webadderallorg/Recordly/issues"
 	},
 	"private": true,
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --config vite.config.ts",


### PR DESCRIPTION
## Summary
- Prepare the v1.3.3 stability patch release.
- Bump package metadata from 1.3.2 to 1.3.3.

## Release scope since v1.3.2
- Preserved webcam preview HUD bounds during recording.
- Expanded Linux HUD fallback bounds for menus while keeping recording HUD compact.
- Routed Linux/X11 screen capture through real desktop sources instead of the Wayland portal sentinel.
- Preserved saved editor preset crop-region settings.
- Kept fresh-recording timeline clips visible while background analysis runs.
- Restored HUD clickability after webcam preview hide/show and improved timeline clip drag/reorder behavior.

## Verification
- PASS: `git diff --check`
- PASS: `npx biome check package.json package-lock.json`
- PASS: release version metadata check (`package.json`, `package-lock.json`, root lock package all report 1.3.3)
- NOTE: Code-level validation for the included fixes ran in their focused PRs, especially #611, #612, #613, #614, #615, and #616.
- NOTE: The GitHub release workflow will run packaged macOS, Windows, and Linux builds after the `v1.3.3` release is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version bump (1.3.3)

---

**Note:** This release contains no user-facing feature or bug fix changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/webadderallorg/Recordly/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->