### PR TITLE
Fix Windows HUD native popup click handling

### DIFF
--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -21,19 +21,19 @@ describe("getHudOverlayWindowBounds", () => {
 
 	it("uses a bottom-centered compact fallback when mouse passthrough is unavailable", () => {
 		expect(getHudOverlayWindowBounds(workArea, false)).toEqual({
-			x: 650,
-			y: 920,
-			width: 860,
-			height: 160,
+			x: 720,
+			y: 960,
+			width: 720,
+			height: 120,
 		});
 	});
 
 	it("expands the non-passthrough fallback for HUD menus and hover interaction", () => {
 		expect(getHudOverlayWindowBounds(workArea, false, true)).toEqual({
-			x: 650,
-			y: 540,
-			width: 860,
-			height: 540,
+			x: 720,
+			y: 560,
+			width: 720,
+			height: 520,
 		});
 	});
 
@@ -50,9 +50,9 @@ describe("getHudOverlayWindowBounds", () => {
 			),
 		).toEqual({
 			x: -100,
-			y: 280,
+			y: 320,
 			width: 640,
-			height: 160,
+			height: 120,
 		});
 	});
 
@@ -92,16 +92,16 @@ describe("resizeHudOverlayFallbackBounds", () => {
 				{
 					x: 420,
 					y: 700,
-					width: 860,
-					height: 160,
+					width: 720,
+					height: 120,
 				},
 				true,
 			),
 		).toEqual({
 			x: 420,
-			y: 320,
-			width: 860,
-			height: 540,
+			y: 300,
+			width: 720,
+			height: 520,
 		});
 	});
 
@@ -111,17 +111,17 @@ describe("resizeHudOverlayFallbackBounds", () => {
 				workArea,
 				{
 					x: 420,
-					y: 320,
-					width: 860,
-					height: 540,
+					y: 300,
+					width: 720,
+					height: 520,
 				},
 				false,
 			),
 		).toEqual({
 			x: 420,
 			y: 700,
-			width: 860,
-			height: 160,
+			width: 720,
+			height: 120,
 		});
 	});
 
@@ -132,16 +132,16 @@ describe("resizeHudOverlayFallbackBounds", () => {
 				{
 					x: 1500,
 					y: 900,
-					width: 860,
-					height: 160,
+					width: 720,
+					height: 120,
 				},
 				true,
 			),
 		).toEqual({
-			x: 1060,
-			y: 520,
-			width: 860,
-			height: 540,
+			x: 1200,
+			y: 500,
+			width: 720,
+			height: 520,
 		});
 	});
 });

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -5,9 +5,9 @@ export interface HudOverlayWorkArea {
 	height: number;
 }
 
-const NON_PASSTHROUGH_HUD_WIDTH_DIP = 860;
-const NON_PASSTHROUGH_HUD_COMPACT_HEIGHT_DIP = 160;
-const NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP = 540;
+const NON_PASSTHROUGH_HUD_WIDTH_DIP = 720;
+const NON_PASSTHROUGH_HUD_COMPACT_HEIGHT_DIP = 120;
+const NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP = 520;
 
 function clamp(value: number, min: number, max: number): number {
 	return Math.min(Math.max(value, min), max);

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app, BrowserWindow, ipcMain } from "electron";
@@ -118,22 +117,15 @@ function isHudOverlayCaptureProtectionSupported(): boolean {
 	return process.platform !== "linux";
 }
 
-function getWindowsBuildNumber(): number | null {
-	if (process.platform !== "win32") {
-		return null;
-	}
-
-	const build = Number.parseInt(os.release().split(".")[2] ?? "", 10);
-	return Number.isFinite(build) ? build : null;
-}
-
 export function isHudOverlayMousePassthroughSupported(): boolean {
 	if (process.platform === "linux") {
 		return false;
 	}
 
-	const build = getWindowsBuildNumber();
-	if (build !== null && build < 22000) {
+	// Windows can forward transparent-window mouse events, but keeping a full-screen
+	// topmost HUD in that mode interferes with native popups and file pickers.
+	// Treat Windows as compact-HUD-only so the overlay never spans the desktop.
+	if (process.platform === "win32") {
 		return false;
 	}
 

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -182,6 +182,7 @@ function LaunchWindowContent() {
 			isHudDraggingRef,
 			isWebcamPreviewDraggingRef,
 			webcamPreviewDragStartRef,
+			useMousePassthroughTracking: hudOverlayMousePassthroughSupported !== false,
 		});
 
 	useEffect(() => {

--- a/src/components/launch/hooks/useLaunchHudInteractionState.ts
+++ b/src/components/launch/hooks/useLaunchHudInteractionState.ts
@@ -5,31 +5,40 @@ export function useLaunchHudInteractionState({
 	isHudDraggingRef,
 	isWebcamPreviewDraggingRef,
 	webcamPreviewDragStartRef,
+	useMousePassthroughTracking,
 }: {
 	openId: string | null;
 	isHudDraggingRef: RefObject<boolean>;
 	isWebcamPreviewDraggingRef: RefObject<boolean>;
 	webcamPreviewDragStartRef: RefObject<unknown>;
+	useMousePassthroughTracking: boolean;
 }) {
 	const isMouseOverHudRef = useRef(false);
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const lastInteractiveReassertAtRef = useRef(0);
 
-	const setHudMouseInteractive = useCallback((force = false) => {
-		const now = performance.now();
-		if (
-			!force &&
-			isMouseOverHudRef.current &&
-			now - lastInteractiveReassertAtRef.current < 250
-		) {
-			return;
-		}
+	const setHudMouseInteractive = useCallback(
+		(force = false) => {
+			if (!useMousePassthroughTracking) {
+				return;
+			}
 
-		isMouseOverHudRef.current = true;
-		lastInteractiveReassertAtRef.current = now;
-		if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		window.electronAPI?.hudOverlaySetIgnoreMouse?.(false);
-	}, []);
+			const now = performance.now();
+			if (
+				!force &&
+				isMouseOverHudRef.current &&
+				now - lastInteractiveReassertAtRef.current < 250
+			) {
+				return;
+			}
+
+			isMouseOverHudRef.current = true;
+			lastInteractiveReassertAtRef.current = now;
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+			window.electronAPI?.hudOverlaySetIgnoreMouse?.(false);
+		},
+		[useMousePassthroughTracking],
+	);
 
 	useEffect(() => {
 		if (openId !== null) {
@@ -46,6 +55,10 @@ export function useLaunchHudInteractionState({
 
 	useEffect(() => {
 		const handleMouseTracking = (e: globalThis.MouseEvent) => {
+			if (!useMousePassthroughTracking) {
+				return;
+			}
+
 			const target = e.target as HTMLElement | null;
 			if (!target) return;
 			const isInteractive = !!target.closest(
@@ -70,6 +83,10 @@ export function useLaunchHudInteractionState({
 			}
 		};
 
+		if (!useMousePassthroughTracking) {
+			return;
+		}
+
 		window.addEventListener("mouseover", handleMouseTracking);
 		window.addEventListener("mousemove", handleMouseTracking);
 		return () => {
@@ -80,6 +97,7 @@ export function useLaunchHudInteractionState({
 		isHudDraggingRef,
 		isWebcamPreviewDraggingRef,
 		setHudMouseInteractive,
+		useMousePassthroughTracking,
 		webcamPreviewDragStartRef,
 	]);
 
@@ -93,6 +111,10 @@ export function useLaunchHudInteractionState({
 
 	const handleHudMouseLeave = useCallback(
 		(event: MouseEvent<HTMLDivElement>) => {
+			if (!useMousePassthroughTracking) {
+				return;
+			}
+
 			const nextTarget = event.relatedTarget;
 			if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) {
 				return;
@@ -113,7 +135,12 @@ export function useLaunchHudInteractionState({
 				}
 			}, 300);
 		},
-		[isHudDraggingRef, isWebcamPreviewDraggingRef, webcamPreviewDragStartRef],
+		[
+			isHudDraggingRef,
+			isWebcamPreviewDraggingRef,
+			useMousePassthroughTracking,
+			webcamPreviewDragStartRef,
+		],
 	);
 
 	return {


### PR DESCRIPTION
## Summary

Fixes Windows native popup/file-picker click handling by removing the fullscreen transparent HUD passthrough path on Windows. Windows now uses the compact HUD fallback, so the topmost transparent overlay no longer spans the desktop and cannot interfere with native popups. The fallback HUD bounds were tightened to reduce the transparent area around the controls and popovers.

## Root Cause

On Windows, the HUD could be a transparent always-on-top window covering the full work area while relying on `setIgnoreMouseEvents(true, { forward: true })`. Native popups and file picker dialogs are sensitive to focus/z-order changes, and this fullscreen topmost overlay could prevent them from receiving clicks.

## Changes

- Treat Windows as compact-HUD-only instead of fullscreen passthrough HUD.
- Gate renderer mouse passthrough tracking so it only runs on platforms that use passthrough.
- Tighten compact and expanded fallback HUD bounds.
- Update HUD bounds tests for the new fallback geometry.

## Validation

- `npx biome check electron/hudOverlayBounds.ts electron/hudOverlayBounds.test.ts electron/windows.ts src/components/launch/LaunchWindow.tsx src/components/launch/hooks/useLaunchHudInteractionState.ts`
- `npx tsc --noEmit`
- `npx vitest --run electron/hudOverlayBounds.test.ts src/components/launch/hudMousePassthrough.test.ts`
- Built a Windows installer with `npm run build:win`
- Manually verified on Windows 11 that native popups/file picker interactions can be clicked while Recordly is open.

## Platform Testing Note

This has only been tested on Windows 11. It has not been tested on macOS, Linux, Windows 10, or other Windows versions.
