### PR TITLE
fix: keep Windows audio capture alive after transient WASAPI errors

### DIFF
--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -241,6 +241,10 @@ static void writeCompanionAudioTimingMetadata(
     if (timestampErrorCount > 0) {
         metadataFile << ",\"timestampErrorCount\":" << timestampErrorCount;
     }
+    const uint32_t recoverableErrorCount = capture.recoverableErrorCount();
+    if (recoverableErrorCount > 0) {
+        metadataFile << ",\"recoverableWasapiErrorCount\":" << recoverableErrorCount;
+    }
     metadataFile << "}";
 }
 
@@ -470,11 +474,13 @@ int main(int argc, char* argv[]) {
             loopback.timestampErrorCount() > 0 ||
             loopback.gapFillCount() > 0 ||
             loopback.compactedDiscontinuityCount() > 0 ||
-            loopback.compactedSilentDiscontinuityCount() > 0
+            loopback.compactedSilentDiscontinuityCount() > 0 ||
+            loopback.recoverableErrorCount() > 0
         ) {
             std::cerr << "WARNING: System audio timing metadata includes discontinuities="
                       << loopback.dataDiscontinuityCount()
                       << " timestampErrors=" << loopback.timestampErrorCount()
+                      << " recoverableWasapiErrors=" << loopback.recoverableErrorCount()
                       << " gapFills=" << loopback.gapFillCount()
                       << " insertedSilenceFrames=" << loopback.insertedSilenceFrames()
                       << " compactedDiscontinuities=" << loopback.compactedDiscontinuityCount()
@@ -491,11 +497,13 @@ int main(int argc, char* argv[]) {
             micCapture.timestampErrorCount() > 0 ||
             micCapture.gapFillCount() > 0 ||
             micCapture.compactedDiscontinuityCount() > 0 ||
-            micCapture.compactedSilentDiscontinuityCount() > 0
+            micCapture.compactedSilentDiscontinuityCount() > 0 ||
+            micCapture.recoverableErrorCount() > 0
         ) {
             std::cerr << "WARNING: Microphone timing metadata includes discontinuities="
                       << micCapture.dataDiscontinuityCount()
                       << " timestampErrors=" << micCapture.timestampErrorCount()
+                      << " recoverableWasapiErrors=" << micCapture.recoverableErrorCount()
                       << " gapFills=" << micCapture.gapFillCount()
                       << " insertedSilenceFrames=" << micCapture.insertedSilenceFrames()
                       << " compactedDiscontinuities=" << micCapture.compactedDiscontinuityCount()

--- a/electron/native/wgc-capture/src/wasapi_loopback.cpp
+++ b/electron/native/wgc-capture/src/wasapi_loopback.cpp
@@ -16,6 +16,7 @@ constexpr uint32_t kMinimumGapFillThresholdMs = 50;
 constexpr uint32_t kDiscontinuityGapFillThresholdMs = 140;
 constexpr uint32_t kSilentDiscontinuityCompactThresholdMs = 40;
 constexpr uint32_t kBoundaryFadeInMs = 5;
+constexpr uint32_t kMaxRecoverableWasapiErrorWarnings = 10;
 
 int64_t queryPerformanceCounterHns() {
     LARGE_INTEGER counter;
@@ -53,6 +54,10 @@ int16_t pcm24ToInt16(const BYTE* sample) {
         value |= ~0xFFFFFF;
     }
     return static_cast<int16_t>(value >> 8);
+}
+
+bool isRecoverableWasapiCaptureError(HRESULT hr) {
+    return hr == AUDCLNT_E_BUFFER_ERROR;
 }
 }
 
@@ -200,7 +205,9 @@ bool WasapiCapture::start() {
     compactedDiscontinuityFrames_ = 0;
     compactedSilentDiscontinuityCount_ = 0;
     compactedSilentDiscontinuityFrames_ = 0;
+    recoverableErrorCount_ = 0;
     fadeInFramesRemaining_ = 0;
+    fatalError_ = false;
     writeWavHeader(outputFile_, 0);
 
     HRESULT hr = audioClient_->Start();
@@ -392,8 +399,15 @@ void WasapiCapture::captureThread() {
 
     DWORD sleepMs = static_cast<DWORD>((static_cast<double>(bufferFrameCount_) / mixFormat_->nSamplesPerSec) * 500.0);
     if (sleepMs < 5) sleepMs = 5;
+    auto logRecoverableError = [this](const char* operation, HRESULT hr) {
+        const uint32_t count = recoverableErrorCount_.fetch_add(1) + 1;
+        if (count <= kMaxRecoverableWasapiErrorWarnings) {
+            std::cerr << "WASAPI: Recovering from " << operation << " hr=0x"
+                      << std::hex << hr << std::dec << std::endl;
+        }
+    };
 
-    while (capturing_) {
+    while (capturing_ && !fatalError_) {
         if (paused_) {
             Sleep(10);
             continue;
@@ -404,7 +418,13 @@ void WasapiCapture::captureThread() {
         UINT32 packetLength = 0;
         HRESULT hr = captureClient_->GetNextPacketSize(&packetLength);
         if (FAILED(hr)) {
+            if (isRecoverableWasapiCaptureError(hr)) {
+                logRecoverableError("GetNextPacketSize", hr);
+                Sleep(sleepMs);
+                continue;
+            }
             std::cerr << "WASAPI: GetNextPacketSize failed hr=0x" << std::hex << hr << std::dec << std::endl;
+            fatalError_ = true;
             break;
         }
 
@@ -422,7 +442,13 @@ void WasapiCapture::captureThread() {
                 &devicePosition,
                 &qpcPosition);
             if (FAILED(hr)) {
+                if (isRecoverableWasapiCaptureError(hr)) {
+                    logRecoverableError("GetBuffer", hr);
+                    packetLength = 0;
+                    break;
+                }
                 std::cerr << "WASAPI: GetBuffer failed hr=0x" << std::hex << hr << std::dec << std::endl;
+                fatalError_ = true;
                 break;
             }
 
@@ -496,7 +522,13 @@ void WasapiCapture::captureThread() {
                 captureClient_->ReleaseBuffer(numFrames);
                 hr = captureClient_->GetNextPacketSize(&packetLength);
                 if (FAILED(hr)) {
+                    if (isRecoverableWasapiCaptureError(hr)) {
+                        logRecoverableError("GetNextPacketSize", hr);
+                        packetLength = 0;
+                        continue;
+                    }
                     std::cerr << "WASAPI: GetNextPacketSize failed hr=0x" << std::hex << hr << std::dec << std::endl;
+                    fatalError_ = true;
                     break;
                 }
                 continue;
@@ -563,7 +595,13 @@ void WasapiCapture::captureThread() {
 
             hr = captureClient_->GetNextPacketSize(&packetLength);
             if (FAILED(hr)) {
+                if (isRecoverableWasapiCaptureError(hr)) {
+                    logRecoverableError("GetNextPacketSize", hr);
+                    packetLength = 0;
+                    continue;
+                }
                 std::cerr << "WASAPI: GetNextPacketSize failed hr=0x" << std::hex << hr << std::dec << std::endl;
+                fatalError_ = true;
                 break;
             }
         }

--- a/electron/native/wgc-capture/src/wasapi_loopback.h
+++ b/electron/native/wgc-capture/src/wasapi_loopback.h
@@ -32,6 +32,7 @@ public:
     uint64_t compactedDiscontinuityFrames() const { return compactedDiscontinuityFrames_.load(); }
     uint32_t compactedSilentDiscontinuityCount() const { return compactedSilentDiscontinuityCount_.load(); }
     uint64_t compactedSilentDiscontinuityFrames() const { return compactedSilentDiscontinuityFrames_.load(); }
+    uint32_t recoverableErrorCount() const { return recoverableErrorCount_.load(); }
 
 private:
     bool initializeCommon();
@@ -45,6 +46,7 @@ private:
     std::string outputPath_;
     std::thread thread_;
     std::atomic<bool> capturing_{false};
+    std::atomic<bool> fatalError_{false};
     std::atomic<bool> paused_{false};
     HANDLE outputFile_ = INVALID_HANDLE_VALUE;
     std::atomic<uint64_t> totalDataBytes_{0};
@@ -69,5 +71,6 @@ private:
     std::atomic<uint64_t> compactedDiscontinuityFrames_{0};
     std::atomic<uint32_t> compactedSilentDiscontinuityCount_{0};
     std::atomic<uint64_t> compactedSilentDiscontinuityFrames_{0};
+    std::atomic<uint32_t> recoverableErrorCount_{0};
     std::atomic<uint32_t> fadeInFramesRemaining_{0};
 };


### PR DESCRIPTION
Fixes #629

This targets the Windows recordings where audio can be present for the first few seconds and then disappear while video continues recording.

What changed:
- Treat transient WASAPI `AUDCLNT_E_BUFFER_ERROR` capture failures as recoverable instead of letting the audio capture path go silent/stale.
- Continue the capture loop after recoverable buffer errors so the next valid packet can resume audio writing.
- Preserve fatal handling for non-recoverable WASAPI failures.
- Add `recoverableWasapiErrorCount` to companion audio timing metadata and stderr diagnostics so future reports can confirm whether recovery happened during the recording.

Validation:
- `npm test -- electron/ipc/recording/windowsFallbacks.test.ts electron/ipc/recording/diagnostics.test.ts`
- `npm run build:windows-capture` on macOS confirms the project script skips Windows helper builds off Windows. The native helper still needs a Windows build/recording check in CI or on a Windows machine.

Bounty note: this PR is submitted for the $50 bounty mentioned in #629.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio capture resilience: transient/system and microphone audio glitches are now handled without aborting capture. Recoverable capture errors are counted, warning messages and the end-of-recording timing metadata now include this recoverable error count, and repeated warnings are rate-limited to reduce log spam.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->