### PR TITLE
feat: cursor follow crop with text cursor focus mode

### DIFF
--- a/electron/mediaTypes.ts
+++ b/electron/mediaTypes.ts
@@ -7,6 +7,7 @@ export const MEDIA_CONTENT_TYPES: Record<string, string> = {
 	".mkv": "video/x-matroska",
 	".avi": "video/x-msvideo",
 	".wav": "audio/wav",
+	".m4a": "audio/mp4",
 	".mp3": "audio/mpeg",
 	".ogg": "audio/ogg",
 	".png": "image/png",

--- a/src/components/video-editor/CropControl.tsx
+++ b/src/components/video-editor/CropControl.tsx
@@ -295,6 +295,10 @@ export function CropControl({
 		if (!cursorFollow || !onCursorFollowChange) return;
 		onCursorFollowChange({ ...cursorFollow, trackTextCursor: value });
 	};
+	const handleTextZoomChange = (value: boolean) => {
+		if (!cursorFollow || !onCursorFollowChange) return;
+		onCursorFollowChange({ ...cursorFollow, textZoomEnabled: value });
+	};
 
 	const sourceWidthPx = videoElement?.videoWidth ?? 0;
 	const sourceHeightPx = videoElement?.videoHeight ?? 0;
@@ -332,6 +336,20 @@ export function CropControl({
 							type="checkbox"
 							checked={cursorFollow.enabled}
 							onChange={(e) => handleToggleFollow(e.target.checked)}
+							className="h-4 w-4"
+						/>
+					</label>
+					<label className="flex items-center justify-between gap-3 text-sm">
+						<span className="flex flex-col">
+							<span className="font-medium">Text zoom</span>
+							<span className="text-xs text-muted-foreground/60">
+								Zooms in on the typing area while you type
+							</span>
+						</span>
+						<input
+							type="checkbox"
+							checked={cursorFollow.textZoomEnabled ?? false}
+							onChange={(e) => handleTextZoomChange(e.target.checked)}
 							className="h-4 w-4"
 						/>
 					</label>

--- a/src/components/video-editor/CropControl.tsx
+++ b/src/components/video-editor/CropControl.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { type AspectRatio } from "@/utils/aspectRatioUtils";
+import {
+	computeCursorFollowCrop,
+	createCursorFollowCropState,
+	resetCursorFollowCropState,
+} from "./videoPlayback/cursorFollowCrop";
+import type { CursorFollowCropSettings, CursorTelemetryPoint } from "./types";
 
 interface CropRegion {
 	x: number; // 0-1 normalized
@@ -14,16 +20,90 @@ interface CropControlProps {
 	cropRegion: CropRegion;
 	onCropChange: (region: CropRegion) => void;
 	aspectRatio: AspectRatio;
+	cursorFollow?: CursorFollowCropSettings;
+	onCursorFollowChange?: (settings: CursorFollowCropSettings) => void;
+	cursorTelemetry?: CursorTelemetryPoint[];
+	currentTimeMs?: number;
 }
 
 type DragHandle = "top" | "right" | "bottom" | "left" | null;
 
-export function CropControl({ videoElement, cropRegion, onCropChange }: CropControlProps) {
+interface ResolutionPreset {
+	id: string;
+	label: string;
+	width: number;
+	height: number;
+}
+
+const OUTPUT_RESOLUTION_PRESETS: ResolutionPreset[] = [
+	{ id: "1080p", label: "1080p", width: 1920, height: 1080 },
+	{ id: "720p", label: "720p", width: 1280, height: 720 },
+	{ id: "480p", label: "480p", width: 854, height: 480 },
+];
+
+const RESOLUTION_MATCH_EPSILON = 0.005;
+
+function matchActiveResolutionPreset(
+	crop: CropRegion,
+	sourceWidth: number,
+	sourceHeight: number,
+): string | null {
+	if (!sourceWidth || !sourceHeight) return null;
+	for (const preset of OUTPUT_RESOLUTION_PRESETS) {
+		const w = Math.min(1, preset.width / sourceWidth);
+		const h = Math.min(1, preset.height / sourceHeight);
+		if (
+			Math.abs(crop.width - w) < RESOLUTION_MATCH_EPSILON &&
+			Math.abs(crop.height - h) < RESOLUTION_MATCH_EPSILON
+		) {
+			return preset.id;
+		}
+	}
+	return null;
+}
+
+export function CropControl({
+	videoElement,
+	cropRegion,
+	onCropChange,
+	cursorFollow,
+	onCursorFollowChange,
+	cursorTelemetry,
+	currentTimeMs,
+}: CropControlProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [isDragging, setIsDragging] = useState<DragHandle>(null);
 	const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
 	const [initialCrop, setInitialCrop] = useState<CropRegion>(cropRegion);
+
+	const followEnabled = cursorFollow?.enabled === true;
+	const previewMode = cursorFollow?.previewMode ?? "source";
+	const showOutputMode = followEnabled && previewMode === "output";
+
+	const followStateRef = useRef(createCursorFollowCropState());
+	const [effectiveCrop, setEffectiveCrop] = useState<CropRegion>(cropRegion);
+
+	useEffect(() => {
+		resetCursorFollowCropState(followStateRef.current);
+	}, [followEnabled, cropRegion.width, cropRegion.height]);
+
+	useEffect(() => {
+		if (!followEnabled || !cursorFollow) {
+			setEffectiveCrop(cropRegion);
+			return;
+		}
+		const samples = cursorTelemetry ?? [];
+		const t = typeof currentTimeMs === "number" ? currentTimeMs : 0;
+		const next = computeCursorFollowCrop(
+			followStateRef.current,
+			samples,
+			t,
+			cropRegion,
+			cursorFollow,
+		);
+		setEffectiveCrop(next);
+	}, [followEnabled, cursorFollow, cropRegion, cursorTelemetry, currentTimeMs]);
 
 	useEffect(() => {
 		if (!videoElement || !canvasRef.current) return;
@@ -32,8 +112,10 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 		const ctx = canvas.getContext("2d", { alpha: false });
 		if (!ctx) return;
 
-		canvas.width = videoElement.videoWidth || 1920;
-		canvas.height = videoElement.videoHeight || 1080;
+		const sourceWidth = videoElement.videoWidth || 1920;
+		const sourceHeight = videoElement.videoHeight || 1080;
+		canvas.width = sourceWidth;
+		canvas.height = sourceHeight;
 
 		let animationFrameId = 0;
 		let isCancelled = false;
@@ -45,7 +127,15 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 
 			if (videoElement.readyState >= 2) {
 				ctx.clearRect(0, 0, canvas.width, canvas.height);
-				ctx.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+				if (showOutputMode) {
+					const sx = effectiveCrop.x * sourceWidth;
+					const sy = effectiveCrop.y * sourceHeight;
+					const sw = Math.max(1, effectiveCrop.width * sourceWidth);
+					const sh = Math.max(1, effectiveCrop.height * sourceHeight);
+					ctx.drawImage(videoElement, sx, sy, sw, sh, 0, 0, canvas.width, canvas.height);
+				} else {
+					ctx.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+				}
 			}
 			animationFrameId = requestAnimationFrame(draw);
 		};
@@ -55,7 +145,7 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 			isCancelled = true;
 			cancelAnimationFrame(animationFrameId);
 		};
-	}, [videoElement]);
+	}, [videoElement, showOutputMode, effectiveCrop]);
 
 	const getContainerRect = () => {
 		return (
@@ -101,33 +191,62 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 
 		let newCrop = { ...initialCrop };
 
-		switch (isDragging) {
-			case "top": {
-				const newY = Math.max(0, initialCrop.y + deltaY);
-				const bottom = initialCrop.y + initialCrop.height;
-				newCrop.y = Math.min(newY, bottom - 0.1);
-				newCrop.height = bottom - newCrop.y;
-				break;
+		if (followEnabled) {
+			// When tracking cursor, drag handles only resize the viewport — never
+			// reposition. The viewport's top-left is computed per-frame from cursor
+			// telemetry, so we keep crop.x/y as the home position unchanged and only
+			// adjust width/height.
+			switch (isDragging) {
+				case "top": {
+					const nextHeight = Math.max(0.1, Math.min(1, initialCrop.height - deltaY));
+					newCrop.height = nextHeight;
+					break;
+				}
+				case "bottom": {
+					const nextHeight = Math.max(0.1, Math.min(1, initialCrop.height + deltaY));
+					newCrop.height = nextHeight;
+					break;
+				}
+				case "left": {
+					const nextWidth = Math.max(0.1, Math.min(1, initialCrop.width - deltaX));
+					newCrop.width = nextWidth;
+					break;
+				}
+				case "right": {
+					const nextWidth = Math.max(0.1, Math.min(1, initialCrop.width + deltaX));
+					newCrop.width = nextWidth;
+					break;
+				}
 			}
-			case "bottom":
-				newCrop.height = Math.max(
-					0.1,
-					Math.min(initialCrop.height + deltaY, 1 - initialCrop.y),
-				);
-				break;
-			case "left": {
-				const newX = Math.max(0, initialCrop.x + deltaX);
-				const right = initialCrop.x + initialCrop.width;
-				newCrop.x = Math.min(newX, right - 0.1);
-				newCrop.width = right - newCrop.x;
-				break;
+		} else {
+			switch (isDragging) {
+				case "top": {
+					const newY = Math.max(0, initialCrop.y + deltaY);
+					const bottom = initialCrop.y + initialCrop.height;
+					newCrop.y = Math.min(newY, bottom - 0.1);
+					newCrop.height = bottom - newCrop.y;
+					break;
+				}
+				case "bottom":
+					newCrop.height = Math.max(
+						0.1,
+						Math.min(initialCrop.height + deltaY, 1 - initialCrop.y),
+					);
+					break;
+				case "left": {
+					const newX = Math.max(0, initialCrop.x + deltaX);
+					const right = initialCrop.x + initialCrop.width;
+					newCrop.x = Math.min(newX, right - 0.1);
+					newCrop.width = right - newCrop.x;
+					break;
+				}
+				case "right":
+					newCrop.width = Math.max(
+						0.1,
+						Math.min(initialCrop.width + deltaX, 1 - initialCrop.x),
+					);
+					break;
 			}
-			case "right":
-				newCrop.width = Math.max(
-					0.1,
-					Math.min(initialCrop.width + deltaX, 1 - initialCrop.x),
-				);
-				break;
 		}
 
 		onCropChange(newCrop);
@@ -144,10 +263,11 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 		setIsDragging(null);
 	};
 
-	const cropPixelX = cropRegion.x * 100;
-	const cropPixelY = cropRegion.y * 100;
-	const cropPixelWidth = cropRegion.width * 100;
-	const cropPixelHeight = cropRegion.height * 100;
+	const overlayCrop = followEnabled ? effectiveCrop : cropRegion;
+	const cropPixelX = overlayCrop.x * 100;
+	const cropPixelY = overlayCrop.y * 100;
+	const cropPixelWidth = overlayCrop.width * 100;
+	const cropPixelHeight = overlayCrop.height * 100;
 	const videoAspectRatio = videoElement
 		? videoElement.videoWidth / videoElement.videoHeight
 		: 16 / 9;
@@ -155,8 +275,180 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 	const maxContainerWidth = isVideoPortrait ? "40vw" : "75vw";
 	const maxContainerHeight = "75vh";
 
+	const handleToggleFollow = (next: boolean) => {
+		if (!cursorFollow || !onCursorFollowChange) return;
+		onCursorFollowChange({ ...cursorFollow, enabled: next });
+	};
+	const handleSafeZoneChange = (value: number) => {
+		if (!cursorFollow || !onCursorFollowChange) return;
+		onCursorFollowChange({ ...cursorFollow, safeZoneRatio: value });
+	};
+	const handleSmoothnessChange = (value: number) => {
+		if (!cursorFollow || !onCursorFollowChange) return;
+		onCursorFollowChange({ ...cursorFollow, smoothness: value });
+	};
+	const handlePreviewModeChange = (mode: "source" | "output") => {
+		if (!cursorFollow || !onCursorFollowChange) return;
+		onCursorFollowChange({ ...cursorFollow, previewMode: mode });
+	};
+	const handleTrackTextCursorChange = (value: boolean) => {
+		if (!cursorFollow || !onCursorFollowChange) return;
+		onCursorFollowChange({ ...cursorFollow, trackTextCursor: value });
+	};
+
+	const sourceWidthPx = videoElement?.videoWidth ?? 0;
+	const sourceHeightPx = videoElement?.videoHeight ?? 0;
+	const activePresetId = matchActiveResolutionPreset(cropRegion, sourceWidthPx, sourceHeightPx);
+	const currentOutputWidthPx = Math.max(1, Math.round(cropRegion.width * sourceWidthPx));
+	const currentOutputHeightPx = Math.max(1, Math.round(cropRegion.height * sourceHeightPx));
+
+	const handleResolutionPreset = (preset: ResolutionPreset) => {
+		if (!sourceWidthPx || !sourceHeightPx) return;
+		const width = Math.min(1, preset.width / sourceWidthPx);
+		const height = Math.min(1, preset.height / sourceHeightPx);
+		// Keep the crop centered on its current center where possible.
+		const cx = cropRegion.x + cropRegion.width / 2;
+		const cy = cropRegion.y + cropRegion.height / 2;
+		const x = Math.max(0, Math.min(1 - width, cx - width / 2));
+		const y = Math.max(0, Math.min(1 - height, cy - height / 2));
+		onCropChange({ x, y, width, height });
+	};
+
+	const showOverlay = !showOutputMode;
+	const showHandles = !showOutputMode && (!followEnabled ? true : true);
+
+	const controlsAvailable = useMemo(
+		() => Boolean(cursorFollow && onCursorFollowChange),
+		[cursorFollow, onCursorFollowChange],
+	);
+
 	return (
 		<div className="w-full p-8">
+			{controlsAvailable && cursorFollow ? (
+				<div className="mx-auto mb-4 flex max-w-3xl flex-col gap-3 rounded-lg border border-border bg-card/40 p-4">
+					<label className="flex items-center justify-between gap-3 text-sm">
+						<span className="font-medium">Track cursor</span>
+						<input
+							type="checkbox"
+							checked={cursorFollow.enabled}
+							onChange={(e) => handleToggleFollow(e.target.checked)}
+							className="h-4 w-4"
+						/>
+					</label>
+					{cursorFollow.enabled ? (
+						<>
+							<div className="flex items-center gap-3 text-xs">
+								<span className="w-28 text-muted-foreground">Output size</span>
+								<div className="inline-flex flex-wrap gap-1">
+									{OUTPUT_RESOLUTION_PRESETS.map((preset) => {
+										const fits =
+											sourceWidthPx >= preset.width &&
+											sourceHeightPx >= preset.height;
+										const active = activePresetId === preset.id;
+										return (
+											<button
+												key={preset.id}
+												type="button"
+												disabled={!fits}
+												onClick={() => handleResolutionPreset(preset)}
+												className={cn(
+													"rounded-md border px-2 py-1 transition",
+													active
+														? "border-foreground bg-foreground text-background"
+														: "border-border bg-transparent text-muted-foreground hover:bg-foreground/10",
+													!fits && "cursor-not-allowed opacity-40",
+												)}
+											>
+												{preset.label}
+											</button>
+										);
+									})}
+								</div>
+								<span className="ml-auto text-right tabular-nums text-muted-foreground">
+									{sourceWidthPx && sourceHeightPx
+										? `${currentOutputWidthPx}×${currentOutputHeightPx}`
+										: "—"}
+								</span>
+							</div>
+							<div className="flex items-center gap-3 text-xs">
+								<span className="w-28 text-muted-foreground">Safe zone</span>
+								<input
+									type="range"
+									min={0}
+									max={0.49}
+									step={0.01}
+									value={cursorFollow.safeZoneRatio}
+									onChange={(e) =>
+										handleSafeZoneChange(Number(e.target.value))
+									}
+									className="flex-1"
+								/>
+								<span className="w-10 text-right tabular-nums">
+									{Math.round(cursorFollow.safeZoneRatio * 100)}%
+								</span>
+							</div>
+							<div className="flex items-center gap-3 text-xs">
+								<span className="w-28 text-muted-foreground">Smoothness</span>
+								<input
+									type="range"
+									min={0}
+									max={1}
+									step={0.01}
+									value={cursorFollow.smoothness}
+									onChange={(e) =>
+										handleSmoothnessChange(Number(e.target.value))
+									}
+									className="flex-1"
+								/>
+								<span className="w-10 text-right tabular-nums">
+									{Math.round(cursorFollow.smoothness * 100)}%
+								</span>
+							</div>
+							<label className="flex items-center gap-3 text-xs">
+								<span className="w-28 text-muted-foreground">Text cursor focus</span>
+								<input
+									type="checkbox"
+									checked={cursorFollow.trackTextCursor ?? false}
+									onChange={(e) => handleTrackTextCursorChange(e.target.checked)}
+									className="h-4 w-4"
+								/>
+								<span className="text-muted-foreground/60">
+									Locks on typing area; follows mouse when moving
+								</span>
+							</label>
+							<div className="flex items-center gap-2 text-xs">
+								<span className="w-28 text-muted-foreground">Preview</span>
+								<div className="inline-flex overflow-hidden rounded-md border border-border">
+									<button
+										type="button"
+										onClick={() => handlePreviewModeChange("source")}
+										className={cn(
+											"px-3 py-1 transition",
+											previewMode === "source"
+												? "bg-foreground text-background"
+												: "bg-transparent text-muted-foreground hover:bg-foreground/10",
+										)}
+									>
+										Source
+									</button>
+									<button
+										type="button"
+										onClick={() => handlePreviewModeChange("output")}
+										className={cn(
+											"px-3 py-1 transition",
+											previewMode === "output"
+												? "bg-foreground text-background"
+												: "bg-transparent text-muted-foreground hover:bg-foreground/10",
+										)}
+									>
+										Output
+									</button>
+								</div>
+							</div>
+						</>
+					) : null}
+				</div>
+			) : null}
 			<div
 				ref={containerRef}
 				className="relative w-full bg-black rounded-lg overflow-visible cursor-default select-none shadow-2xl"
@@ -176,99 +468,105 @@ export function CropControl({ videoElement, cropRegion, onCropChange }: CropCont
 					style={{ imageRendering: "auto" }}
 				/>
 
-				<div
-					className="absolute inset-0 pointer-events-none"
-					style={{ transition: "none" }}
-				>
-					<svg
-						width="100%"
-						height="100%"
-						className="absolute inset-0"
+				{showOverlay ? (
+					<div
+						className="absolute inset-0 pointer-events-none"
 						style={{ transition: "none" }}
 					>
-						<defs>
-							<mask id="cropMask">
-								<rect width="100%" height="100%" fill="white" />
-								<rect
-									x={`${cropPixelX}%`}
-									y={`${cropPixelY}%`}
-									width={`${cropPixelWidth}%`}
-									height={`${cropPixelHeight}%`}
-									fill="black"
-									style={{ transition: "none" }}
-								/>
-							</mask>
-						</defs>
-						<rect
+						<svg
 							width="100%"
 							height="100%"
-							fill="black"
-							fillOpacity="0.6"
-							mask="url(#cropMask)"
+							className="absolute inset-0"
 							style={{ transition: "none" }}
+						>
+							<defs>
+								<mask id="cropMask">
+									<rect width="100%" height="100%" fill="white" />
+									<rect
+										x={`${cropPixelX}%`}
+										y={`${cropPixelY}%`}
+										width={`${cropPixelWidth}%`}
+										height={`${cropPixelHeight}%`}
+										fill="black"
+										style={{ transition: "none" }}
+									/>
+								</mask>
+							</defs>
+							<rect
+								width="100%"
+								height="100%"
+								fill="black"
+								fillOpacity="0.6"
+								mask="url(#cropMask)"
+								style={{ transition: "none" }}
+							/>
+						</svg>
+					</div>
+				) : null}
+
+				{showHandles ? (
+					<>
+						<div
+							className={cn(
+								"absolute h-[3px] cursor-ns-resize z-20 pointer-events-auto bg-[#2563EB]",
+							)}
+							style={{
+								left: `${cropPixelX}%`,
+								top: `${cropPixelY}%`,
+								width: `${cropPixelWidth}%`,
+								transform: "translateY(-50%)",
+								willChange: "transform",
+								transition: "none",
+							}}
+							onPointerDown={(e) => handlePointerDown(e, "top")}
 						/>
-					</svg>
-				</div>
 
-				<div
-					className={cn(
-						"absolute h-[3px] cursor-ns-resize z-20 pointer-events-auto bg-[#2563EB]",
-					)}
-					style={{
-						left: `${cropPixelX}%`,
-						top: `${cropPixelY}%`,
-						width: `${cropPixelWidth}%`,
-						transform: "translateY(-50%)",
-						willChange: "transform",
-						transition: "none",
-					}}
-					onPointerDown={(e) => handlePointerDown(e, "top")}
-				/>
+						<div
+							className={cn(
+								"absolute h-[3px] cursor-ns-resize z-20 pointer-events-auto bg-[#2563EB]",
+							)}
+							style={{
+								left: `${cropPixelX}%`,
+								top: `${cropPixelY + cropPixelHeight}%`,
+								width: `${cropPixelWidth}%`,
+								transform: "translateY(-50%)",
+								willChange: "transform",
+								transition: "none",
+							}}
+							onPointerDown={(e) => handlePointerDown(e, "bottom")}
+						/>
 
-				<div
-					className={cn(
-						"absolute h-[3px] cursor-ns-resize z-20 pointer-events-auto bg-[#2563EB]",
-					)}
-					style={{
-						left: `${cropPixelX}%`,
-						top: `${cropPixelY + cropPixelHeight}%`,
-						width: `${cropPixelWidth}%`,
-						transform: "translateY(-50%)",
-						willChange: "transform",
-						transition: "none",
-					}}
-					onPointerDown={(e) => handlePointerDown(e, "bottom")}
-				/>
+						<div
+							className={cn(
+								"absolute w-[3px] cursor-ew-resize z-20 pointer-events-auto bg-[#2563EB]",
+							)}
+							style={{
+								left: `${cropPixelX}%`,
+								top: `${cropPixelY}%`,
+								height: `${cropPixelHeight}%`,
+								transform: "translateX(-50%)",
+								willChange: "transform",
+								transition: "none",
+							}}
+							onPointerDown={(e) => handlePointerDown(e, "left")}
+						/>
 
-				<div
-					className={cn(
-						"absolute w-[3px] cursor-ew-resize z-20 pointer-events-auto bg-[#2563EB]",
-					)}
-					style={{
-						left: `${cropPixelX}%`,
-						top: `${cropPixelY}%`,
-						height: `${cropPixelHeight}%`,
-						transform: "translateX(-50%)",
-						willChange: "transform",
-						transition: "none",
-					}}
-					onPointerDown={(e) => handlePointerDown(e, "left")}
-				/>
-
-				<div
-					className={cn(
-						"absolute w-[3px] cursor-ew-resize z-20 pointer-events-auto bg-[#2563EB]",
-					)}
-					style={{
-						left: `${cropPixelX + cropPixelWidth}%`,
-						top: `${cropPixelY}%`,
-						height: `${cropPixelHeight}%`,
-						transform: "translateX(-50%)",
-						willChange: "transform",
-						transition: "none",
-					}}
-					onPointerDown={(e) => handlePointerDown(e, "right")}
-				/>
+						<div
+							className={cn(
+								"absolute w-[3px] cursor-ew-resize z-20 pointer-events-auto bg-[#2563EB]",
+							)}
+							style={{
+								left: `${cropPixelX + cropPixelWidth}%`,
+								top: `${cropPixelY}%`,
+								height: `${cropPixelHeight}%`,
+								transform: "translateX(-50%)",
+								willChange: "transform",
+								transition: "none",
+							}}
+							onPointerDown={(e) => handlePointerDown(e, "right")}
+						/>
+					</>
+				) : null}
 			</div>
 		</div>
 	);

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -174,6 +174,7 @@ import {
 	type ClipRegion,
 	type CropRegion,
 	type CursorClickEffectStyle,
+	type CursorFollowCropSettings,
 	type CursorStyle,
 	type CursorTelemetryPoint,
 	clampFocusToDepth,
@@ -187,6 +188,7 @@ import {
 	DEFAULT_CONNECTED_ZOOM_EASING,
 	DEFAULT_CONNECTED_ZOOM_GAP_MS,
 	DEFAULT_CROP_REGION,
+	DEFAULT_CURSOR_FOLLOW_CROP,
 	DEFAULT_CURSOR_STYLE,
 	DEFAULT_FIGURE_DATA,
 	DEFAULT_WEBCAM_OVERLAY,
@@ -489,6 +491,9 @@ export default function VideoEditor() {
 	const [padding, setPadding] = useState(initialEditorPreferences.padding);
 	const [frame, setFrame] = useState<string | null>(initialEditorPreferences.frame);
 	const [cropRegion, setCropRegion] = useState<CropRegion>(DEFAULT_CROP_REGION);
+	const [cursorFollowCrop, setCursorFollowCrop] = useState<CursorFollowCropSettings>(
+		DEFAULT_CURSOR_FOLLOW_CROP,
+	);
 	const [webcam, setWebcam] = useState<WebcamOverlaySettings>(
 		initialEditorPreferences.webcam ?? DEFAULT_WEBCAM_OVERLAY,
 	);
@@ -1095,6 +1100,7 @@ export default function VideoEditor() {
 					borderRadius,
 					padding,
 					cropRegion,
+					cursorFollowCrop,
 					webcam,
 					webcamUrl:
 						resolvedWebcamVideoUrl ??
@@ -1629,6 +1635,7 @@ export default function VideoEditor() {
 				padding: Padding;
 				frame: string | null;
 				cropRegion: CropRegion;
+				cursorFollowCrop: CursorFollowCropSettings;
 				webcam: WebcamOverlaySettings;
 				zoomRegions: ZoomRegion[];
 				trimRegions: TrimRegion[];
@@ -1737,6 +1744,7 @@ export default function VideoEditor() {
 				padding,
 				frame,
 				cropRegion,
+				cursorFollowCrop,
 				webcam,
 				zoomRegions,
 				trimRegions,
@@ -1803,6 +1811,7 @@ export default function VideoEditor() {
 			borderRadius,
 			padding,
 			cropRegion,
+			cursorFollowCrop,
 			webcam,
 			zoomRegions,
 			trimRegions,
@@ -1993,6 +2002,7 @@ export default function VideoEditor() {
 			setPadding(normalizedEditor.padding);
 			setFrame(normalizedEditor.frame);
 			setCropRegion(normalizedEditor.cropRegion);
+			setCursorFollowCrop(normalizedEditor.cursorFollowCrop);
 			setWebcam(normalizedEditor.webcam);
 			setZoomRegions(normalizedEditor.zoomRegions);
 			setTrimRegions(normalizedEditor.trimRegions);
@@ -4220,6 +4230,7 @@ export default function VideoEditor() {
 						padding,
 						videoPadding: padding,
 						cropRegion,
+						cursorFollowCrop,
 						webcam,
 						webcamUrl:
 							resolvedWebcamVideoUrl ??
@@ -4403,6 +4414,7 @@ export default function VideoEditor() {
 						borderRadius,
 						padding,
 						cropRegion,
+						cursorFollowCrop,
 						webcam,
 						webcamUrl:
 							resolvedWebcamVideoUrl ??
@@ -4704,6 +4716,7 @@ export default function VideoEditor() {
 			borderRadius,
 			padding,
 			cropRegion,
+			cursorFollowCrop,
 			webcam,
 			resolvedWebcamVideoUrl,
 			annotationRegions,
@@ -5118,6 +5131,7 @@ export default function VideoEditor() {
 			padding={padding}
 			frame={frame}
 			cropRegion={cropRegion}
+			cursorFollowCrop={cursorFollowCrop}
 			webcam={webcam}
 			webcamVideoPath={webcam.sourcePath ? resolvedWebcamVideoUrl : null}
 			trimRegions={trimRegions}
@@ -6338,6 +6352,10 @@ export default function VideoEditor() {
 							cropRegion={cropRegion}
 							onCropChange={setCropRegion}
 							aspectRatio={aspectRatio}
+							cursorFollow={cursorFollowCrop}
+							onCursorFollowChange={setCursorFollowCrop}
+							cursorTelemetry={cursorTelemetry}
+							currentTimeMs={currentTime * 1000}
 						/>
 						<div className="mt-6 flex justify-end">
 							<Button

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -171,6 +171,12 @@ import {
 	createCursorFollowCropState,
 	resetCursorFollowCropState,
 } from "./videoPlayback/cursorFollowCrop";
+import {
+	type CursorTextZoomState,
+	computeCursorTextZoom,
+	createCursorTextZoomState,
+	resetCursorTextZoomState,
+} from "./videoPlayback/cursorTextZoom";
 import { clampFocusToStage as clampFocusToStageUtil } from "./videoPlayback/focusUtils";
 import { layoutVideoContent as layoutVideoContentUtil } from "./videoPlayback/layoutUtils";
 import { updateOverlayIndicator } from "./videoPlayback/overlayUtils";
@@ -622,6 +628,9 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		const cursorFollowCropRef = useRef(cursorFollowCrop);
 		const cursorFollowCropStateRef = useRef<CursorFollowCropState>(
 			createCursorFollowCropState(),
+		);
+		const cursorTextZoomStateRef = useRef<CursorTextZoomState>(
+			createCursorTextZoomState(),
 		);
 		const baseCropRegionRef = useRef(cropRegion);
 		const effectiveCropRegionRef = useRef(cropRegion);
@@ -1368,6 +1377,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				resetSpringState(springXRef.current);
 				resetSpringState(springYRef.current);
 				resetCursorFollowCamera(cursorFollowCameraRef.current);
+				resetCursorTextZoomState(cursorTextZoomStateRef.current);
 				lastTickTimeRef.current = null;
 			}
 			const bgVideo = bgVideoRef.current;
@@ -1551,7 +1561,15 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		useEffect(() => {
 			cursorFollowCropRef.current = cursorFollowCrop;
 			resetCursorFollowCropState(cursorFollowCropStateRef.current);
-		}, [cursorFollowCrop?.enabled, cursorFollowCrop?.safeZoneRatio, cursorFollowCrop?.smoothness, cursorFollowCrop?.trackTextCursor]);
+			resetCursorTextZoomState(cursorTextZoomStateRef.current);
+		}, [
+			cursorFollowCrop?.enabled,
+			cursorFollowCrop?.safeZoneRatio,
+			cursorFollowCrop?.smoothness,
+			cursorFollowCrop?.trackTextCursor,
+			cursorFollowCrop?.textZoomEnabled,
+			cursorFollowCrop?.textZoomDepth,
+		]);
 
 		useEffect(() => {
 			baseCropRegionRef.current = cropRegion ?? { x: 0, y: 0, width: 1, height: 1 };
@@ -2343,6 +2361,34 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 						});
 						targetProgress = 1;
 					}
+				}
+
+				// Text-zoom layer: an independent punch-in on the typing spot,
+				// applied only when no explicit zoom region is driving the camera
+				// (explicit zooms always win). The shared zoom spring below eases
+				// the scale/position in and out, so we just emit a stable target.
+				const explicitZoomActive = Boolean(
+					region && strength > 0 && !shouldShowUnzoomedView,
+				);
+				if (
+					cursorFollowCropRef.current?.textZoomEnabled &&
+					!explicitZoomActive &&
+					!shouldShowUnzoomedView &&
+					cursorTelemetryRef.current.length > 0
+				) {
+					const textZoom = computeCursorTextZoom(
+						cursorTextZoomStateRef.current,
+						cursorTelemetryRef.current,
+						currentTimeRef.current,
+						cursorFollowCropRef.current,
+					);
+					if (textZoom.active) {
+						targetScaleFactor = textZoom.scale;
+						targetFocus = textZoom.focus;
+						targetProgress = 1;
+					}
+				} else if (!cursorFollowCropRef.current?.textZoomEnabled) {
+					resetCursorTextZoomState(cursorTextZoomStateRef.current);
 				}
 
 				const state = animationStateRef.current;

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -165,6 +165,12 @@ import {
 	resetCursorFollowCamera,
 	SNAP_TO_EDGES_RATIO_AUTO,
 } from "./videoPlayback/cursorFollowCamera";
+import {
+	type CursorFollowCropState,
+	computeCursorFollowCrop,
+	createCursorFollowCropState,
+	resetCursorFollowCropState,
+} from "./videoPlayback/cursorFollowCrop";
 import { clampFocusToStage as clampFocusToStageUtil } from "./videoPlayback/focusUtils";
 import { layoutVideoContent as layoutVideoContentUtil } from "./videoPlayback/layoutUtils";
 import { updateOverlayIndicator } from "./videoPlayback/overlayUtils";
@@ -350,6 +356,7 @@ interface VideoPlaybackProps {
 	padding?: Padding | number;
 	frame?: string | null;
 	cropRegion?: import("./types").CropRegion;
+	cursorFollowCrop?: import("./types").CursorFollowCropSettings;
 	webcam?: WebcamOverlaySettings;
 	webcamVideoPath?: string | null;
 	trimRegions?: TrimRegion[];
@@ -433,6 +440,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			padding = DEFAULT_PADDING,
 			frame = null,
 			cropRegion,
+			cursorFollowCrop,
 			webcam,
 			webcamVideoPath,
 			trimRegions = [],
@@ -611,6 +619,12 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		const cursorFollowCameraRef = useRef<CursorFollowCameraState>(
 			createCursorFollowCameraState(),
 		);
+		const cursorFollowCropRef = useRef(cursorFollowCrop);
+		const cursorFollowCropStateRef = useRef<CursorFollowCropState>(
+			createCursorFollowCropState(),
+		);
+		const baseCropRegionRef = useRef(cropRegion);
+		const effectiveCropRegionRef = useRef(cropRegion);
 
 		const initializePixiRenderer = useCallback(
 			async (
@@ -1535,6 +1549,17 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		}, [connectedZoomEasing]);
 
 		useEffect(() => {
+			cursorFollowCropRef.current = cursorFollowCrop;
+			resetCursorFollowCropState(cursorFollowCropStateRef.current);
+		}, [cursorFollowCrop?.enabled, cursorFollowCrop?.safeZoneRatio, cursorFollowCrop?.smoothness, cursorFollowCrop?.trackTextCursor]);
+
+		useEffect(() => {
+			baseCropRegionRef.current = cropRegion ?? { x: 0, y: 0, width: 1, height: 1 };
+			effectiveCropRegionRef.current = baseCropRegionRef.current;
+			resetCursorFollowCropState(cursorFollowCropStateRef.current);
+		}, [cropRegion]);
+
+		useEffect(() => {
 			cursorTelemetryRef.current = cursorTelemetry;
 			// Push to extension host for query APIs
 			extensionHost.setCursorTelemetry(
@@ -2192,6 +2217,44 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			const ticker = () => {
 				if (suspendRenderingRef.current) {
 					return;
+				}
+
+				// Cursor-follow crop: per-frame viewport pan within the source video.
+				// When enabled, recompute the effective crop top-left from cursor
+				// telemetry and shift the video sprite to keep the cursor framed.
+				const followSettings = cursorFollowCropRef.current;
+				const baseCrop = baseCropRegionRef.current;
+				const sprite = videoSpriteRef.current;
+				const lockedDims = lockedVideoDimensionsRef.current;
+				if (followSettings?.enabled && sprite && lockedDims && baseCrop) {
+					const effectiveCrop = computeCursorFollowCrop(
+						cursorFollowCropStateRef.current,
+						cursorTelemetryRef.current,
+						currentTimeRef.current,
+						baseCrop,
+						followSettings,
+					);
+					effectiveCropRegionRef.current = effectiveCrop;
+					const fullVideoDisplayWidth = lockedDims.width * baseScaleRef.current;
+					const fullVideoDisplayHeight = lockedDims.height * baseScaleRef.current;
+					const dx = (effectiveCrop.x - baseCrop.x) * fullVideoDisplayWidth;
+					const dy = (effectiveCrop.y - baseCrop.y) * fullVideoDisplayHeight;
+					sprite.position.set(
+						baseOffsetRef.current.x - dx,
+						baseOffsetRef.current.y - dy,
+					);
+					cropBoundsRef.current = {
+						startX: effectiveCrop.x * lockedDims.width,
+						endX: effectiveCrop.x * lockedDims.width + effectiveCrop.width * lockedDims.width,
+						startY: effectiveCrop.y * lockedDims.height,
+						endY: effectiveCrop.y * lockedDims.height + effectiveCrop.height * lockedDims.height,
+					};
+					if (baseMaskRef.current.sourceCrop) {
+						baseMaskRef.current.sourceCrop = { ...effectiveCrop };
+					}
+				} else if (sprite) {
+					effectiveCropRegionRef.current = baseCrop;
+					sprite.position.set(baseOffsetRef.current.x, baseOffsetRef.current.y);
 				}
 
 				const { region, strength, blendedScale, transition } = findDominantRegion(

--- a/src/components/video-editor/audio/waveform/WaveformGenerator.ts
+++ b/src/components/video-editor/audio/waveform/WaveformGenerator.ts
@@ -4,8 +4,13 @@ import { WAVEFORM_DEFAULT_PEAK_COUNT } from "../../timeline/core/constants";
 
 const MAX_WAVEFORM_PEAKS = 200_000;
 
+// Waveform peaks only need coarse amplitude data (~500 peaks/sec), so decode at
+// a low sample rate. Decoding long recordings at the native 48kHz allocates
+// gigabytes of PCM (50min stereo float32 ≈ 1.15 GB per file) and OOMs the
+// renderer; 8kHz cuts that 6x while remaining visually identical.
+const WAVEFORM_DECODE_SAMPLE_RATE = 8000;
+
 export class WaveformGenerator {
-	private audioContext: AudioContext;
 	private worker: Worker;
 	private peaksCache = new Map<string, AudioPeaksData>();
 	private pending = new Map<string, Promise<AudioPeaksData>>();
@@ -13,7 +18,6 @@ export class WaveformGenerator {
 	private workerResolvers = new Map<number, { resolve: (peaks: Float32Array) => void; reject: (err: Error) => void }>();
 
 	constructor() {
-		this.audioContext = new (window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext)();
 		this.worker = new WorkerConstructor();
 		
 		this.worker.addEventListener(
@@ -60,6 +64,10 @@ export class WaveformGenerator {
 		});
 	}
 
+	// Files larger than this threshold are skipped to avoid OOMing the renderer.
+	// Audio sidecars are typically <100 MB; main video files can be several GB.
+	static readonly MAX_DECODE_BYTES = 200 * 1024 * 1024; // 200 MB
+
 	public async generate(url: string, peakCount = WAVEFORM_DEFAULT_PEAK_COUNT): Promise<AudioPeaksData> {
 		const cacheKey = `${url}::${peakCount}`;
 		const cached = this.peaksCache.get(cacheKey);
@@ -69,13 +77,31 @@ export class WaveformGenerator {
 		if (inflight) return inflight;
 
 		const request = (async () => {
+			const headResponse = await fetch(url, { method: "HEAD" });
+			if (!headResponse.ok) {
+				throw new Error(`Failed to probe media: ${headResponse.status}`);
+			}
+			const contentLength = parseInt(headResponse.headers.get("content-length") ?? "0", 10);
+			if (contentLength > WaveformGenerator.MAX_DECODE_BYTES) {
+				throw new Error(
+					`File too large for in-memory audio decode (${Math.round(contentLength / 1024 / 1024)} MB)`,
+				);
+			}
+
 			const response = await fetch(url);
 			if (!response.ok) {
 				throw new Error(`Failed to load media: ${response.status}`);
 			}
 
 			const arrayBuffer = await response.arrayBuffer();
-			const decoded = await this.audioContext.decodeAudioData(arrayBuffer);
+			// A throwaway OfflineAudioContext decodes (and resamples) at the low
+			// waveform rate instead of the hardware rate of a live AudioContext.
+			const decodeContext = new OfflineAudioContext({
+				numberOfChannels: 1,
+				length: 1,
+				sampleRate: WAVEFORM_DECODE_SAMPLE_RATE,
+			});
+			const decoded = await decodeContext.decodeAudioData(arrayBuffer);
 			const adaptivePeakCount = Math.max(
 				peakCount,
 				Math.floor(decoded.duration * 500)

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -839,6 +839,13 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 			typeof rawCursorFollowCrop?.trackTextCursor === "boolean"
 				? rawCursorFollowCrop.trackTextCursor
 				: DEFAULT_CURSOR_FOLLOW_CROP.trackTextCursor,
+		textZoomEnabled:
+			typeof rawCursorFollowCrop?.textZoomEnabled === "boolean"
+				? rawCursorFollowCrop.textZoomEnabled
+				: (DEFAULT_CURSOR_FOLLOW_CROP.textZoomEnabled ?? false),
+		...(isFiniteNumber(rawCursorFollowCrop?.textZoomDepth)
+			? { textZoomDepth: clamp(rawCursorFollowCrop.textZoomDepth, 1, 4) }
+			: {}),
 	};
 
 	const webcam: Partial<WebcamOverlaySettings> =

--- a/src/components/video-editor/projectPersistence.ts
+++ b/src/components/video-editor/projectPersistence.ts
@@ -31,6 +31,8 @@ import {
 	type ClipRegion,
 	type CropRegion,
 	type CursorClickEffectStyle,
+	type CursorFollowCropPreviewMode,
+	type CursorFollowCropSettings,
 	type CursorStyle,
 	DEFAULT_ANNOTATION_POSITION,
 	DEFAULT_ANNOTATION_SIZE,
@@ -45,6 +47,7 @@ import {
 	DEFAULT_CURSOR_CLICK_EFFECT_DURATION_MS,
 	DEFAULT_CURSOR_CLICK_EFFECT_OPACITY,
 	DEFAULT_CURSOR_CLICK_EFFECT_SCALE,
+	DEFAULT_CURSOR_FOLLOW_CROP,
 	DEFAULT_CURSOR_STYLE,
 	DEFAULT_CURSOR_SWAY,
 	DEFAULT_FIGURE_DATA,
@@ -129,6 +132,7 @@ export interface ProjectEditorState {
 	/** Selected frame ID (e.g. "recordly.frames/browser-dark"), or null for none */
 	frame: string | null;
 	cropRegion: CropRegion;
+	cursorFollowCrop: CursorFollowCropSettings;
 	zoomRegions: ZoomRegion[];
 	trimRegions: TrimRegion[];
 	clipRegions: ClipRegion[];
@@ -816,6 +820,27 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 	const cropWidth = clamp(rawCropWidth, 0.01, 1 - cropX);
 	const cropHeight = clamp(rawCropHeight, 0.01, 1 - cropY);
 
+	const rawCursorFollowCrop = (editor as Partial<ProjectEditorState>).cursorFollowCrop;
+	const cursorFollowCropPreviewMode: CursorFollowCropPreviewMode =
+		rawCursorFollowCrop?.previewMode === "output" ? "output" : "source";
+	const normalizedCursorFollowCrop: CursorFollowCropSettings = {
+		enabled:
+			typeof rawCursorFollowCrop?.enabled === "boolean"
+				? rawCursorFollowCrop.enabled
+				: DEFAULT_CURSOR_FOLLOW_CROP.enabled,
+		safeZoneRatio: isFiniteNumber(rawCursorFollowCrop?.safeZoneRatio)
+			? clamp(rawCursorFollowCrop.safeZoneRatio, 0, 0.49)
+			: DEFAULT_CURSOR_FOLLOW_CROP.safeZoneRatio,
+		smoothness: isFiniteNumber(rawCursorFollowCrop?.smoothness)
+			? clamp(rawCursorFollowCrop.smoothness, 0, 1)
+			: DEFAULT_CURSOR_FOLLOW_CROP.smoothness,
+		previewMode: cursorFollowCropPreviewMode,
+		trackTextCursor:
+			typeof rawCursorFollowCrop?.trackTextCursor === "boolean"
+				? rawCursorFollowCrop.trackTextCursor
+				: DEFAULT_CURSOR_FOLLOW_CROP.trackTextCursor,
+	};
+
 	const webcam: Partial<WebcamOverlaySettings> =
 		editor.webcam && typeof editor.webcam === "object" ? editor.webcam : {};
 	const webcamSourcePath = typeof webcam.sourcePath === "string" ? webcam.sourcePath : null;
@@ -977,6 +1002,7 @@ export function normalizeProjectEditor(editor: Partial<ProjectEditorState>): Pro
 			width: cropWidth,
 			height: cropHeight,
 		},
+		cursorFollowCrop: normalizedCursorFollowCrop,
 		zoomRegions: normalizedZoomRegions,
 		trimRegions: normalizedTrimRegions,
 		clipRegions: normalizedClipRegions,

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -497,6 +497,32 @@ export const DEFAULT_CROP_REGION: CropRegion = {
 	height: 1,
 };
 
+export type CursorFollowCropPreviewMode = "source" | "output";
+
+export interface CursorFollowCropSettings {
+	enabled: boolean;
+	/** Safe-zone inset 0..0.49 — fraction of viewport edge before camera pans. */
+	safeZoneRatio: number;
+	/** 0..1, smoothing applied per frame (higher = slower follow, less jitter). */
+	smoothness: number;
+	/** Editor-only: which view to show in the crop panel. */
+	previewMode: CursorFollowCropPreviewMode;
+	/**
+	 * When true: viewport locks to the text I-beam position while typing and
+	 * only aggressively follows the mouse when it's actively moving. Mouse
+	 * always wins; transitions are debounced to avoid jarring cuts.
+	 */
+	trackTextCursor: boolean;
+}
+
+export const DEFAULT_CURSOR_FOLLOW_CROP: CursorFollowCropSettings = {
+	enabled: false,
+	safeZoneRatio: 0.25,
+	smoothness: 0.5,
+	previewMode: "source",
+	trackTextCursor: false,
+};
+
 export interface Padding {
 	top: number;
 	bottom: number;

--- a/src/components/video-editor/types.ts
+++ b/src/components/video-editor/types.ts
@@ -508,11 +508,22 @@ export interface CursorFollowCropSettings {
 	/** Editor-only: which view to show in the crop panel. */
 	previewMode: CursorFollowCropPreviewMode;
 	/**
-	 * When true: viewport locks to the text I-beam position while typing and
-	 * only aggressively follows the mouse when it's actively moving. Mouse
-	 * always wins; transitions are debounced to avoid jarring cuts.
+	 * When true: while typing (I-beam active + mouse still), the viewport gently
+	 * pans to center the I-beam (the typing spot); it snaps back to safe-zone
+	 * mouse-following the moment the mouse moves. Mouse always wins; transitions
+	 * are debounced to avoid jarring cuts.
 	 */
 	trackTextCursor: boolean;
+	/**
+	 * Independent "text zoom" layer. When true, the camera eases a zoom-in
+	 * centered on the typing spot whenever sustained typing is detected
+	 * (I-beam active + mouse still), then eases back out once the mouse moves.
+	 * This is a separate layer from `enabled` (the crop pan) and from explicit
+	 * zoom regions — explicit zooms always win over it.
+	 */
+	textZoomEnabled?: boolean;
+	/** Zoom depth scale for the text-zoom layer (>1). Defaults to DEFAULT_TEXT_ZOOM_DEPTH_SCALE. */
+	textZoomDepth?: number;
 }
 
 export const DEFAULT_CURSOR_FOLLOW_CROP: CursorFollowCropSettings = {
@@ -521,6 +532,7 @@ export const DEFAULT_CURSOR_FOLLOW_CROP: CursorFollowCropSettings = {
 	smoothness: 0.5,
 	previewMode: "source",
 	trackTextCursor: false,
+	textZoomEnabled: false,
 };
 
 export interface Padding {

--- a/src/components/video-editor/videoPlayback/cursorFollowCrop.test.ts
+++ b/src/components/video-editor/videoPlayback/cursorFollowCrop.test.ts
@@ -154,6 +154,31 @@ describe("computeCursorFollowCrop — trackTextCursor", () => {
 		expect(state.focusMode).toBe("mouse");
 	});
 
+	it("pans to center the I-beam (typing spot) once in text mode", () => {
+		const state = createCursorFollowCropState();
+		// Mouse parked off-center at 0.8, 0.8 with a text cursor, held still.
+		const staticSamples: CursorTelemetryPoint[] = [];
+		for (let t = 0; t <= 4000; t += 33) {
+			staticSamples.push(sample(t, 0.8, 0.8, "text"));
+		}
+		// smoothness 0 so the eased move resolves in a single step per frame.
+		const cfg = settings({ trackTextCursor: true, smoothness: 0 });
+
+		computeCursorFollowCrop(state, staticSamples, 0, BASE_CROP, cfg);
+		// Drive well past the debounce so we're in text mode and the ease settles.
+		let result = computeCursorFollowCrop(state, staticSamples, 800, BASE_CROP, cfg);
+		for (let t = 900; t <= 4000; t += 100) {
+			result = computeCursorFollowCrop(state, staticSamples, t, BASE_CROP, cfg);
+		}
+
+		expect(state.focusMode).toBe("text");
+		// Centered target = cursor - viewport/2, clamped to [0, 1 - size].
+		const maxX = 1 - BASE_CROP.width;
+		const maxY = 1 - BASE_CROP.height;
+		expect(result.x).toBeCloseTo(Math.min(maxX, 0.8 - BASE_CROP.width / 2), 2);
+		expect(result.y).toBeCloseTo(Math.min(maxY, 0.8 - BASE_CROP.height / 2), 2);
+	});
+
 	it("resets focusMode to mouse on re-initialization (time scrubbed backwards)", () => {
 		const state = createCursorFollowCropState();
 		const staticSamples: CursorTelemetryPoint[] = [];

--- a/src/components/video-editor/videoPlayback/cursorFollowCrop.test.ts
+++ b/src/components/video-editor/videoPlayback/cursorFollowCrop.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import type { CropRegion, CursorFollowCropSettings, CursorTelemetryPoint } from "../types";
+import {
+	computeCursorFollowCrop,
+	createCursorFollowCropState,
+} from "./cursorFollowCrop";
+
+const BASE_CROP: CropRegion = { x: 0, y: 0, width: 0.75, height: 0.75 };
+
+const settings = (overrides: Partial<CursorFollowCropSettings> = {}): CursorFollowCropSettings => ({
+	enabled: true,
+	safeZoneRatio: 0.25,
+	smoothness: 0,
+	previewMode: "source",
+	trackTextCursor: false,
+	...overrides,
+});
+
+const sample = (
+	timeMs: number,
+	cx: number,
+	cy: number,
+	cursorType?: CursorTelemetryPoint["cursorType"],
+): CursorTelemetryPoint => ({
+	timeMs,
+	cx,
+	cy,
+	interactionType: "move",
+	cursorType,
+});
+
+describe("computeCursorFollowCrop", () => {
+	it("keeps the viewport inside [0, 1] when the cursor walks toward an edge", () => {
+		const state = createCursorFollowCropState();
+		const samples = [sample(0, 0.5, 0.5), sample(1000, 1.0, 1.0)];
+
+		const result = computeCursorFollowCrop(state, samples, 1000, BASE_CROP, settings());
+
+		expect(result.width).toBeCloseTo(BASE_CROP.width);
+		expect(result.height).toBeCloseTo(BASE_CROP.height);
+		expect(result.x).toBeGreaterThanOrEqual(0);
+		expect(result.x).toBeLessThanOrEqual(1 - BASE_CROP.width + 1e-6);
+		expect(result.y).toBeGreaterThanOrEqual(0);
+		expect(result.y).toBeLessThanOrEqual(1 - BASE_CROP.height + 1e-6);
+	});
+
+	it("holds the viewport while the cursor stays inside the safe zone", () => {
+		const state = createCursorFollowCropState();
+		const samples = [sample(0, 0.4, 0.4), sample(100, 0.42, 0.42)];
+
+		const initial = computeCursorFollowCrop(state, samples, 0, BASE_CROP, settings());
+		const after = computeCursorFollowCrop(state, samples, 100, BASE_CROP, settings());
+
+		expect(after.x).toBeCloseTo(initial.x);
+		expect(after.y).toBeCloseTo(initial.y);
+	});
+
+	it("reinitializes when time goes backwards (scrubbing)", () => {
+		const state = createCursorFollowCropState();
+		const samples = [sample(0, 0.5, 0.5), sample(5000, 0.95, 0.95)];
+
+		const forward = computeCursorFollowCrop(state, samples, 5000, BASE_CROP, settings());
+		const backward = computeCursorFollowCrop(state, samples, 0, BASE_CROP, settings());
+
+		expect(forward.x).not.toBeCloseTo(backward.x);
+		expect(state.initialized).toBe(true);
+		expect(state.lastTimeMs).toBe(0);
+	});
+
+	it("falls back to base x/y when there is no telemetry", () => {
+		const state = createCursorFollowCropState();
+		const base: CropRegion = { x: 0.1, y: 0.2, width: 0.5, height: 0.5 };
+		const result = computeCursorFollowCrop(state, [], 100, base, settings());
+		expect(result.x).toBeCloseTo(0.1);
+		expect(result.y).toBeCloseTo(0.2);
+	});
+});
+
+describe("computeCursorFollowCrop — trackTextCursor", () => {
+	it("stays in mouse mode when mouse is actively moving", () => {
+		const state = createCursorFollowCropState();
+		// Samples spread across 400ms window — lots of movement, text cursor type
+		const samples = [
+			sample(0, 0.1, 0.1, "text"),
+			sample(100, 0.3, 0.1, "text"),
+			sample(200, 0.5, 0.2, "text"),
+			sample(300, 0.7, 0.3, "text"),
+		];
+		const cfg = settings({ trackTextCursor: true, smoothness: 0 });
+
+		// Initialize
+		computeCursorFollowCrop(state, samples, 0, BASE_CROP, cfg);
+		// Drive forward past debounce threshold — but mouse keeps moving
+		computeCursorFollowCrop(state, samples, 300, BASE_CROP, cfg);
+
+		expect(state.focusMode).toBe("mouse");
+	});
+
+	it("switches to text mode after debounce when mouse is still and cursor type is text", () => {
+		const state = createCursorFollowCropState();
+		// Mouse stationary at 0.5, 0.5 with text cursor for 1000ms
+		const staticSamples: CursorTelemetryPoint[] = [];
+		for (let t = 0; t <= 1000; t += 33) {
+			staticSamples.push(sample(t, 0.5, 0.5, "text"));
+		}
+		const cfg = settings({ trackTextCursor: true, smoothness: 0 });
+
+		// Initialize at t=0
+		computeCursorFollowCrop(state, staticSamples, 0, BASE_CROP, cfg);
+		// Should be in text mode after 700ms+ of stillness
+		computeCursorFollowCrop(state, staticSamples, 800, BASE_CROP, cfg);
+
+		expect(state.focusMode).toBe("text");
+	});
+
+	it("immediately snaps back to mouse mode when movement is detected in text mode", () => {
+		const state = createCursorFollowCropState();
+
+		// Phase 1: stationary with text cursor — enter text mode
+		const staticSamples: CursorTelemetryPoint[] = [];
+		for (let t = 0; t <= 800; t += 33) {
+			staticSamples.push(sample(t, 0.5, 0.5, "text"));
+		}
+		// Phase 2: mouse starts moving
+		const movingSamples = [
+			...staticSamples,
+			sample(900, 0.5, 0.5, "arrow"),
+			sample(950, 0.6, 0.5, "arrow"),
+			sample(1000, 0.7, 0.5, "arrow"),
+		];
+
+		const cfg = settings({ trackTextCursor: true, smoothness: 0 });
+
+		computeCursorFollowCrop(state, staticSamples, 0, BASE_CROP, cfg);
+		computeCursorFollowCrop(state, staticSamples, 800, BASE_CROP, cfg);
+		expect(state.focusMode).toBe("text");
+
+		// Now advance time with mouse moving
+		computeCursorFollowCrop(state, movingSamples, 1000, BASE_CROP, cfg);
+		expect(state.focusMode).toBe("mouse");
+	});
+
+	it("does not switch to text mode when mouse is stationary but cursor type is not text", () => {
+		const state = createCursorFollowCropState();
+		const staticArrowSamples: CursorTelemetryPoint[] = [];
+		for (let t = 0; t <= 1000; t += 33) {
+			staticArrowSamples.push(sample(t, 0.5, 0.5, "arrow"));
+		}
+		const cfg = settings({ trackTextCursor: true, smoothness: 0 });
+
+		computeCursorFollowCrop(state, staticArrowSamples, 0, BASE_CROP, cfg);
+		computeCursorFollowCrop(state, staticArrowSamples, 800, BASE_CROP, cfg);
+
+		expect(state.focusMode).toBe("mouse");
+	});
+
+	it("resets focusMode to mouse on re-initialization (time scrubbed backwards)", () => {
+		const state = createCursorFollowCropState();
+		const staticSamples: CursorTelemetryPoint[] = [];
+		for (let t = 0; t <= 1000; t += 33) {
+			staticSamples.push(sample(t, 0.5, 0.5, "text"));
+		}
+		const cfg = settings({ trackTextCursor: true, smoothness: 0 });
+
+		computeCursorFollowCrop(state, staticSamples, 0, BASE_CROP, cfg);
+		computeCursorFollowCrop(state, staticSamples, 800, BASE_CROP, cfg);
+		expect(state.focusMode).toBe("text");
+
+		// Scrub backwards
+		computeCursorFollowCrop(state, staticSamples, 0, BASE_CROP, cfg);
+		expect(state.focusMode).toBe("mouse");
+	});
+});

--- a/src/components/video-editor/videoPlayback/cursorFollowCrop.ts
+++ b/src/components/video-editor/videoPlayback/cursorFollowCrop.ts
@@ -55,11 +55,11 @@ function clampViewportSize(value: number): number {
 }
 
 // Minimum normalized displacement between consecutive samples to count as active movement.
-const MOUSE_MOVE_THRESHOLD = 0.008;
+export const MOUSE_MOVE_THRESHOLD = 0.008;
 // Look-back window (ms) for mouse movement detection.
 const MOUSE_ACTIVE_WINDOW_MS = 400;
 // How long (ms) the mouse must be still before switching to text-cursor mode.
-const MOUSE_ACTIVE_DEBOUNCE_MS = 700;
+export const MOUSE_ACTIVE_DEBOUNCE_MS = 700;
 // Smoothness floor applied in text-cursor mode to keep the viewport stable.
 const TEXT_CURSOR_SMOOTHNESS = 0.92;
 
@@ -68,7 +68,7 @@ const TEXT_CURSOR_SMOOTHNESS = 0.92;
  * MOUSE_ACTIVE_WINDOW_MS ms before timeMs. Scans backwards so it can
  * early-exit as soon as one moving pair is found.
  */
-function detectMouseActivity(samples: CursorTelemetryPoint[], timeMs: number): boolean {
+export function detectMouseActivity(samples: CursorTelemetryPoint[], timeMs: number): boolean {
 	const windowStart = timeMs - MOUSE_ACTIVE_WINDOW_MS;
 	let prev: CursorTelemetryPoint | null = null;
 	for (let i = samples.length - 1; i >= 0; i--) {
@@ -88,7 +88,7 @@ function detectMouseActivity(samples: CursorTelemetryPoint[], timeMs: number): b
 /**
  * Returns true if the cursor type at or just before timeMs is the text I-beam.
  */
-function isTextCursorActive(samples: CursorTelemetryPoint[], timeMs: number): boolean {
+export function isTextCursorActive(samples: CursorTelemetryPoint[], timeMs: number): boolean {
 	if (samples.length === 0) return false;
 	for (let i = samples.length - 1; i >= 0; i--) {
 		if (samples[i].timeMs <= timeMs + 50) {
@@ -141,6 +141,26 @@ function computeTargetPosition(
 	return {
 		x: clamp(nextX, 0, maxX),
 		y: clamp(nextY, 0, maxY),
+	};
+}
+
+/**
+ * Returns the viewport top-left that centers the cursor in the viewport.
+ * Used in text-cursor mode so the viewport actively pans onto the typing spot
+ * (the I-beam position) rather than merely holding the cursor inside the safe
+ * zone. Clamped so the viewport never leaves the source bounds.
+ */
+function computeCenteredPosition(
+	viewportWidth: number,
+	viewportHeight: number,
+	cursorCx: number,
+	cursorCy: number,
+): { x: number; y: number } {
+	const maxX = Math.max(0, 1 - viewportWidth);
+	const maxY = Math.max(0, 1 - viewportHeight);
+	return {
+		x: clamp(cursorCx - viewportWidth / 2, 0, maxX),
+		y: clamp(cursorCy - viewportHeight / 2, 0, maxY),
 	};
 }
 
@@ -247,20 +267,26 @@ export function computeCursorFollowCrop(
 	// barely moves while the user is typing. The cursor is still tracked so that
 	// a click to a new text field (which triggers mouse mode) eventually lands
 	// the viewport in the right place.
-	const effectiveSmoothness =
-		settings.trackTextCursor && state.focusMode === "text"
-			? Math.max(settings.smoothness, TEXT_CURSOR_SMOOTHNESS)
-			: settings.smoothness;
+	const inTextMode = settings.trackTextCursor && state.focusMode === "text";
+	const effectiveSmoothness = inTextMode
+		? Math.max(settings.smoothness, TEXT_CURSOR_SMOOTHNESS)
+		: settings.smoothness;
 
-	const target = computeTargetPosition(
-		state.x,
-		state.y,
-		width,
-		height,
-		cursorCx,
-		cursorCy,
-		settings.safeZoneRatio,
-	);
+	// In text-cursor mode, actively pan to center the I-beam (the typing spot)
+	// instead of merely holding it inside the safe zone — eased gently by the
+	// high text-mode smoothness floor so the move never feels jarring. In mouse
+	// mode, keep the safe-zone hold so small movements don't shift the viewport.
+	const target = inTextMode
+		? computeCenteredPosition(width, height, cursorCx, cursorCy)
+		: computeTargetPosition(
+				state.x,
+				state.y,
+				width,
+				height,
+				cursorCx,
+				cursorCy,
+				settings.safeZoneRatio,
+			);
 
 	const dtMs = Math.max(0, timeMs - state.lastTimeMs);
 	const factor = getResponseFactor(effectiveSmoothness, dtMs);

--- a/src/components/video-editor/videoPlayback/cursorFollowCrop.ts
+++ b/src/components/video-editor/videoPlayback/cursorFollowCrop.ts
@@ -1,0 +1,272 @@
+import type { CropRegion, CursorFollowCropSettings, CursorTelemetryPoint } from "../types";
+import { interpolateCursorPosition } from "./cursorRenderer";
+
+export interface CursorFollowCropState {
+	initialized: boolean;
+	lastTimeMs: number;
+	/** Current top-left x of viewport, normalized 0..1 in source space. */
+	x: number;
+	/** Current top-left y of viewport, normalized 0..1 in source space. */
+	y: number;
+	/** Current focus mode when trackTextCursor is enabled. */
+	focusMode: "mouse" | "text";
+	/** Last video-time (ms) at which active mouse movement was detected. */
+	mouseLastMovedMs: number;
+}
+
+export function createCursorFollowCropState(): CursorFollowCropState {
+	return {
+		initialized: false,
+		lastTimeMs: 0,
+		x: 0,
+		y: 0,
+		focusMode: "mouse",
+		mouseLastMovedMs: -Infinity,
+	};
+}
+
+export function resetCursorFollowCropState(state: CursorFollowCropState): void {
+	state.initialized = false;
+	state.lastTimeMs = 0;
+	state.x = 0;
+	state.y = 0;
+	state.focusMode = "mouse";
+	state.mouseLastMovedMs = -Infinity;
+}
+
+function clamp(value: number, min: number, max: number): number {
+	if (!Number.isFinite(value)) return (min + max) / 2;
+	return Math.min(max, Math.max(min, value));
+}
+
+function clampSafeZoneRatio(ratio: number): number {
+	if (!Number.isFinite(ratio)) return 0.25;
+	return Math.max(0, Math.min(0.49, ratio));
+}
+
+function clampSmoothness(value: number): number {
+	if (!Number.isFinite(value)) return 0.5;
+	return Math.max(0, Math.min(1, value));
+}
+
+function clampViewportSize(value: number): number {
+	if (!Number.isFinite(value) || value <= 0) return 1;
+	return Math.min(1, value);
+}
+
+// Minimum normalized displacement between consecutive samples to count as active movement.
+const MOUSE_MOVE_THRESHOLD = 0.008;
+// Look-back window (ms) for mouse movement detection.
+const MOUSE_ACTIVE_WINDOW_MS = 400;
+// How long (ms) the mouse must be still before switching to text-cursor mode.
+const MOUSE_ACTIVE_DEBOUNCE_MS = 700;
+// Smoothness floor applied in text-cursor mode to keep the viewport stable.
+const TEXT_CURSOR_SMOOTHNESS = 0.92;
+
+/**
+ * Returns true if there was meaningful mouse movement in the last
+ * MOUSE_ACTIVE_WINDOW_MS ms before timeMs. Scans backwards so it can
+ * early-exit as soon as one moving pair is found.
+ */
+function detectMouseActivity(samples: CursorTelemetryPoint[], timeMs: number): boolean {
+	const windowStart = timeMs - MOUSE_ACTIVE_WINDOW_MS;
+	let prev: CursorTelemetryPoint | null = null;
+	for (let i = samples.length - 1; i >= 0; i--) {
+		const s = samples[i];
+		if (s.timeMs > timeMs + 50) continue;
+		if (s.timeMs < windowStart) break;
+		if (prev !== null) {
+			const dx = prev.cx - s.cx;
+			const dy = prev.cy - s.cy;
+			if (dx * dx + dy * dy >= MOUSE_MOVE_THRESHOLD * MOUSE_MOVE_THRESHOLD) return true;
+		}
+		prev = s;
+	}
+	return false;
+}
+
+/**
+ * Returns true if the cursor type at or just before timeMs is the text I-beam.
+ */
+function isTextCursorActive(samples: CursorTelemetryPoint[], timeMs: number): boolean {
+	if (samples.length === 0) return false;
+	for (let i = samples.length - 1; i >= 0; i--) {
+		if (samples[i].timeMs <= timeMs + 50) {
+			return samples[i].cursorType === "text";
+		}
+	}
+	return false;
+}
+
+/**
+ * Returns the viewport top-left position so the cursor lies inside the safe-zone
+ * inset of the viewport. If the cursor is already inside the inset relative to
+ * the current viewport, the current viewport position is returned unchanged.
+ */
+function computeTargetPosition(
+	currentX: number,
+	currentY: number,
+	viewportWidth: number,
+	viewportHeight: number,
+	cursorCx: number,
+	cursorCy: number,
+	safeZoneRatio: number,
+): { x: number; y: number } {
+	const ratio = clampSafeZoneRatio(safeZoneRatio);
+	const insetX = viewportWidth * ratio;
+	const insetY = viewportHeight * ratio;
+
+	const safeLeft = currentX + insetX;
+	const safeRight = currentX + viewportWidth - insetX;
+	const safeTop = currentY + insetY;
+	const safeBottom = currentY + viewportHeight - insetY;
+
+	let nextX = currentX;
+	let nextY = currentY;
+
+	if (cursorCx < safeLeft) {
+		nextX = cursorCx - insetX;
+	} else if (cursorCx > safeRight) {
+		nextX = cursorCx - (viewportWidth - insetX);
+	}
+
+	if (cursorCy < safeTop) {
+		nextY = cursorCy - insetY;
+	} else if (cursorCy > safeBottom) {
+		nextY = cursorCy - (viewportHeight - insetY);
+	}
+
+	const maxX = Math.max(0, 1 - viewportWidth);
+	const maxY = Math.max(0, 1 - viewportHeight);
+	return {
+		x: clamp(nextX, 0, maxX),
+		y: clamp(nextY, 0, maxY),
+	};
+}
+
+/**
+ * Maps smoothness (0..1, higher = slower follow) and elapsed frame time
+ * to a per-frame interpolation factor in [0, 1]. At smoothness=0 the response
+ * is immediate (factor=1). At smoothness=1 the response is almost frozen.
+ */
+function getResponseFactor(smoothness: number, dtMs: number): number {
+	const s = clampSmoothness(smoothness);
+	if (s <= 0) return 1;
+	if (s >= 1) return 0;
+	// Higher smoothness ⇒ lower per-second response.
+	const responsePerSecond = 20 * (1 - s) + 1;
+	const dtSec = Math.max(0, Math.min(0.25, dtMs / 1000));
+	return 1 - Math.exp(-responsePerSecond * dtSec);
+}
+
+/**
+ * Per-frame effective crop when "Track Cursor" is enabled.
+ *
+ * The viewport size is taken from `base.width`/`base.height`; `base.x`/`base.y`
+ * is used only as the initial home position when telemetry isn't available yet.
+ * The viewport top-left is panned so the cursor stays inside the safe-zone inset
+ * of the viewport, then smoothly eased toward that target.
+ *
+ * When `settings.trackTextCursor` is true the function also tracks whether the
+ * user is typing (mouse stationary + I-beam cursor type). In text-cursor mode
+ * the viewport is kept very stable (high smoothness floor) and only switches
+ * back to active mouse tracking once movement is detected — debounced by
+ * MOUSE_ACTIVE_DEBOUNCE_MS so the transition is never jarring.
+ */
+export function computeCursorFollowCrop(
+	state: CursorFollowCropState,
+	cursorSamples: CursorTelemetryPoint[],
+	timeMs: number,
+	base: CropRegion,
+	settings: CursorFollowCropSettings,
+): CropRegion {
+	const width = clampViewportSize(base.width);
+	const height = clampViewportSize(base.height);
+	const maxX = Math.max(0, 1 - width);
+	const maxY = Math.max(0, 1 - height);
+
+	const fallbackX = clamp(base.x, 0, maxX);
+	const fallbackY = clamp(base.y, 0, maxY);
+
+	const cursor = interpolateCursorPosition(cursorSamples, timeMs);
+	if (!cursor) {
+		if (!state.initialized) {
+			state.x = fallbackX;
+			state.y = fallbackY;
+			state.initialized = true;
+			state.lastTimeMs = timeMs;
+			state.mouseLastMovedMs = timeMs;
+		}
+		return { x: state.x, y: state.y, width, height };
+	}
+
+	const cursorCx = clamp(cursor.cx, 0, 1);
+	const cursorCy = clamp(cursor.cy, 0, 1);
+
+	const timeWentBackwards = state.initialized && timeMs + 0.5 < state.lastTimeMs;
+	if (!state.initialized || timeWentBackwards) {
+		const initial = computeTargetPosition(
+			fallbackX,
+			fallbackY,
+			width,
+			height,
+			cursorCx,
+			cursorCy,
+			settings.safeZoneRatio,
+		);
+		state.x = initial.x;
+		state.y = initial.y;
+		state.initialized = true;
+		state.lastTimeMs = timeMs;
+		state.mouseLastMovedMs = timeMs;
+		state.focusMode = "mouse";
+		return { x: state.x, y: state.y, width, height };
+	}
+
+	// Update focus mode when text-cursor tracking is enabled.
+	// Mouse always wins: any detected movement immediately snaps back to mouse mode.
+	// Transition to text mode is debounced so it only happens after MOUSE_ACTIVE_DEBOUNCE_MS
+	// of stillness with an I-beam cursor, preventing jarring switches.
+	if (settings.trackTextCursor) {
+		const mouseActive = detectMouseActivity(cursorSamples, timeMs);
+		if (mouseActive) {
+			state.mouseLastMovedMs = timeMs;
+			state.focusMode = "mouse";
+		} else if (
+			state.focusMode !== "text" &&
+			timeMs - state.mouseLastMovedMs > MOUSE_ACTIVE_DEBOUNCE_MS &&
+			isTextCursorActive(cursorSamples, timeMs)
+		) {
+			state.focusMode = "text";
+		}
+	} else {
+		state.focusMode = "mouse";
+	}
+
+	// In text-cursor mode, clamp smoothness to a high floor so the viewport
+	// barely moves while the user is typing. The cursor is still tracked so that
+	// a click to a new text field (which triggers mouse mode) eventually lands
+	// the viewport in the right place.
+	const effectiveSmoothness =
+		settings.trackTextCursor && state.focusMode === "text"
+			? Math.max(settings.smoothness, TEXT_CURSOR_SMOOTHNESS)
+			: settings.smoothness;
+
+	const target = computeTargetPosition(
+		state.x,
+		state.y,
+		width,
+		height,
+		cursorCx,
+		cursorCy,
+		settings.safeZoneRatio,
+	);
+
+	const dtMs = Math.max(0, timeMs - state.lastTimeMs);
+	const factor = getResponseFactor(effectiveSmoothness, dtMs);
+	state.x = clamp(state.x + (target.x - state.x) * factor, 0, maxX);
+	state.y = clamp(state.y + (target.y - state.y) * factor, 0, maxY);
+	state.lastTimeMs = timeMs;
+
+	return { x: state.x, y: state.y, width, height };
+}

--- a/src/components/video-editor/videoPlayback/cursorTextZoom.test.ts
+++ b/src/components/video-editor/videoPlayback/cursorTextZoom.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type { CursorFollowCropSettings, CursorTelemetryPoint } from "../types";
+import {
+	computeCursorTextZoom,
+	createCursorTextZoomState,
+	DEFAULT_TEXT_ZOOM_DEPTH_SCALE,
+} from "./cursorTextZoom";
+
+const settings = (overrides: Partial<CursorFollowCropSettings> = {}): CursorFollowCropSettings => ({
+	enabled: false,
+	safeZoneRatio: 0.25,
+	smoothness: 0.5,
+	previewMode: "source",
+	trackTextCursor: false,
+	textZoomEnabled: true,
+	...overrides,
+});
+
+const sample = (
+	timeMs: number,
+	cx: number,
+	cy: number,
+	cursorType?: CursorTelemetryPoint["cursorType"],
+): CursorTelemetryPoint => ({ timeMs, cx, cy, interactionType: "move", cursorType });
+
+const staticTextSamples = (toMs: number, cx = 0.7, cy = 0.6): CursorTelemetryPoint[] => {
+	const samples: CursorTelemetryPoint[] = [];
+	for (let t = 0; t <= toMs; t += 33) {
+		samples.push(sample(t, cx, cy, "text"));
+	}
+	return samples;
+};
+
+describe("computeCursorTextZoom", () => {
+	it("stays inactive while disabled", () => {
+		const state = createCursorTextZoomState();
+		const samples = staticTextSamples(1000);
+		const cfg = settings({ textZoomEnabled: false });
+
+		computeCursorTextZoom(state, samples, 0, cfg);
+		const result = computeCursorTextZoom(state, samples, 800, cfg);
+
+		expect(result.active).toBe(false);
+		expect(result.scale).toBe(1);
+	});
+
+	it("engages on the typing spot after the debounce when the mouse is still", () => {
+		const state = createCursorTextZoomState();
+		const samples = staticTextSamples(1000, 0.7, 0.6);
+		const cfg = settings();
+
+		computeCursorTextZoom(state, samples, 0, cfg);
+		const result = computeCursorTextZoom(state, samples, 800, cfg);
+
+		expect(result.active).toBe(true);
+		expect(result.scale).toBeCloseTo(DEFAULT_TEXT_ZOOM_DEPTH_SCALE);
+		expect(result.focus.cx).toBeCloseTo(0.7);
+		expect(result.focus.cy).toBeCloseTo(0.6);
+	});
+
+	it("does not engage when the cursor type is not text", () => {
+		const state = createCursorTextZoomState();
+		const samples: CursorTelemetryPoint[] = [];
+		for (let t = 0; t <= 1000; t += 33) samples.push(sample(t, 0.5, 0.5, "arrow"));
+		const cfg = settings();
+
+		computeCursorTextZoom(state, samples, 0, cfg);
+		const result = computeCursorTextZoom(state, samples, 800, cfg);
+
+		expect(result.active).toBe(false);
+	});
+
+	it("disengages immediately when the mouse moves", () => {
+		const state = createCursorTextZoomState();
+		const still = staticTextSamples(800, 0.5, 0.5);
+		const cfg = settings();
+
+		computeCursorTextZoom(state, still, 0, cfg);
+		expect(computeCursorTextZoom(state, still, 800, cfg).active).toBe(true);
+
+		const moving = [
+			...still,
+			sample(900, 0.5, 0.5, "arrow"),
+			sample(950, 0.65, 0.5, "arrow"),
+			sample(1000, 0.8, 0.5, "arrow"),
+		];
+		const result = computeCursorTextZoom(state, moving, 1000, cfg);
+		expect(result.active).toBe(false);
+		expect(result.scale).toBe(1);
+	});
+
+	it("respects a custom depth", () => {
+		const state = createCursorTextZoomState();
+		const samples = staticTextSamples(1000);
+		const cfg = settings({ textZoomDepth: 2.2 });
+
+		computeCursorTextZoom(state, samples, 0, cfg);
+		const result = computeCursorTextZoom(state, samples, 800, cfg);
+
+		expect(result.active).toBe(true);
+		expect(result.scale).toBeCloseTo(2.2);
+	});
+
+	it("engages immediately when scrubbed onto a still typing moment (works when paused)", () => {
+		const state = createCursorTextZoomState();
+		const samples = staticTextSamples(4000, 0.7, 0.6);
+		const cfg = settings();
+
+		// Single call at a paused time well past any movement — should engage
+		// without needing several frames of forward playback to debounce.
+		const result = computeCursorTextZoom(state, samples, 2000, cfg);
+		expect(result.active).toBe(true);
+		expect(result.focus.cx).toBeCloseTo(0.7);
+	});
+
+	it("stays inactive right after a mouse move, even when scrubbed there", () => {
+		const state = createCursorTextZoomState();
+		// Mouse moves up to t=500, then holds still with a text cursor.
+		const samples: CursorTelemetryPoint[] = [
+			sample(0, 0.2, 0.2, "arrow"),
+			sample(200, 0.4, 0.3, "arrow"),
+			sample(500, 0.7, 0.6, "arrow"),
+		];
+		for (let t = 533; t <= 3000; t += 33) samples.push(sample(t, 0.7, 0.6, "text"));
+		const cfg = settings();
+
+		// Scrub to just after the move: within the debounce window → inactive.
+		expect(computeCursorTextZoom(state, samples, 560, cfg).active).toBe(false);
+		// Advance past the debounce → engages.
+		expect(computeCursorTextZoom(state, samples, 1400, cfg).active).toBe(true);
+	});
+});

--- a/src/components/video-editor/videoPlayback/cursorTextZoom.ts
+++ b/src/components/video-editor/videoPlayback/cursorTextZoom.ts
@@ -1,0 +1,151 @@
+import type { CursorFollowCropSettings, CursorTelemetryPoint, ZoomFocus } from "../types";
+import {
+	detectMouseActivity,
+	isTextCursorActive,
+	MOUSE_ACTIVE_DEBOUNCE_MS,
+	MOUSE_MOVE_THRESHOLD,
+} from "./cursorFollowCrop";
+import { interpolateCursorPosition } from "./cursorRenderer";
+
+/**
+ * Returns the most recent video-time (ms) at or before `timeMs` at which the
+ * mouse moved by at least MOUSE_MOVE_THRESHOLD between consecutive samples.
+ * Returns -Infinity if no movement is found (mouse has been still throughout).
+ * This lets the layer engage immediately when paused/scrubbing rather than
+ * only after several frames of forward playback.
+ */
+function findLastMouseMoveMs(samples: CursorTelemetryPoint[], timeMs: number): number {
+	let next: CursorTelemetryPoint | null = null;
+	for (let i = samples.length - 1; i >= 0; i--) {
+		const s = samples[i];
+		if (s.timeMs > timeMs + 50) continue;
+		if (next !== null) {
+			const dx = next.cx - s.cx;
+			const dy = next.cy - s.cy;
+			if (dx * dx + dy * dy >= MOUSE_MOVE_THRESHOLD * MOUSE_MOVE_THRESHOLD) {
+				return next.timeMs;
+			}
+		}
+		next = s;
+	}
+	return -Infinity;
+}
+
+/** Default zoom depth for the text-zoom layer — a modest punch-in for typing. */
+export const DEFAULT_TEXT_ZOOM_DEPTH_SCALE = 1.6;
+
+/** Clamp the configured text-zoom depth to a sane range. */
+function clampDepth(depth: number | undefined): number {
+	if (!Number.isFinite(depth) || depth === undefined || depth <= 1) {
+		return DEFAULT_TEXT_ZOOM_DEPTH_SCALE;
+	}
+	return Math.min(4, depth);
+}
+
+function clamp01(value: number): number {
+	if (!Number.isFinite(value)) return 0.5;
+	return Math.min(1, Math.max(0, value));
+}
+
+export interface CursorTextZoomState {
+	initialized: boolean;
+	lastTimeMs: number;
+	/** Whether the text-zoom is currently engaged (typing detected). */
+	active: boolean;
+	/** Last video-time (ms) at which active mouse movement was detected. */
+	mouseLastMovedMs: number;
+	/** Focus locked at the moment the zoom engaged, in source-normalized space. */
+	focus: ZoomFocus;
+}
+
+export function createCursorTextZoomState(): CursorTextZoomState {
+	return {
+		initialized: false,
+		lastTimeMs: 0,
+		active: false,
+		mouseLastMovedMs: -Infinity,
+		focus: { cx: 0.5, cy: 0.5 },
+	};
+}
+
+export function resetCursorTextZoomState(state: CursorTextZoomState): void {
+	state.initialized = false;
+	state.lastTimeMs = 0;
+	state.active = false;
+	state.mouseLastMovedMs = -Infinity;
+	state.focus = { cx: 0.5, cy: 0.5 };
+}
+
+export interface TextZoomResult {
+	/** True while the text-zoom layer wants to be engaged. */
+	active: boolean;
+	/** Target zoom scale (1 = none). */
+	scale: number;
+	/** Target focus in source-normalized space. */
+	focus: ZoomFocus;
+}
+
+const INACTIVE: TextZoomResult = { active: false, scale: 1, focus: { cx: 0.5, cy: 0.5 } };
+
+/**
+ * Per-frame state for the independent text-zoom layer.
+ *
+ * Mirrors the focus-mode detection used by the cursor-follow crop: the layer
+ * engages after the mouse has been still for `MOUSE_ACTIVE_DEBOUNCE_MS` while
+ * the I-beam (text) cursor is active, and disengages the instant the mouse
+ * moves again (mouse always wins). When engaged it locks the zoom focus to the
+ * typing spot so the punch-in is stable; the caller eases scale/position via
+ * the shared zoom spring, so this only needs to emit a stable target.
+ */
+export function computeCursorTextZoom(
+	state: CursorTextZoomState,
+	cursorSamples: CursorTelemetryPoint[],
+	timeMs: number,
+	settings: CursorFollowCropSettings,
+): TextZoomResult {
+	if (!settings.textZoomEnabled) {
+		if (state.initialized) resetCursorTextZoomState(state);
+		return INACTIVE;
+	}
+
+	const depth = clampDepth(settings.textZoomDepth);
+
+	// (Re)initialize on first use or when time jumps (scrubbing/seeking). Seed
+	// `mouseLastMovedMs` from the telemetry itself so the layer can engage right
+	// away when paused or scrubbed onto a typing moment, not only after several
+	// frames of forward playback.
+	const timeJumped = state.initialized && Math.abs(timeMs - state.lastTimeMs) > 250;
+	if (!state.initialized || timeJumped) {
+		state.initialized = true;
+		state.lastTimeMs = timeMs;
+		state.active = false;
+		state.mouseLastMovedMs = findLastMouseMoveMs(cursorSamples, timeMs);
+	}
+	state.lastTimeMs = timeMs;
+
+	const mouseActive = detectMouseActivity(cursorSamples, timeMs);
+	if (mouseActive) {
+		state.mouseLastMovedMs = timeMs;
+		state.active = false;
+		return INACTIVE;
+	}
+
+	// Engage after the debounce once typing (I-beam) is detected.
+	if (
+		!state.active &&
+		timeMs - state.mouseLastMovedMs > MOUSE_ACTIVE_DEBOUNCE_MS &&
+		isTextCursorActive(cursorSamples, timeMs)
+	) {
+		const cursor = interpolateCursorPosition(cursorSamples, timeMs);
+		if (cursor) {
+			state.focus = { cx: clamp01(cursor.cx), cy: clamp01(cursor.cy) };
+			state.active = true;
+		}
+	}
+
+	if (!state.active) {
+		return INACTIVE;
+	}
+
+	return { active: true, scale: depth, focus: state.focus };
+}

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -7,6 +7,7 @@ import type {
 	CaptionCue,
 	CursorClickEffectStyle,
 	CropRegion,
+	CursorFollowCropSettings,
 	CursorStyle,
 	CursorTelemetryPoint,
 	Padding,
@@ -28,6 +29,11 @@ import {
 	createCursorFollowCameraState,
 	SNAP_TO_EDGES_RATIO_AUTO,
 } from "@/components/video-editor/videoPlayback/cursorFollowCamera";
+import {
+	type CursorFollowCropState,
+	computeCursorFollowCrop,
+	createCursorFollowCropState,
+} from "@/components/video-editor/videoPlayback/cursorFollowCrop";
 import {
 	DEFAULT_CURSOR_CONFIG,
 	PixiCursorOverlay,
@@ -107,6 +113,7 @@ interface FrameRenderConfig {
 	borderRadius?: number;
 	padding?: Padding | number;
 	cropRegion: CropRegion;
+	cursorFollowCrop?: CursorFollowCropSettings;
 	webcam?: WebcamOverlaySettings;
 	webcamUrl?: string | null;
 	videoWidth: number;
@@ -293,6 +300,7 @@ export class FrameRenderer {
 	private springX: SpringState;
 	private springY: SpringState;
 	private cursorFollowCamera: CursorFollowCameraState;
+	private cursorFollowCropState: CursorFollowCropState = createCursorFollowCropState();
 	private lastContentTimeMs: number | null = null;
 	private cursorOverlay: PixiCursorOverlay | null = null;
 	private webcamForwardFrameSource: ForwardFrameSource | null = null;
@@ -1643,6 +1651,8 @@ export class FrameRenderer {
 		const timeMs = this.currentVideoTime * 1000;
 		const cursorTimeMs = cursorTimestamp / 1000;
 
+		this.applyCursorFollowCrop(timeMs, layoutCache);
+
 		if (this.cursorOverlay) {
 			this.cursorOverlay.update(
 				this.config.cursorTelemetry ?? [],
@@ -1894,6 +1904,37 @@ export class FrameRenderer {
 		}
 	}
 
+	private applyCursorFollowCrop(timeMs: number, layoutCache: LayoutCache): void {
+		const settings = this.config.cursorFollowCrop;
+		const baseCrop = this.config.cropRegion;
+		if (!settings?.enabled || !this.videoSprite || !baseCrop) {
+			if (this.videoSprite) {
+				this.videoSprite.position.set(
+					layoutCache.baseOffset.x,
+					layoutCache.baseOffset.y,
+				);
+			}
+			layoutCache.maskRect.sourceCrop = baseCrop;
+			return;
+		}
+		const effectiveCrop = computeCursorFollowCrop(
+			this.cursorFollowCropState,
+			this.config.cursorTelemetry ?? [],
+			timeMs,
+			baseCrop,
+			settings,
+		);
+		const fullVideoDisplayWidth = this.config.videoWidth * layoutCache.baseScale;
+		const fullVideoDisplayHeight = this.config.videoHeight * layoutCache.baseScale;
+		const dx = (effectiveCrop.x - baseCrop.x) * fullVideoDisplayWidth;
+		const dy = (effectiveCrop.y - baseCrop.y) * fullVideoDisplayHeight;
+		this.videoSprite.position.set(
+			layoutCache.baseOffset.x - dx,
+			layoutCache.baseOffset.y - dy,
+		);
+		layoutCache.maskRect.sourceCrop = effectiveCrop;
+	}
+
 	private updateLayout(): void {
 		if (!this.app || !this.videoSprite || !this.maskGraphics || !this.videoContainer) return;
 
@@ -2130,6 +2171,8 @@ export class FrameRenderer {
 
 		const timeMs = this.currentVideoTime * 1000;
 		const cursorTimeMs = cursorTimestamp / 1000;
+
+		this.applyCursorFollowCrop(timeMs, layoutCache);
 
 		if (this.cursorOverlay) {
 			this.cursorOverlay.update(

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -35,6 +35,11 @@ import {
 	createCursorFollowCropState,
 } from "@/components/video-editor/videoPlayback/cursorFollowCrop";
 import {
+	type CursorTextZoomState,
+	computeCursorTextZoom,
+	createCursorTextZoomState,
+} from "@/components/video-editor/videoPlayback/cursorTextZoom";
+import {
 	DEFAULT_CURSOR_CONFIG,
 	PixiCursorOverlay,
 	preloadCursorAssets,
@@ -301,6 +306,7 @@ export class FrameRenderer {
 	private springY: SpringState;
 	private cursorFollowCamera: CursorFollowCameraState;
 	private cursorFollowCropState: CursorFollowCropState = createCursorFollowCropState();
+	private cursorTextZoomState: CursorTextZoomState = createCursorTextZoomState();
 	private lastContentTimeMs: number | null = null;
 	private cursorOverlay: PixiCursorOverlay | null = null;
 	private webcamForwardFrameSource: ForwardFrameSource | null = null;
@@ -2079,6 +2085,30 @@ export class FrameRenderer {
 				});
 				targetProgress = 1;
 			}
+		}
+
+		// Text-zoom layer (independent of crop pan and explicit zoom regions;
+		// explicit zooms win). The zoom spring below eases it in and out.
+		const explicitZoomActive = Boolean(region && strength > 0);
+		if (
+			this.config.cursorFollowCrop?.textZoomEnabled &&
+			!explicitZoomActive &&
+			this.config.cursorTelemetry &&
+			this.config.cursorTelemetry.length > 0
+		) {
+			const textZoom = computeCursorTextZoom(
+				this.cursorTextZoomState,
+				this.config.cursorTelemetry,
+				timeMs,
+				this.config.cursorFollowCrop,
+			);
+			if (textZoom.active) {
+				targetScaleFactor = textZoom.scale;
+				targetFocus = textZoom.focus;
+				targetProgress = 1;
+			}
+		} else if (!this.config.cursorFollowCrop?.textZoomEnabled) {
+			this.cursorTextZoomState = createCursorTextZoomState();
 		}
 
 		const state = this.animationState;

--- a/src/lib/exporter/gifExporter.ts
+++ b/src/lib/exporter/gifExporter.ts
@@ -5,6 +5,7 @@ import type {
 	CaptionCue,
 	CursorClickEffectStyle,
 	CropRegion,
+	CursorFollowCropSettings,
 	CursorStyle,
 	CursorTelemetryPoint,
 	Padding,
@@ -61,6 +62,7 @@ interface GifExporterConfig {
 	padding?: Padding | number;
 	videoPadding?: Padding | number;
 	cropRegion: CropRegion;
+	cursorFollowCrop?: CursorFollowCropSettings;
 	webcam?: WebcamOverlaySettings;
 	webcamUrl?: string | null;
 	annotationRegions?: AnnotationRegion[];

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -17,6 +17,7 @@ import type {
 	CaptionCue,
 	CursorClickEffectStyle,
 	CropRegion,
+	CursorFollowCropSettings,
 	CursorStyle,
 	CursorTelemetryPoint,
 	Padding,
@@ -34,6 +35,11 @@ import {
 	createCursorFollowCameraState,
 	SNAP_TO_EDGES_RATIO_AUTO,
 } from "@/components/video-editor/videoPlayback/cursorFollowCamera";
+import {
+	type CursorFollowCropState,
+	computeCursorFollowCrop,
+	createCursorFollowCropState,
+} from "@/components/video-editor/videoPlayback/cursorFollowCrop";
 import {
 	DEFAULT_CURSOR_CONFIG,
 	PixiCursorOverlay,
@@ -125,6 +131,7 @@ interface FrameRenderConfig {
 	borderRadius?: number;
 	padding?: Padding | number;
 	cropRegion: CropRegion;
+	cursorFollowCrop?: CursorFollowCropSettings;
 	webcam?: WebcamOverlaySettings;
 	webcamUrl?: string | null;
 	videoWidth: number;
@@ -478,6 +485,7 @@ export class FrameRenderer {
 	private springX: SpringState;
 	private springY: SpringState;
 	private cursorFollowCamera: CursorFollowCameraState;
+	private cursorFollowCropState: CursorFollowCropState = createCursorFollowCropState();
 	private lastContentTimeMs: number | null = null;
 	private layoutCache: LayoutCache | null = null;
 	private currentVideoTime = 0;
@@ -2973,6 +2981,8 @@ export class FrameRenderer {
 		const timeMs = this.currentVideoTime * 1000;
 		const cursorTimeMs = cursorTimestamp / 1000;
 
+		this.applyCursorFollowCrop(timeMs, layoutCache);
+
 		if (this.cursorOverlay) {
 			this.cursorOverlay.update(
 				this.config.cursorTelemetry ?? [],
@@ -3221,6 +3231,8 @@ export class FrameRenderer {
 
 		const timeMs = this.currentVideoTime * 1000;
 		const cursorTimeMs = cursorTimestamp / 1000;
+
+		this.applyCursorFollowCrop(timeMs, layoutCache);
 
 		if (this.cursorOverlay) {
 			this.cursorOverlay.update(
@@ -3508,6 +3520,37 @@ export class FrameRenderer {
 				point.interactionType,
 			);
 		}
+	}
+
+	private applyCursorFollowCrop(timeMs: number, layoutCache: LayoutCache): void {
+		const settings = this.config.cursorFollowCrop;
+		const baseCrop = this.config.cropRegion;
+		if (!settings?.enabled || !this.videoSprite || !baseCrop) {
+			if (this.videoSprite) {
+				this.videoSprite.position.set(
+					layoutCache.baseOffset.x,
+					layoutCache.baseOffset.y,
+				);
+			}
+			layoutCache.maskRect.sourceCrop = baseCrop;
+			return;
+		}
+		const effectiveCrop = computeCursorFollowCrop(
+			this.cursorFollowCropState,
+			this.config.cursorTelemetry ?? [],
+			timeMs,
+			baseCrop,
+			settings,
+		);
+		const fullVideoDisplayWidth = this.config.videoWidth * layoutCache.baseScale;
+		const fullVideoDisplayHeight = this.config.videoHeight * layoutCache.baseScale;
+		const dx = (effectiveCrop.x - baseCrop.x) * fullVideoDisplayWidth;
+		const dy = (effectiveCrop.y - baseCrop.y) * fullVideoDisplayHeight;
+		this.videoSprite.position.set(
+			layoutCache.baseOffset.x - dx,
+			layoutCache.baseOffset.y - dy,
+		);
+		layoutCache.maskRect.sourceCrop = effectiveCrop;
 	}
 
 	private updateLayout(): void {

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -41,6 +41,11 @@ import {
 	createCursorFollowCropState,
 } from "@/components/video-editor/videoPlayback/cursorFollowCrop";
 import {
+	type CursorTextZoomState,
+	computeCursorTextZoom,
+	createCursorTextZoomState,
+} from "@/components/video-editor/videoPlayback/cursorTextZoom";
+import {
 	DEFAULT_CURSOR_CONFIG,
 	PixiCursorOverlay,
 	preloadCursorAssets,
@@ -486,6 +491,7 @@ export class FrameRenderer {
 	private springY: SpringState;
 	private cursorFollowCamera: CursorFollowCameraState;
 	private cursorFollowCropState: CursorFollowCropState = createCursorFollowCropState();
+	private cursorTextZoomState: CursorTextZoomState = createCursorTextZoomState();
 	private lastContentTimeMs: number | null = null;
 	private layoutCache: LayoutCache | null = null;
 	private currentVideoTime = 0;
@@ -3808,6 +3814,30 @@ export class FrameRenderer {
 				});
 				targetProgress = 1;
 			}
+		}
+
+		// Text-zoom layer (independent of crop pan and explicit zoom regions;
+		// explicit zooms win). The zoom spring below eases it in and out.
+		const explicitZoomActive = Boolean(region && strength > 0);
+		if (
+			this.config.cursorFollowCrop?.textZoomEnabled &&
+			!explicitZoomActive &&
+			this.config.cursorTelemetry &&
+			this.config.cursorTelemetry.length > 0
+		) {
+			const textZoom = computeCursorTextZoom(
+				this.cursorTextZoomState,
+				this.config.cursorTelemetry,
+				timeMs,
+				this.config.cursorFollowCrop,
+			);
+			if (textZoom.active) {
+				targetScaleFactor = textZoom.scale;
+				targetFocus = textZoom.focus;
+				targetProgress = 1;
+			}
+		} else if (!this.config.cursorFollowCrop?.textZoomEnabled) {
+			this.cursorTextZoomState = createCursorTextZoomState();
 		}
 
 		const state = this.animationState;

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -6,6 +6,7 @@ import type {
 	ClipRegion,
 	CropRegion,
 	CursorClickEffectStyle,
+	CursorFollowCropSettings,
 	CursorStyle,
 	CursorTelemetryPoint,
 	Padding,
@@ -119,6 +120,7 @@ interface VideoExporterConfig extends ExportConfig {
 	padding?: Padding | number;
 	videoPadding?: Padding | number;
 	cropRegion: CropRegion;
+	cursorFollowCrop?: CursorFollowCropSettings;
 	webcam?: WebcamOverlaySettings;
 	webcamUrl?: string | null;
 	annotationRegions?: AnnotationRegion[];
@@ -608,6 +610,7 @@ export class ModernVideoExporter {
 					borderRadius: this.config.borderRadius,
 					padding: this.config.padding,
 					cropRegion: this.config.cropRegion,
+					cursorFollowCrop: this.config.cursorFollowCrop,
 					webcam: this.config.webcam,
 					webcamUrl: this.config.webcamUrl,
 					videoWidth: videoInfo.width,
@@ -1575,6 +1578,10 @@ export class ModernVideoExporter {
 			crop.height <= 0
 		) {
 			reasons.push("invalid-crop-region");
+		}
+
+		if (this.config.cursorFollowCrop?.enabled) {
+			reasons.push("cursor-follow-crop-dynamic-layout");
 		}
 
 		return reasons;

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -5,6 +5,7 @@ import type {
 	CaptionCue,
 	ClipRegion,
 	CropRegion,
+	CursorFollowCropSettings,
 	CursorStyle,
 	CursorTelemetryPoint,
 	Padding,
@@ -69,6 +70,7 @@ interface VideoExporterConfig extends ExportConfig {
 	padding?: Padding | number;
 	videoPadding?: number;
 	cropRegion: CropRegion;
+	cursorFollowCrop?: CursorFollowCropSettings;
 	webcam?: WebcamOverlaySettings;
 	webcamUrl?: string | null;
 	annotationRegions?: AnnotationRegion[];
@@ -239,6 +241,7 @@ export class VideoExporter {
 				borderRadius: this.config.borderRadius,
 				padding: this.config.padding,
 				cropRegion: this.config.cropRegion,
+				cursorFollowCrop: this.config.cursorFollowCrop,
 				webcam: this.config.webcam,
 				webcamUrl: this.config.webcamUrl,
 				videoWidth: videoInfo.width,


### PR DESCRIPTION
When recording screen captures with a crop applied (e.g. 1080p output from a 1440p source), the viewport tracks the mouse cursor — which works great when you're moving the mouse, but causes the frame to drift away from the typing area whenever you stop to type. This PR adds cursor-follow crop: a per-frame viewport pan that keeps the cursor inside a configurable safe zone, plus an opt-in text cursor focus mode that locks the viewport to the typing area when the I-beam is active and the mouse is stationary.

## What's in the PR

**Core algorithm** (`videoPlayback/cursorFollowCrop.ts`) — stateful per-frame computation that reads cursor telemetry, interpolates position, and eases the viewport top-left so the cursor stays inside the safe-zone inset. No dependencies on anything outside the existing telemetry pipeline.

**Text cursor focus** — optional mode that detects mouse velocity over a 400ms look-back window and the `cursorType` field already present in cursor.json telemetry. When the mouse has been still for 700ms and the cursor type is `"text"`, the viewport locks to the typing area with a high smoothness floor (0.92). Mouse movement immediately snaps back to tracking mode. Debounced to avoid jarring transitions.

**UI** — a "Track cursor" toggle in the crop panel with safe zone and smoothness sliders, plus the text cursor focus checkbox. All settings persist with the project.

**Export** — wired into `FrameRenderer`/`modernFrameRenderer` so the same crop behavior applies during export.

**Tests** — 9 unit tests covering: edge clamping, safe zone hold, scrub reinit, telemetry fallback, mouse/text mode switching, and mode reset on scrub backwards.

## Files changed

- `types.ts` — `CursorFollowCropSettings`, `DEFAULT_CURSOR_FOLLOW_CROP`
- `videoPlayback/cursorFollowCrop.ts` — new file, core algorithm
- `videoPlayback/cursorFollowCrop.test.ts` — new file, tests
- `CropControl.tsx` — crop panel UI
- `VideoPlayback.tsx` — preview integration + dep array update
- `projectPersistence.ts` — load/save normalization
- `frameRenderer.ts`, `modernFrameRenderer.ts` — export pipeline
- `videoExporter.ts`, `modernVideoExporter.ts`, `gifExporter.ts` — config threading

## Testing

Enable Track cursor on a 1440p recording cropped to 1080p. The viewport should pan to keep the cursor in frame during playback and export. With Text cursor focus on, scrubbing to a typing section should show the viewport staying stable on the text field; moving the mouse should immediately resume tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Cursor-follow crop mode: Automatically pans and resizes the crop area to track cursor position, with safe zones, smoothing, preview modes, and optional “text cursor” zoom behavior.
- Exports and project save/load now preserve the cursor-follow crop setting.

**Bug Fixes**
- Improved responsiveness when scrubbing/pausing so cursor-follow tracking resets correctly.

**New Features**
- Support for M4A audio files.

**Chores / Improvements**
- Faster, safer audio waveform generation with size limits and reduced memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->