### PR TITLE
fix(export): use real source dimensions for 4K "Original" export

### DIFF
--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -1402,7 +1402,7 @@ export default function VideoEditor() {
 				gifSizePreset,
 				GIF_SIZE_PRESETS,
 			),
-		[gifSizePreset],
+		[gifSizePreset, isPreviewReady],
 	);
 
 	const desiredMp4SourceDimensions = useMemo(
@@ -1412,7 +1412,7 @@ export default function VideoEditor() {
 				videoPlaybackRef.current?.video?.videoHeight || 1080,
 				aspectRatio,
 			),
-		[aspectRatio],
+		[aspectRatio, isPreviewReady],
 	);
 
 	const mp4OutputDimensions = useMemo(() => {


### PR DESCRIPTION
# Pull Request Template

## Description
The MP4/GIF export-dimension memos read the live videoWidth/videoHeight through videoPlaybackRef but only depended on aspectRatio/gifSizePreset. They computed once before metadata loaded, fell back to 1920x1080, and never recomputed — so a 3840x2160 recording showed and exported as 1920x1080 when "Original" was selected.

Add isPreviewReady to both memo dependency arrays so they recompute once the video is ready (videoWidth > 0). mp4OutputDimensions and the export pipeline derive from these, so the correct source size now flows to both the displayed "Original" value and the actual export.

## Motivation
4K Export is not working

## Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
#639 

## Screenshots / Video
<img width="3215" height="1976" alt="image" src="https://github.com/user-attachments/assets/ac7f06ac-ef68-4f78-a799-f05822157ada" />

## Testing Guide
1. With a 4K Monitor choose Screen 1 (Primary)
2. Click on Record Button
3. Stop
4. Try to export Video to MP4
5. Original Size show 3840x2160 and export to 3840x2160

## Checklist
- [X] I have performed a self-review of my code.
- [X] I have added any necessary screenshots or videos.
- [X] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized video editor performance by deferring dimension calculations until the preview is ready, reducing unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->