### PR TITLE
fix(windows): use WGC for window capture

### DIFF
--- a/src/hooks/useScreenRecorder.test.ts
+++ b/src/hooks/useScreenRecorder.test.ts
@@ -164,8 +164,12 @@ describe("shouldUseNativeWindowsCaptureForSource", () => {
 		expect(shouldUseNativeWindowsCaptureForSource({ id: "screen:101:0" })).toBe(true);
 	});
 
-	it("routes window sources through browser capture", () => {
-		expect(shouldUseNativeWindowsCaptureForSource({ id: "window:123456:0" })).toBe(false);
+	it("keeps native Windows capture on window sources", () => {
+		expect(shouldUseNativeWindowsCaptureForSource({ id: "window:123456:0" })).toBe(true);
+	});
+
+	it("keeps browser capture for non-desktop sources", () => {
+		expect(shouldUseNativeWindowsCaptureForSource({ id: "browser-tab:abc" })).toBe(false);
 	});
 });
 

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -213,7 +213,10 @@ export function resolveBrowserCaptureCursorPolicy({
 export function shouldUseNativeWindowsCaptureForSource(
 	source: Pick<ProcessedDesktopSource, "id"> | null | undefined,
 ): boolean {
-	return source?.id?.startsWith("screen:") === true;
+	return (
+		source?.id?.startsWith("screen:") === true ||
+		source?.id?.startsWith("window:") === true
+	);
 }
 
 export function createProcessedMicrophoneConstraints(


### PR DESCRIPTION
## Summary
- route Windows window sources through the native WGC path instead of browser/Electron capture
- keep the Windows native capture gate aligned with the existing window-target resolver
- add a regression test so Windows desktop sources use native capture for both screens and windows

## Validation
- node /Users/work/Desktop/recordly/node_modules/vitest/vitest.mjs --root /Users/work/Desktop/recordly-wgc-fix --config /Users/work/Desktop/recordly-wgc-fix/vitest.config.ts run /Users/work/Desktop/recordly-wgc-fix/src/hooks/useScreenRecorder.test.ts /Users/work/Desktop/recordly-wgc-fix/electron/ipc/windowsCaptureSelection.test.ts
- /Users/work/Desktop/recordly/node_modules/.bin/tsc -p tsconfig.json --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced window capture in screen recording to use native system capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->