### PR TITLE
fix(mac): honor selected microphone in native ScreenCaptureKit capture

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -557,6 +557,11 @@ interface Window {
 			startDelayMsByPath?: Record<string, number>;
 			error?: string;
 		}>;
+		listNativeMicrophones: () => Promise<{
+			success: boolean;
+			devices: Array<{ id: string; name: string }>;
+			error?: string;
+		}>;
 		setRecordingState: (recording: boolean) => Promise<void>;
 		getCursorTelemetry: (videoPath?: string) => Promise<{
 			success: boolean;

--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -1384,6 +1384,35 @@ export function registerRecordingHandlers(
 		return { success: true, diagnostics: lastNativeCaptureDiagnostics };
 	});
 
+	ipcMain.handle("list-native-microphones", async () => {
+		if (process.platform !== "darwin") {
+			return { success: true, devices: [] as Array<{ id: string; name: string }> };
+		}
+		try {
+			const helperPath = await ensureNativeCaptureHelperBinary();
+			const { stdout } = await execFileAsync(helperPath, ["--list-microphones"], {
+				timeout: 10000,
+			});
+			const parsed = JSON.parse(stdout.trim());
+			const devices = Array.isArray(parsed)
+				? parsed.filter(
+						(entry): entry is { id: string; name: string } =>
+							Boolean(entry) &&
+							typeof entry.id === "string" &&
+							typeof entry.name === "string",
+					)
+				: [];
+			return { success: true, devices };
+		} catch (error) {
+			console.error("Failed to enumerate native microphones:", error);
+			return {
+				success: false,
+				devices: [] as Array<{ id: string; name: string }>,
+				error: String(error),
+			};
+		}
+	});
+
 	ipcMain.handle("get-video-audio-fallback-paths", async (_event, videoPath: string) => {
 		if (!videoPath) {
 			return { success: true, paths: [], startDelayMsByPath: {} };

--- a/electron/native/ScreenCaptureKitRecorder.swift
+++ b/electron/native/ScreenCaptureKitRecorder.swift
@@ -528,15 +528,31 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 	private static func resolveMicrophoneCaptureDeviceID(config: CaptureConfig) -> String? {
 		let audioDevices = AVCaptureDevice.devices(for: .audio)
 
+		// Prefer an exact Core Audio uniqueID — the app resolves the selected
+		// device to its uniqueID via the --list-microphones enumeration and passes
+		// it here, so this is the authoritative match.
+		if let microphoneDeviceId = config.microphoneDeviceId?.trimmingCharacters(in: .whitespacesAndNewlines), !microphoneDeviceId.isEmpty {
+			if audioDevices.contains(where: { $0.uniqueID == microphoneDeviceId }) {
+				return microphoneDeviceId
+			}
+		}
+
+		// Fall back to matching by name. Web device labels don't always equal the
+		// Core Audio localizedName verbatim, so match exact, then case-insensitive,
+		// then a containment match in either direction.
 		if let microphoneLabel = config.microphoneLabel?.trimmingCharacters(in: .whitespacesAndNewlines), !microphoneLabel.isEmpty {
 			if let matchedDevice = audioDevices.first(where: { $0.localizedName == microphoneLabel }) {
 				return matchedDevice.uniqueID
 			}
-		}
-
-		if let microphoneDeviceId = config.microphoneDeviceId?.trimmingCharacters(in: .whitespacesAndNewlines), !microphoneDeviceId.isEmpty {
-			if audioDevices.contains(where: { $0.uniqueID == microphoneDeviceId }) {
-				return microphoneDeviceId
+			let target = microphoneLabel.lowercased()
+			if let matchedDevice = audioDevices.first(where: { $0.localizedName.lowercased() == target }) {
+				return matchedDevice.uniqueID
+			}
+			if let matchedDevice = audioDevices.first(where: {
+				let name = $0.localizedName.lowercased()
+				return !name.isEmpty && (name.contains(target) || target.contains(name))
+			}) {
+				return matchedDevice.uniqueID
 			}
 		}
 
@@ -649,6 +665,22 @@ guard CommandLine.arguments.count >= 2 else {
 	fputs("Missing config JSON\n", stderr)
 	fflush(stderr)
 	exit(1)
+}
+
+// Microphone enumeration mode: print the real Core Audio input devices as JSON
+// (uniqueID + localizedName) so the app can let the user pick a device and pass
+// back its uniqueID. Runs before any screen-capture preflight so it never
+// triggers screen-recording permission prompts.
+if CommandLine.arguments[1] == "--list-microphones" {
+	let audioDevices = AVCaptureDevice.devices(for: .audio)
+	let payload = audioDevices.map { ["id": $0.uniqueID, "name": $0.localizedName] }
+	if let data = try? JSONSerialization.data(withJSONObject: payload),
+	   let json = String(data: data, encoding: .utf8) {
+		print(json)
+	} else {
+		print("[]")
+	}
+	exit(0)
 }
 
 // Force CoreGraphics Services initialization on the main thread.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -465,6 +465,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	getVideoAudioFallbackPaths: (videoPath: string) => {
 		return ipcRenderer.invoke("get-video-audio-fallback-paths", videoPath);
 	},
+	listNativeMicrophones: () => {
+		return ipcRenderer.invoke("list-native-microphones");
+	},
 	getSources: async (opts: Electron.SourcesOptions) => {
 		return await ipcRenderer.invoke("get-sources", opts);
 	},

--- a/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
+++ b/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
@@ -6,7 +6,7 @@ import {
 	ZOOM_OUT_EARLY_START_MS,
 } from "./constants";
 import { clampFocusToScale } from "./focusUtils";
-import { clamp01, cubicBezier, easeOutZoom } from "./mathUtils";
+import { clamp01, easeOutZoom } from "./mathUtils";
 
 const CHAINED_ZOOM_PAN_GAP_MS = 1350;
 const CONNECTED_ZOOM_PAN_DURATION_MS = 1000;
@@ -33,14 +33,6 @@ type ConnectedPanTransition = {
 	startScale: number;
 	endScale: number;
 };
-
-function lerp(start: number, end: number, amount: number) {
-	return start + (end - start) * amount;
-}
-
-function easeConnectedPan(value: number) {
-	return cubicBezier(0.1, 0.0, 0.2, 1.0, value);
-}
 
 export function computeRegionStrength(
 	region: ZoomRegion,
@@ -77,13 +69,6 @@ export function computeRegionStrength(
 
 	const progress = clamp01((adjustedTimeMs - zoomOutStart) / zoomOutDurationMs);
 	return 1 - easeOutZoom(progress);
-}
-
-function getLinearFocus(start: ZoomFocus, end: ZoomFocus, amount: number): ZoomFocus {
-	return {
-		cx: lerp(start.cx, end.cx, amount),
-		cy: lerp(start.cy, end.cy, amount),
-	};
 }
 
 function getResolvedFocus(region: ZoomRegion, zoomScale: number): ZoomFocus {
@@ -194,44 +179,6 @@ function getConnectedRegionHold(timeMs: number, connectedPairs: ConnectedRegionP
 				blendedScale: null,
 			};
 		}
-	}
-
-	return null;
-}
-
-function getConnectedRegionTransition(connectedPairs: ConnectedRegionPair[], timeMs: number) {
-	for (const pair of connectedPairs) {
-		const { currentRegion, nextRegion, transitionStart, transitionEnd } = pair;
-
-		if (timeMs < transitionStart || timeMs > transitionEnd) {
-			continue;
-		}
-
-		const transitionProgress = easeConnectedPan(
-			clamp01((timeMs - transitionStart) / Math.max(1, transitionEnd - transitionStart)),
-		);
-		const currentScale = ZOOM_DEPTH_SCALES[currentRegion.depth];
-		const nextScale = ZOOM_DEPTH_SCALES[nextRegion.depth];
-		const transitionScale = lerp(currentScale, nextScale, transitionProgress);
-		const currentFocus = getResolvedFocus(currentRegion, currentScale);
-		const nextFocus = getResolvedFocus(nextRegion, nextScale);
-		const transitionFocus = getLinearFocus(currentFocus, nextFocus, transitionProgress);
-
-		return {
-			region: {
-				...nextRegion,
-				focus: transitionFocus,
-			},
-			strength: 1,
-			blendedScale: transitionScale,
-			transition: {
-				progress: transitionProgress,
-				startFocus: currentFocus,
-				endFocus: nextFocus,
-				startScale: currentScale,
-				endScale: nextScale,
-			},
-		};
 	}
 
 	return null;

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1483,7 +1483,12 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					{
 						capturesSystemAudio: systemAudioEnabled,
 						capturesMicrophone: microphoneEnabled,
-						microphoneDeviceId: nativeMicId ?? microphoneDeviceId,
+						// On macOS, only the resolved Core Audio uniqueID is usable; the web
+						// deviceId can't match, so pass the resolved id (or nothing and let
+						// the helper fall back to label matching) rather than a web id.
+						microphoneDeviceId: useNativeMacScreenCapture
+							? nativeMicId
+							: microphoneDeviceId,
 						microphoneLabel: micLabel,
 					},
 				);

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -1441,6 +1441,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			if (useNativeMacScreenCapture || useNativeWindowsCapture) {
 				// Resolve the selected mic label for native capture backends.
 				let micLabel: string | undefined;
+				let nativeMicId: string | undefined;
 				if (microphoneEnabled) {
 					try {
 						const devices = await navigator.mediaDevices.enumerateDevices();
@@ -1451,6 +1452,30 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					} catch {
 						// Fall through — native process will use the default mic
 					}
+
+					// The web deviceId is an opaque per-origin hash that never matches a
+					// Core Audio uniqueID, so the native recorder can't honor it directly.
+					// Map the selected mic to its real native uniqueID via the helper's
+					// enumeration so ScreenCaptureKit records the chosen device instead of
+					// silently falling back to the system default.
+					if (useNativeMacScreenCapture && micLabel) {
+						try {
+							const nativeMics = await window.electronAPI.listNativeMicrophones?.();
+							if (nativeMics?.success && nativeMics.devices.length > 0) {
+								const normalize = (value: string) => value.trim().toLowerCase();
+								const target = normalize(micLabel);
+								const match =
+									nativeMics.devices.find((d) => normalize(d.name) === target) ??
+									nativeMics.devices.find((d) => {
+										const name = normalize(d.name);
+										return name.length > 0 && (name.includes(target) || target.includes(name));
+									});
+								nativeMicId = match?.id;
+							}
+						} catch {
+							// Fall through — native side still attempts label matching.
+						}
+					}
 				}
 
 				const nativeResult = await window.electronAPI.startNativeScreenRecording(
@@ -1458,7 +1483,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 					{
 						capturesSystemAudio: systemAudioEnabled,
 						capturesMicrophone: microphoneEnabled,
-						microphoneDeviceId,
+						microphoneDeviceId: nativeMicId ?? microphoneDeviceId,
 						microphoneLabel: micLabel,
 					},
 				);


### PR DESCRIPTION
## Problem

On macOS (native ScreenCaptureKit backend), selecting a specific microphone in Recordly has no effect — the recorder always captures the **system default input device**. If the default is a poor/far device (e.g. a Bluetooth speakerphone running in HFP/SCO narrowband mode), recordings come out muffled and quiet regardless of what the user picked.

## Root cause

The renderer passed the **web `MediaDevices` deviceId** (an opaque, per-origin hashed string) plus the web device label to the native helper. The Swift helper then tried to match those against `AVCaptureDevice`:

- The web `deviceId` never equals a Core Audio `uniqueID`, so that match always failed.
- The web label rarely equals `AVCaptureDevice.localizedName` verbatim (and can be empty when the capturing context lacks mic permission), so exact label matching usually failed too.

When both failed, `resolveMicrophoneCaptureDeviceID` returned `nil` and ScreenCaptureKit silently fell back to the system default mic.

## Fix

- **Helper (`ScreenCaptureKitRecorder.swift`):** add a `--list-microphones` mode that prints the real Core Audio input devices (`uniqueID` + `localizedName`) as JSON. Runs before any screen-capture preflight so enumeration never triggers a Screen Recording permission prompt.
- **Main + preload + types:** add a `list-native-microphones` IPC that runs the helper in that mode and returns the device list.
- **Renderer (`useScreenRecorder.ts`):** at record-start, resolve the selected mic to its real Core Audio `uniqueID` via that enumeration and pass it as `microphoneDeviceId`, so ScreenCaptureKit records the chosen device.
- **Resolver:** prefer the exact `uniqueID`, then fall back to tolerant (case-insensitive / containment) label matching as a backstop.

## Note on the second commit

`fix(build): remove orphaned connected-zoom transition dead code` is included because `main` currently fails `tsc` (`getConnectedRegionTransition` and its only-local helpers in `zoomRegionUtils.ts` are unreferenced, tripping `noUnusedLocals`), which blocks compiling/building this change. Happy to split it into its own PR if preferred.

## Testing

- `npx tsc` clean; `vitest` suites pass.
- Compiled the helper with `swiftc` and verified `--list-microphones` returns the real devices with their `uniqueID`s.
- Verified on an Apple Silicon build that selecting a specific mic now records that device instead of the system default.

Found while investigating #662.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native microphone enumeration so the app can list available input devices on macOS.

* **Bug Fixes**
  * Improved microphone selection for macOS native screen recording to more reliably pick the intended device.
  * Removed the connected zoom/pan transition interpolation to avoid problematic transitions; dominant region behavior preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->