### PR TITLE
Fix Lightning default render backend

### DIFF
--- a/src/lib/exporter/modernVideoExporter.fallback.test.ts
+++ b/src/lib/exporter/modernVideoExporter.fallback.test.ts
@@ -337,4 +337,83 @@ describe("ModernVideoExporter native fallback routing", () => {
 			}),
 		);
 	});
+
+	it("uses the stable Lightning render backend by default", async () => {
+		const { ModernVideoExporter } = await import("./modernVideoExporter");
+		const { FrameRenderer } = await import("./modernFrameRenderer");
+		mocks.streamingDecoderGetEffectiveDuration.mockReturnValue(1);
+
+		const exporter = new ModernVideoExporter({
+			videoUrl: "file:///recording.mp4",
+			width: 1920,
+			height: 1080,
+			frameRate: 30,
+			bitrate: 8_000_000,
+			wallpaper: "#101010",
+			padding: 0,
+			borderRadius: 0,
+			backgroundBlur: 0,
+			shadowIntensity: 0,
+			showShadow: false,
+			cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+			backendPreference: "webcodecs",
+		} as never) as unknown as {
+			export: () => Promise<{ success: boolean; blob?: Blob; error?: string }>;
+			initializeEncoder: () => Promise<unknown>;
+		};
+
+		vi.spyOn(exporter, "initializeEncoder").mockResolvedValue({
+			codec: "avc1.640034",
+			hardwareAcceleration: "prefer-hardware",
+		});
+
+		const result = await exporter.export();
+
+		expect(result.success).toBe(true);
+		expect(FrameRenderer).toHaveBeenCalledWith(
+			expect.objectContaining({
+				preferredRenderBackend: "webgl",
+			}),
+		);
+	});
+
+	it("allows an explicit Lightning render backend override", async () => {
+		const { ModernVideoExporter } = await import("./modernVideoExporter");
+		const { FrameRenderer } = await import("./modernFrameRenderer");
+		mocks.streamingDecoderGetEffectiveDuration.mockReturnValue(1);
+
+		const exporter = new ModernVideoExporter({
+			videoUrl: "file:///recording.mp4",
+			width: 1920,
+			height: 1080,
+			frameRate: 30,
+			bitrate: 8_000_000,
+			wallpaper: "#101010",
+			padding: 0,
+			borderRadius: 0,
+			backgroundBlur: 0,
+			shadowIntensity: 0,
+			showShadow: false,
+			cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+			backendPreference: "webcodecs",
+			preferredRenderBackend: "webgpu",
+		} as never) as unknown as {
+			export: () => Promise<{ success: boolean; blob?: Blob; error?: string }>;
+			initializeEncoder: () => Promise<unknown>;
+		};
+
+		vi.spyOn(exporter, "initializeEncoder").mockResolvedValue({
+			codec: "avc1.640034",
+			hardwareAcceleration: "prefer-hardware",
+		});
+
+		const result = await exporter.export();
+
+		expect(result.success).toBe(true);
+		expect(FrameRenderer).toHaveBeenCalledWith(
+			expect.objectContaining({
+				preferredRenderBackend: "webgpu",
+			}),
+		);
+	});
 });

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -51,6 +51,7 @@ import {
 } from "@/lib/wallpapers";
 import { AudioProcessor, isAacAudioEncodingSupported } from "./audioEncoder";
 import {
+	getDefaultLightningRenderBackend,
 	normalizeLightningRuntimePlatform,
 	shouldPreferNativeAutoBackend,
 	shouldPreferNativeStaticLayoutBeforeBreeze,
@@ -585,7 +586,8 @@ export class ModernVideoExporter {
 				this.renderer = new ModernFrameRenderer({
 					width: this.config.width,
 					height: this.config.height,
-					preferredRenderBackend: undefined,
+					preferredRenderBackend:
+						this.config.preferredRenderBackend ?? getDefaultLightningRenderBackend(),
 					wallpaper: this.config.wallpaper,
 					zoomRegions: this.config.zoomRegions,
 					showShadow: this.config.showShadow,


### PR DESCRIPTION
## Description
Fix Lightning exports so they use the stable default render backend when no explicit backend is configured.

## Motivation
On Linux, Lightning export could select WebGPU automatically when `navigator.gpu` was available, even though the renderer policy defaults Lightning to WebGL for stability. This could trigger export failures in the WebGPU path. The change makes `ModernVideoExporter` apply the existing Lightning backend policy by default, while still allowing explicit WebGPU overrides for testing/debugging.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Fix #644

## Screenshots / Video
N/A

## Testing Guide
Run:

```bash
npm test -- src/lib/exporter/modernVideoExporter.fallback.test.ts src/lib/exporter/backendPolicy.test.ts
```

Verified locally: 2 test files passed, 16 tests passed.

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved render backend selection for video exporting when no explicit preference is provided; the exporter now assigns an appropriate default instead of leaving the value undefined.

* **Tests**
  * Added test coverage for render backend routing behavior to validate correct configuration handling in both default and explicit preference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->