### PR TITLE
fix(timeline): roll playhead seconds into the next minute

### DIFF
--- a/src/components/video-editor/timeline/core/time.test.ts
+++ b/src/components/video-editor/timeline/core/time.test.ts
@@ -38,6 +38,15 @@ describe("timeline core/time", () => {
 		expect(formatPlayheadTime(61_400)).toBe("1:01.4");
 	});
 
+	it("rolls seconds into the next minute when rounding reaches 60", () => {
+		// 59.95s–59.99s round up to 60.0s and must carry into the minute
+		// instead of rendering "60.0s" or "1:60.0".
+		expect(formatPlayheadTime(59_950)).toBe("1:00.0");
+		expect(formatPlayheadTime(59_970)).toBe("1:00.0");
+		expect(formatPlayheadTime(119_970)).toBe("2:00.0");
+		expect(formatPlayheadTime(0)).toBe("0.0s");
+	});
+
 	it("normalizes wheel delta by deltaMode", () => {
 		expect(normalizeWheelDeltaToPixels(2, 0)).toBe(2);
 		expect(normalizeWheelDeltaToPixels(2, 1)).toBe(32);

--- a/src/components/video-editor/timeline/core/time.ts
+++ b/src/components/video-editor/timeline/core/time.ts
@@ -108,9 +108,13 @@ export function formatTimeLabel(milliseconds: number, intervalMs: number) {
 }
 
 export function formatPlayheadTime(ms: number): string {
-	const s = ms / 1000;
-	const min = Math.floor(s / 60);
-	const sec = s % 60;
+	// Round to the displayed precision (tenths of a second) before splitting
+	// into minutes and seconds. Rounding the seconds component on its own lets
+	// values such as 59.97s render as "60.0" and carry into labels like
+	// "1:60.0" or "60.0s" instead of rolling over to the next minute.
+	const tenths = Math.round((ms / 1000) * 10);
+	const min = Math.floor(tenths / 600);
+	const sec = (tenths - min * 600) / 10;
 	if (min > 0) return `${min}:${sec.toFixed(1).padStart(4, "0")}`;
 	return `${sec.toFixed(1)}s`;
 }


### PR DESCRIPTION
## Summary

`formatPlayheadTime` rounds the **seconds** component independently of the minutes/hours, so a time that rounds up to `60.0` does not carry into the next minute. During playback/scrubbing the editor's playhead clock then renders invalid labels.

## Root cause
```ts
const s = ms / 1000;
const min = Math.floor(s / 60);
const sec = s % 60;          // e.g. 59.97
// sec.toFixed(1) -> "60.0", but `min` was already computed
```
`(59.97).toFixed(1)` becomes `"60.0"`, which is appended to the already-computed minute.

## Observed (before)
| input (ms) | output | expected |
|---|---|---|
| 59950 | `60.0s` | `1:00.0` |
| 59970 | `60.0s` | `1:00.0` |
| 119970 | `1:60.0` | `2:00.0` |

## Fix
Round to the displayed precision (tenths of a second) **first**, then split into minutes/seconds so any carry rolls into the minute correctly. Existing outputs (`1234 -> 1.2s`, `61400 -> 1:01.4`) are unchanged.

## Tests
Added a regression test covering the rollover boundary. Full `time.test.ts` suite passes (7/7).

## Risk
Minimal — pure display formatting, no behavioural change outside the rounding boundary; existing assertions preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected video editor timeline playhead time formatting to properly round values near minute transitions, preventing display inconsistencies when time approaches 60 seconds.

* **Tests**
  * Added unit test to validate playhead time rounding behavior at minute boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->