### PR TITLE
fix(export): normalize WebCodecs decoder codec strings

### DIFF
--- a/src/lib/exporter/forwardFrameSource.ts
+++ b/src/lib/exporter/forwardFrameSource.ts
@@ -1,10 +1,8 @@
 import { WebDemuxer } from "web-demuxer";
 import { getEffectiveVideoStreamDurationSeconds } from "@/lib/mediaTiming";
+import { createReadableMediaResourceFile, resolveMediaResourceUrl } from "./localMediaSource";
 import { getDecodedFrameTimelineOffsetUs } from "./streamingDecoder";
-import {
-	createReadableMediaResourceFile,
-	resolveMediaResourceUrl,
-} from "./localMediaSource";
+import { configureVideoDecoder } from "./videoDecoderConfig";
 
 const DEFAULT_MAX_DECODE_QUEUE = 12;
 const DEFAULT_MAX_PENDING_FRAMES = 32;
@@ -108,8 +106,6 @@ export class ForwardFrameSource {
 		}
 
 		const decoderConfig = await this.demuxer.getDecoderConfig("video");
-		const codec = this.metadata.codec.toLowerCase();
-		const shouldPreferSoftwareDecode = codec.includes("av01") || codec.includes("av1");
 
 		this.decoder = new VideoDecoder({
 			output: (frame: VideoFrame) => {
@@ -133,21 +129,7 @@ export class ForwardFrameSource {
 			},
 		});
 
-		const preferredDecoderConfig = shouldPreferSoftwareDecode
-			? {
-					...decoderConfig,
-					hardwareAcceleration: "prefer-software" as const,
-				}
-			: decoderConfig;
-
-		try {
-			this.decoder.configure(preferredDecoderConfig);
-		} catch (error) {
-			if (!shouldPreferSoftwareDecode) {
-				throw error;
-			}
-			this.decoder.configure(decoderConfig);
-		}
+		await configureVideoDecoder(this.decoder, decoderConfig);
 
 		const readEndSec =
 			Math.max(

--- a/src/lib/exporter/streamingDecoder.ts
+++ b/src/lib/exporter/streamingDecoder.ts
@@ -2,6 +2,7 @@ import { WebDemuxer } from "web-demuxer";
 import type { SpeedRegion, TrimRegion } from "@/components/video-editor/types";
 import { getEffectiveVideoStreamDurationSeconds } from "@/lib/mediaTiming";
 import { createReadableMediaResourceFile, resolveMediaResourceUrl } from "./localMediaSource";
+import { configureVideoDecoder } from "./videoDecoderConfig";
 
 const DEFAULT_MAX_DECODE_QUEUE = 12;
 const DEFAULT_MAX_PENDING_FRAMES = 32;
@@ -203,8 +204,6 @@ export class StreamingVideoDecoder {
 		}
 
 		const decoderConfig = await this.demuxer.getDecoderConfig("video");
-		const codec = this.metadata.codec.toLowerCase();
-		const shouldPreferSoftwareDecode = codec.includes("av01") || codec.includes("av1");
 		const effectiveVideoDuration = getEffectiveVideoStreamDurationSeconds({
 			duration: this.metadata.duration,
 			streamDuration: this.metadata.streamDuration,
@@ -282,22 +281,7 @@ export class StreamingVideoDecoder {
 				notifyBackpressureProgress();
 			},
 		});
-		const preferredDecoderConfig = shouldPreferSoftwareDecode
-			? {
-					...decoderConfig,
-					hardwareAcceleration: "prefer-software" as const,
-				}
-			: decoderConfig;
-
-		try {
-			this.decoder.configure(preferredDecoderConfig);
-		} catch (error) {
-			if (!shouldPreferSoftwareDecode) {
-				throw error;
-			}
-			// Fall back to default decoder config if software preference is unsupported.
-			this.decoder.configure(decoderConfig);
-		}
+		await configureVideoDecoder(this.decoder, decoderConfig);
 
 		const getNextFrame = (): Promise<VideoFrame | null> => {
 			if (decodeError) throw decodeError;

--- a/src/lib/exporter/videoDecoderConfig.test.ts
+++ b/src/lib/exporter/videoDecoderConfig.test.ts
@@ -58,17 +58,20 @@ describe("configureVideoDecoder", () => {
 		);
 	});
 
-	it("tries software decoding first for VP9", async () => {
+	it.each(["vp09", "vp09.00.10.08"])("tries software decoding first for %s", async (codec) => {
 		isConfigSupported.mockResolvedValue({ supported: true });
 
 		await configureVideoDecoder({ configure } as unknown as VideoDecoder, {
-			codec: "vp09",
+			codec,
 			codedWidth: 1920,
 			codedHeight: 1080,
 		});
 
 		expect(configure).toHaveBeenCalledWith(
-			expect.objectContaining({ codec: "vp9", hardwareAcceleration: "prefer-software" }),
+			expect.objectContaining({
+				codec: codec === "vp09" ? "vp9" : codec,
+				hardwareAcceleration: "prefer-software",
+			}),
 		);
 	});
 });

--- a/src/lib/exporter/videoDecoderConfig.test.ts
+++ b/src/lib/exporter/videoDecoderConfig.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	configureVideoDecoder,
+	FALLBACK_H264_CODEC,
+	normalizeVideoDecoderConfig,
+} from "./videoDecoderConfig";
+
+describe("normalizeVideoDecoderConfig", () => {
+	it.each([
+		["av01", "av01.0.01M.08"],
+		["h264", FALLBACK_H264_CODEC],
+		["avc1", FALLBACK_H264_CODEC],
+		["vp08", "vp8"],
+		["vp09", "vp9"],
+	])("normalizes %s to %s", (codec, expected) => {
+		expect(normalizeVideoDecoderConfig({ codec }).codec).toBe(expected);
+	});
+
+	it("preserves complete codec strings and decoder metadata", () => {
+		const description = new Uint8Array([1, 2, 3]);
+		const config: VideoDecoderConfig = {
+			codec: "avc1.42c032",
+			codedWidth: 1920,
+			codedHeight: 1080,
+			description,
+		};
+
+		expect(normalizeVideoDecoderConfig(config)).toBe(config);
+	});
+});
+
+describe("configureVideoDecoder", () => {
+	const configure = vi.fn();
+	const isConfigSupported = vi.fn();
+
+	beforeEach(() => {
+		configure.mockReset();
+		isConfigSupported.mockReset();
+		vi.stubGlobal("VideoDecoder", { isConfigSupported });
+	});
+
+	it("falls back when a malformed AVC codec string is unsupported", async () => {
+		isConfigSupported.mockImplementation(async (config: VideoDecoderConfig) => ({
+			supported: config.codec === FALLBACK_H264_CODEC,
+			config,
+		}));
+
+		const configured = await configureVideoDecoder({ configure } as unknown as VideoDecoder, {
+			codec: "avc1.2420032",
+			codedWidth: 2048,
+			codedHeight: 1152,
+		});
+
+		expect(configured.codec).toBe(FALLBACK_H264_CODEC);
+		expect(configure).toHaveBeenCalledOnce();
+		expect(configure).toHaveBeenCalledWith(
+			expect.objectContaining({ codec: FALLBACK_H264_CODEC }),
+		);
+	});
+
+	it("tries software decoding first for VP9", async () => {
+		isConfigSupported.mockResolvedValue({ supported: true });
+
+		await configureVideoDecoder({ configure } as unknown as VideoDecoder, {
+			codec: "vp09",
+			codedWidth: 1920,
+			codedHeight: 1080,
+		});
+
+		expect(configure).toHaveBeenCalledWith(
+			expect.objectContaining({ codec: "vp9", hardwareAcceleration: "prefer-software" }),
+		);
+	});
+});

--- a/src/lib/exporter/videoDecoderConfig.ts
+++ b/src/lib/exporter/videoDecoderConfig.ts
@@ -1,5 +1,6 @@
 export const FALLBACK_H264_CODEC = "avc1.640033";
 
+/** Normalizes demuxer codec aliases into WebCodecs-compatible identifiers. */
 export function normalizeVideoDecoderConfig(config: VideoDecoderConfig): VideoDecoderConfig {
 	let codec = config.codec;
 
@@ -11,15 +12,18 @@ export function normalizeVideoDecoderConfig(config: VideoDecoderConfig): VideoDe
 	return codec === config.codec ? config : { ...config, codec };
 }
 
+/** Returns whether software decoding should be attempted before the default decoder path. */
 function prefersSoftwareDecode(codec: string): boolean {
 	const normalizedCodec = codec.toLowerCase();
 	return (
 		normalizedCodec.includes("av01") ||
 		normalizedCodec.includes("av1") ||
-		normalizedCodec === "vp9"
+		normalizedCodec === "vp9" ||
+		normalizedCodec.startsWith("vp09.")
 	);
 }
 
+/** Builds decoder candidates in preference and fallback order. */
 function decoderConfigCandidates(config: VideoDecoderConfig): VideoDecoderConfig[] {
 	const normalizedConfig = normalizeVideoDecoderConfig(config);
 	const candidates: VideoDecoderConfig[] = [];
@@ -40,6 +44,7 @@ function decoderConfigCandidates(config: VideoDecoderConfig): VideoDecoderConfig
 	return candidates;
 }
 
+/** Configures a decoder with the first supported normalized codec candidate. */
 export async function configureVideoDecoder(
 	decoder: VideoDecoder,
 	config: VideoDecoderConfig,

--- a/src/lib/exporter/videoDecoderConfig.ts
+++ b/src/lib/exporter/videoDecoderConfig.ts
@@ -1,0 +1,63 @@
+export const FALLBACK_H264_CODEC = "avc1.640033";
+
+export function normalizeVideoDecoderConfig(config: VideoDecoderConfig): VideoDecoderConfig {
+	let codec = config.codec;
+
+	if (/^av01$/i.test(codec)) codec = "av01.0.01M.08";
+	if (/^vp08$/i.test(codec)) codec = "vp8";
+	if (/^vp09$/i.test(codec)) codec = "vp9";
+	if (/^(avc1|h264)$/i.test(codec)) codec = FALLBACK_H264_CODEC;
+
+	return codec === config.codec ? config : { ...config, codec };
+}
+
+function prefersSoftwareDecode(codec: string): boolean {
+	const normalizedCodec = codec.toLowerCase();
+	return (
+		normalizedCodec.includes("av01") ||
+		normalizedCodec.includes("av1") ||
+		normalizedCodec === "vp9"
+	);
+}
+
+function decoderConfigCandidates(config: VideoDecoderConfig): VideoDecoderConfig[] {
+	const normalizedConfig = normalizeVideoDecoderConfig(config);
+	const candidates: VideoDecoderConfig[] = [];
+
+	if (prefersSoftwareDecode(normalizedConfig.codec)) {
+		candidates.push({ ...normalizedConfig, hardwareAcceleration: "prefer-software" });
+	}
+
+	candidates.push(normalizedConfig);
+
+	if (
+		/^avc1/i.test(normalizedConfig.codec) &&
+		normalizedConfig.codec.toLowerCase() !== FALLBACK_H264_CODEC
+	) {
+		candidates.push({ ...normalizedConfig, codec: FALLBACK_H264_CODEC });
+	}
+
+	return candidates;
+}
+
+export async function configureVideoDecoder(
+	decoder: VideoDecoder,
+	config: VideoDecoderConfig,
+): Promise<VideoDecoderConfig> {
+	let lastError: unknown;
+
+	for (const candidate of decoderConfigCandidates(config)) {
+		try {
+			const support = await VideoDecoder.isConfigSupported(candidate);
+			if (!support.supported) continue;
+
+			decoder.configure(candidate);
+			return candidate;
+		} catch (error) {
+			lastError = error;
+		}
+	}
+
+	if (lastError instanceof Error) throw lastError;
+	throw new Error(`Unsupported video codec: ${config.codec}`);
+}


### PR DESCRIPTION
## Description

Adds a shared WebCodecs decoder configuration helper used by both the main streaming export decoder and the forward frame source.

The helper normalizes bare codec names returned by `web-demuxer`:

- `av01` to a complete AV1 codec string
- `vp08` to `vp8`
- `vp09` to `vp9`
- `h264` and bare `avc1` to `avc1.640033`

It checks each candidate with `VideoDecoder.isConfigSupported()` before configuration and falls back to `avc1.640033` when a malformed or unsupported AVC codec string is reported.

## Motivation

H.264 recordings in WebM containers can produce codec strings such as `h264`, `avc1`, or `avc1.2420032`. Passing these directly to WebCodecs can fail with `VideoDecoder error: Unknown or ambiguous codec name`, preventing MP4 export.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other

## Related Issue(s)

Closes #674

## Screenshots / Video

Not applicable; this changes decoder configuration and has unit-test coverage.

## Testing Guide

1. `npm test -- src/lib/exporter/videoDecoderConfig.test.ts src/lib/exporter/streamingDecoder.test.ts`
2. `npx biome check src/lib/exporter/videoDecoderConfig.ts src/lib/exporter/videoDecoderConfig.test.ts src/lib/exporter/streamingDecoder.ts src/lib/exporter/forwardFrameSource.ts`
3. Export an H.264 WebM recording whose demuxer codec is bare or malformed.

Focused result: 17 tests passed and all changed files pass Biome.

Full-suite result: 778 of 779 tests passed. The remaining Windows helper-path test requires a staged native Windows binary and fails on the Linux checkout. The repository-wide TypeScript and Biome checks also report existing diagnostics in files outside this change.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added necessary tests.
- [x] I have linked the related issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated video decoder configuration to improve codec normalization and selection, providing broader codec compatibility and more reliable fallback behavior for export and streaming.

* **Tests**
  * Added unit tests covering codec normalization and decoder configuration to ensure consistent playback and decoding behavior across formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->