### PR TITLE
fix(linux): use actual desktopCapturer source on X11

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -712,39 +712,39 @@ function updateTrayMenu(recording: boolean = false) {
 	const trayToolTip = recording ? `Recording: ${selectedSourceName}` : "Recordly";
 	const menuTemplate = recording
 		? [
-				{
-					label: "Show Controls",
-					click: () => {
-						if (!showHudOverlayFromTray()) {
-							focusOrCreateMainWindow();
-						}
-					},
+			{
+				label: "Show Controls",
+				click: () => {
+					if (!showHudOverlayFromTray()) {
+						focusOrCreateMainWindow();
+					}
 				},
-				{
-					label: "Stop Recording",
-					click: () => {
-						if (mainWindow && !mainWindow.isDestroyed()) {
-							mainWindow.webContents.send("stop-recording-from-tray");
-						}
-					},
+			},
+			{
+				label: "Stop Recording",
+				click: () => {
+					if (mainWindow && !mainWindow.isDestroyed()) {
+						mainWindow.webContents.send("stop-recording-from-tray");
+					}
 				},
-			]
+			},
+		]
 		: [
-				{
-					label: "Open",
-					click: () => {
-						if (!showHudOverlayFromTray()) {
-							focusOrCreateMainWindow();
-						}
-					},
+			{
+				label: "Open",
+				click: () => {
+					if (!showHudOverlayFromTray()) {
+						focusOrCreateMainWindow();
+					}
 				},
-				{
-					label: "Quit",
-					click: () => {
-						app.quit();
-					},
+			},
+			{
+				label: "Quit",
+				click: () => {
+					app.quit();
 				},
-			];
+			},
+		];
 	const menu = Menu.buildFromTemplate(menuTemplate);
 	trayContextMenu = menu;
 	tray.setImage(trayIcon);
@@ -1005,7 +1005,7 @@ app.whenReady().then(async () => {
 	// ignored by the native capture pipeline.
 	session.defaultSession.setDisplayMediaRequestHandler(async (_request, callback) => {
 		try {
-			const sourceId = getSelectedSourceId();
+			let sourceId = getSelectedSourceId();
 			// On Linux/Wayland, calling desktopCapturer.getSources() itself
 			// invokes the xdg-desktop-portal picker. If we then return one of
 			// those sources, Chromium triggers a SECOND portal because the
@@ -1014,27 +1014,37 @@ app.whenReady().then(async () => {
 			// is set we skip getSources entirely and hand back a synthetic
 			// source id; Chromium then opens the portal once to actually
 			// resolve the capture.
-			// Default to the sentinel on Linux when no source has been
-			// pre-selected (e.g. fresh session where the renderer skipped the
-			// source picker entirely). This avoids calling getSources() which
-			// would itself trigger an extra portal dialog.
+			const isWayland =
+				process.env.XDG_SESSION_TYPE === "wayland" || !!process.env.WAYLAND_DISPLAY;
+
 			const isLinuxPortalSentinel =
-				process.platform === "linux" && (sourceId === "screen:linux-portal" || !sourceId);
+				process.platform === "linux" && isWayland && (sourceId === "screen:linux-portal" || !sourceId);
 			if (isLinuxPortalSentinel) {
 				callback({ video: { id: "screen:0:0", name: "Entire screen" } });
 				return;
 			}
-			const sources = await desktopCapturer.getSources({ types: ["screen", "window"] });
-			const source = sourceId
-				? (sources.find((s) => s.id === sourceId) ?? sources[0])
-				: sources[0];
-			if (source) {
-				callback({
-					video: { id: source.id, name: source.name },
-				});
-			} else {
-				callback({});
+
+			// On Linux/X11, "screen:linux-portal" is not a real desktopCapturer
+			// source id. Resolve the actual X11 source instead, e.g. screen:428:0.
+			if (process.platform === "linux" && sourceId === "screen:linux-portal") {
+				sourceId = null;
 			}
+
+			const sources = await desktopCapturer.getSources({ types: ["screen", "window"] });
+
+			const source =
+				(sourceId ? sources.find((s) => s.id === sourceId) : undefined) ??
+				sources.find((s) => s.id.startsWith("screen:")) ??
+				sources[0];
+
+			if (!source) {
+				callback({});
+				return;
+			}
+
+			callback({
+				video: { id: source.id, name: source.name, },
+			});
 		} catch (error) {
 			console.error("setDisplayMediaRequestHandler error:", error);
 			callback({});

--- a/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
+++ b/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
@@ -6,7 +6,7 @@ import {
 	ZOOM_OUT_EARLY_START_MS,
 } from "./constants";
 import { clampFocusToScale } from "./focusUtils";
-import { clamp01, cubicBezier, easeOutZoom } from "./mathUtils";
+import { clamp01, easeOutZoom } from "./mathUtils";
 
 const CHAINED_ZOOM_PAN_GAP_MS = 1350;
 const CONNECTED_ZOOM_PAN_DURATION_MS = 1000;
@@ -33,14 +33,6 @@ type ConnectedPanTransition = {
 	startScale: number;
 	endScale: number;
 };
-
-function lerp(start: number, end: number, amount: number) {
-	return start + (end - start) * amount;
-}
-
-function easeConnectedPan(value: number) {
-	return cubicBezier(0.1, 0.0, 0.2, 1.0, value);
-}
 
 export function computeRegionStrength(
 	region: ZoomRegion,
@@ -77,13 +69,6 @@ export function computeRegionStrength(
 
 	const progress = clamp01((adjustedTimeMs - zoomOutStart) / zoomOutDurationMs);
 	return 1 - easeOutZoom(progress);
-}
-
-function getLinearFocus(start: ZoomFocus, end: ZoomFocus, amount: number): ZoomFocus {
-	return {
-		cx: lerp(start.cx, end.cx, amount),
-		cy: lerp(start.cy, end.cy, amount),
-	};
 }
 
 function getResolvedFocus(region: ZoomRegion, zoomScale: number): ZoomFocus {
@@ -194,44 +179,6 @@ function getConnectedRegionHold(timeMs: number, connectedPairs: ConnectedRegionP
 				blendedScale: null,
 			};
 		}
-	}
-
-	return null;
-}
-
-function getConnectedRegionTransition(connectedPairs: ConnectedRegionPair[], timeMs: number) {
-	for (const pair of connectedPairs) {
-		const { currentRegion, nextRegion, transitionStart, transitionEnd } = pair;
-
-		if (timeMs < transitionStart || timeMs > transitionEnd) {
-			continue;
-		}
-
-		const transitionProgress = easeConnectedPan(
-			clamp01((timeMs - transitionStart) / Math.max(1, transitionEnd - transitionStart)),
-		);
-		const currentScale = ZOOM_DEPTH_SCALES[currentRegion.depth];
-		const nextScale = ZOOM_DEPTH_SCALES[nextRegion.depth];
-		const transitionScale = lerp(currentScale, nextScale, transitionProgress);
-		const currentFocus = getResolvedFocus(currentRegion, currentScale);
-		const nextFocus = getResolvedFocus(nextRegion, nextScale);
-		const transitionFocus = getLinearFocus(currentFocus, nextFocus, transitionProgress);
-
-		return {
-			region: {
-				...nextRegion,
-				focus: transitionFocus,
-			},
-			strength: 1,
-			blendedScale: transitionScale,
-			transition: {
-				progress: transitionProgress,
-				startFocus: currentFocus,
-				endFocus: nextFocus,
-				startScale: currentScale,
-				endScale: nextScale,
-			},
-		};
 	}
 
 	return null;


### PR DESCRIPTION
## Description

This PR fixes Linux X11 screen recording startup by resolving the actual screen source from `desktopCapturer.getSources()` instead of using the Linux portal sentinel source on X11.

It also removes unused zoom region helper code that caused `npm run build:linux` to fail with TS6133 unused declaration errors.

## Motivation

On Linux X11, Recordly can receive `screen:linux-portal` as the selected source. That value is not a real X11 `desktopCapturer` source ID.

Previously, the display media request handler treated this as a Linux portal case and returned a synthetic `screen:0:0` source. On X11, this can fail with:

> Failed to start recording: Could not start video source

On my X11 setup, `desktopCapturer.getSources()` returns valid screen sources such as:

```txt
screen:428:0
screen:427:0
```

Using the actual source allows recording to start correctly.

This addresses the X11 capture-source part of #364, but does not attempt to fix the AppImage toolbar/source-selector UI regression.

## Type of Change

* [ ] New Feature
* [x] Bug Fix
* [x] Refactor / Code Cleanup
* [ ] Documentation Update
* [ ] Other (please specify)

## Related Issue(s)

Related to #364

## Screenshots / Video

**Screenshot** (if applicable):

N/A

**Video** (wherever possible):

N/A

## Testing Guide

Tested on Linux X11 with a multi-monitor setup.

Environment:

```bash
echo $XDG_SESSION_TYPE
# x11

echo $DISPLAY
# :1

xrandr --listmonitors
# Monitors: 2
```

Steps tested:

1. Install dependencies.

```bash
npm install
```

2. Run the app in development mode.

```bash
npm run dev
```

3. Start a screen recording from the HUD.

Expected result:

* Recording starts successfully.
* No `Failed to start recording: Could not start video source` error appears.
* Recording opens in the editor after stopping.

4. Export using Legacy export mode.

Expected result:

* Export completes successfully.

5. Run Linux build.

```bash
npm run build:linux
```

Expected result:

* Build completes successfully.
* No TS6133 unused declaration errors from `zoomRegionUtils.ts`.

## Checklist

* [x] I have performed a self-review of my code.
* [ ] I have added any necessary screenshots or videos.
* [x] I have linked related issue(s) and updated the changelog if applicable.

---

*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced screen capture source handling for Linux systems using Wayland display servers, improving detection and selection of the correct display for screen sharing.

* **Refactor**
  * Updated tray context menu to properly display recording control options based on whether the application is actively recording.
  * Optimized zoom region utilities by reducing interpolation calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->