### PR TITLE
fix(projects): streamline import and save flow

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -69,7 +69,28 @@
       "NSCameraUsageDescription": "Recordly needs camera access to record webcam video.",
       "NSMicrophoneUsageDescription": "Recordly needs microphone access to record voice audio.",
       "NSCameraUseContinuityCameraDeviceType": true,
-      "com.apple.security.device.audio-input": true
+      "com.apple.security.device.audio-input": true,
+      "CFBundleDocumentTypes": [
+        {
+          "CFBundleTypeName": "Recordly Project",
+          "CFBundleTypeRole": "Editor",
+          "CFBundleTypeExtensions": ["recordly"],
+          "CFBundleTypeIconFile": "icon.icns",
+          "LSHandlerRank": "Owner",
+          "LSItemContentTypes": ["dev.recordly.app.project"]
+        }
+      ],
+      "UTExportedTypeDeclarations": [
+        {
+          "UTTypeIdentifier": "dev.recordly.app.project",
+          "UTTypeDescription": "Recordly Project",
+          "UTTypeConformsTo": ["public.json"],
+          "UTTypeTagSpecification": {
+            "public.filename-extension": ["recordly"],
+            "public.mime-type": "application/x-recordly-project"
+          }
+        }
+      ]
     }
   },
   "linux": {

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -649,7 +649,16 @@ interface Window {
 			error?: string;
 			canceled?: boolean;
 		}>;
-		openVideoFilePicker: () => Promise<{ success: boolean; path?: string; canceled?: boolean }>;
+		openVideoFilePicker: (options?: { includeProjects?: boolean }) => Promise<{
+			success: boolean;
+			kind?: "media" | "project";
+			path?: string;
+			project?: unknown;
+			extension?: string;
+			message?: string;
+			canceled?: boolean;
+			error?: string;
+		}>;
 		openAudioFilePicker: () => Promise<{ success: boolean; path?: string; canceled?: boolean }>;
 		openWhisperExecutablePicker: () => Promise<{
 			success: boolean;

--- a/electron/ipc/project/manager.test.ts
+++ b/electron/ipc/project/manager.test.ts
@@ -53,7 +53,9 @@ describe("local media path policy", () => {
 		await fs.mkdir(downloadsPath, { recursive: true });
 		await fs.writeFile(exportPath, "test-video");
 
-		const { isAllowedLocalMediaPath, rememberApprovedLocalReadPath } = await import("./manager");
+		const { isAllowedLocalMediaPath, rememberApprovedLocalReadPath } = await import(
+			"./manager"
+		);
 
 		await expect(isAllowedLocalMediaPath(exportPath)).resolves.toBe(false);
 
@@ -71,7 +73,9 @@ describe("local media path policy", () => {
 
 	it("allows approved media paths before the file exists", async () => {
 		const pendingExportPath = path.join(tempRoot, "Downloads", "pending-export.mp4");
-		const { isAllowedLocalMediaPath, rememberApprovedLocalReadPath } = await import("./manager");
+		const { isAllowedLocalMediaPath, rememberApprovedLocalReadPath } = await import(
+			"./manager"
+		);
 
 		await rememberApprovedLocalReadPath(pendingExportPath);
 
@@ -131,7 +135,9 @@ describe("local media path policy", () => {
 			throw error;
 		}
 
-		const { isAllowedLocalMediaPath, resolveApprovedLocalMediaPath } = await import("./manager");
+		const { isAllowedLocalMediaPath, resolveApprovedLocalMediaPath } = await import(
+			"./manager"
+		);
 
 		await expect(isAllowedLocalMediaPath(symlinkInsideUserData)).resolves.toBe(false);
 		await expect(resolveApprovedLocalMediaPath(symlinkInsideUserData)).resolves.toBeNull();
@@ -173,6 +179,29 @@ describe("local media path policy", () => {
 		expect(result.project).toMatchObject({ videoPath });
 	});
 
+	it("rejects invalid project payloads before approving media paths", async () => {
+		const downloadsPath = path.join(tempRoot, "Downloads");
+		const videoPath = path.join(downloadsPath, "recording.mp4");
+		const projectPath = path.join(tempPath, "invalid.recordly");
+		await fs.mkdir(downloadsPath, { recursive: true });
+		await fs.writeFile(videoPath, "test-video");
+		await fs.writeFile(
+			projectPath,
+			JSON.stringify({
+				videoPath,
+				editor: {},
+			}),
+			"utf-8",
+		);
+
+		const { loadProjectFromPath, resolveApprovedLocalMediaPath } = await import("./manager");
+
+		const result = await loadProjectFromPath(projectPath);
+		expect(result.success).toBe(false);
+		expect(result.message).toBe("Invalid project file format");
+		await expect(resolveApprovedLocalMediaPath(videoPath)).resolves.toBeNull();
+	});
+
 	it("approves editor audioRegions audioPath entries when loading a project", async () => {
 		const downloadsPath = path.join(tempRoot, "Downloads");
 		const videoPath = path.join(tempPath, "recording.mp4");
@@ -187,9 +216,7 @@ describe("local media path policy", () => {
 				version: 1,
 				videoPath,
 				editor: {
-					audioRegions: [
-						{ id: "a1", startMs: 0, endMs: 1000, audioPath, volume: 1 },
-					],
+					audioRegions: [{ id: "a1", startMs: 0, endMs: 1000, audioPath, volume: 1 }],
 				},
 			}),
 			"utf-8",

--- a/electron/ipc/project/manager.ts
+++ b/electron/ipc/project/manager.ts
@@ -403,6 +403,29 @@ export async function listProjectLibraryEntries() {
 	};
 }
 
+function isLoadableProjectData(projectData: unknown) {
+	if (!projectData || typeof projectData !== "object" || Array.isArray(projectData)) {
+		return false;
+	}
+
+	const candidate = projectData as {
+		version?: unknown;
+		projectId?: unknown;
+		videoPath?: unknown;
+		editor?: unknown;
+	};
+
+	return (
+		typeof candidate.version === "number" &&
+		(candidate.projectId === undefined || typeof candidate.projectId === "string") &&
+		typeof candidate.videoPath === "string" &&
+		candidate.videoPath.trim().length > 0 &&
+		candidate.editor != null &&
+		typeof candidate.editor === "object" &&
+		!Array.isArray(candidate.editor)
+	);
+}
+
 export async function loadProjectFromPath(projectPath: string) {
 	const normalizedPath = normalizePath(projectPath);
 	let project: unknown;
@@ -414,6 +437,13 @@ export async function loadProjectFromPath(projectPath: string) {
 			success: false,
 			canceled: false,
 			message: `Failed to read project file: ${error instanceof Error ? error.message : String(error)}`,
+		};
+	}
+	if (!isLoadableProjectData(project)) {
+		return {
+			success: false,
+			canceled: false,
+			message: "Invalid project file format",
 		};
 	}
 	const mediaSources = await resolveProjectMediaSources(project);

--- a/electron/ipc/register/captions.ts
+++ b/electron/ipc/register/captions.ts
@@ -1,207 +1,255 @@
+import path from "node:path";
 import { dialog, ipcMain } from "electron";
-import { setCurrentProjectPath } from "../state";
+import { generateAutoCaptionsFromVideo } from "../captions/generate";
 import {
-	getWhisperSmallModelStatus,
-	downloadWhisperSmallModel,
 	deleteWhisperSmallModel,
+	downloadWhisperSmallModel,
+	getWhisperSmallModelStatus,
 	sendWhisperModelDownloadProgress,
 } from "../captions/whisper";
-import { generateAutoCaptionsFromVideo } from "../captions/generate";
+import { LEGACY_PROJECT_FILE_EXTENSIONS, PROJECT_FILE_EXTENSION } from "../constants";
+import { hasProjectFileExtension, loadProjectFromPath } from "../project/manager";
+import { setCurrentProjectPath } from "../state";
 import { approveUserPath, getRecordingsDir } from "../utils";
 
+const VIDEO_FILE_EXTENSIONS = ["webm", "mp4", "mov", "avi", "mkv"];
+const PROJECT_FILE_EXTENSIONS = [PROJECT_FILE_EXTENSION, ...LEGACY_PROJECT_FILE_EXTENSIONS];
+
+type OpenVideoFilePickerOptions = {
+	includeProjects?: boolean;
+};
+
 export function registerCaptionHandlers() {
-  ipcMain.handle('open-video-file-picker', async () => {
-    try {
-      const recordingsDir = await getRecordingsDir()
-      const result = await dialog.showOpenDialog({
-        title: 'Select Video File',
-        defaultPath: recordingsDir,
-        filters: [
-          { name: 'Video Files', extensions: ['webm', 'mp4', 'mov', 'avi', 'mkv'] },
-          { name: 'All Files', extensions: ['*'] }
-        ],
-        properties: ['openFile']
-      });
+	ipcMain.handle("open-video-file-picker", async (_, options?: OpenVideoFilePickerOptions) => {
+		try {
+			const includeProjects = Boolean(options?.includeProjects);
+			const recordingsDir = await getRecordingsDir();
+			const result = await dialog.showOpenDialog({
+				title: includeProjects ? "Import Media or Recordly Project" : "Select Video File",
+				defaultPath: recordingsDir,
+				filters: [
+					...(includeProjects
+						? [
+								{
+									name: "Media or Recordly Projects",
+									extensions: [
+										...VIDEO_FILE_EXTENSIONS,
+										...PROJECT_FILE_EXTENSIONS,
+									],
+								},
+							]
+						: []),
+					{ name: "Video Files", extensions: VIDEO_FILE_EXTENSIONS },
+					...(includeProjects
+						? [{ name: "Recordly Projects", extensions: PROJECT_FILE_EXTENSIONS }]
+						: []),
+					{ name: "All Files", extensions: ["*"] },
+				],
+				properties: ["openFile"],
+			});
 
-      if (result.canceled || result.filePaths.length === 0) {
-        return { success: false, canceled: true };
-      }
+			if (result.canceled || result.filePaths.length === 0) {
+				return { success: false, canceled: true };
+			}
 
-      approveUserPath(result.filePaths[0])
-      setCurrentProjectPath(null)
-      return {
-        success: true,
-        path: result.filePaths[0]
-      };
-    } catch (error) {
-      console.error('Failed to open file picker:', error);
-      return {
-        success: false,
-        message: 'Failed to open file picker',
-        error: String(error)
-      };
-    }
-  });
+			const selectedPath = result.filePaths[0];
 
-  ipcMain.handle('open-audio-file-picker', async () => {
-    try {
-      const result = await dialog.showOpenDialog({
-        title: 'Select Audio File',
-        filters: [
-          { name: 'Audio Files', extensions: ['mp3', 'wav', 'aac', 'm4a', 'flac', 'ogg'] },
-          { name: 'All Files', extensions: ['*'] }
-        ],
-        properties: ['openFile']
-      });
+			if (includeProjects && hasProjectFileExtension(selectedPath)) {
+				const projectResult = await loadProjectFromPath(selectedPath);
+				return projectResult.success
+					? { ...projectResult, kind: "project" }
+					: projectResult;
+			}
 
-      if (result.canceled || result.filePaths.length === 0) {
-        return { success: false, canceled: true };
-      }
+			approveUserPath(selectedPath);
+			setCurrentProjectPath(null);
+			return {
+				success: true,
+				kind: "media",
+				path: selectedPath,
+				extension: path.extname(selectedPath).replace(/^\./, "").toLowerCase(),
+			};
+		} catch (error) {
+			console.error("Failed to open file picker:", error);
+			return {
+				success: false,
+				message: "Failed to open file picker",
+				error: String(error),
+			};
+		}
+	});
 
-      approveUserPath(result.filePaths[0])
-      return {
-        success: true,
-        path: result.filePaths[0]
-      };
-    } catch (error) {
-      console.error('Failed to open audio file picker:', error);
-      return {
-        success: false,
-        message: 'Failed to open audio file picker',
-        error: String(error)
-      };
-    }
-  });
+	ipcMain.handle("open-audio-file-picker", async () => {
+		try {
+			const result = await dialog.showOpenDialog({
+				title: "Select Audio File",
+				filters: [
+					{
+						name: "Audio Files",
+						extensions: ["mp3", "wav", "aac", "m4a", "flac", "ogg"],
+					},
+					{ name: "All Files", extensions: ["*"] },
+				],
+				properties: ["openFile"],
+			});
 
-  ipcMain.handle('open-whisper-executable-picker', async () => {
-    try {
-      const result = await dialog.showOpenDialog({
-        title: 'Select Whisper Executable',
-        filters: [
-          { name: 'Executables', extensions: process.platform === 'win32' ? ['exe', 'cmd', 'bat'] : ['*'] },
-          { name: 'All Files', extensions: ['*'] },
-        ],
-        properties: ['openFile'],
-      })
+			if (result.canceled || result.filePaths.length === 0) {
+				return { success: false, canceled: true };
+			}
 
-      if (result.canceled || result.filePaths.length === 0) {
-        return { success: false, canceled: true }
-      }
+			approveUserPath(result.filePaths[0]);
+			return {
+				success: true,
+				path: result.filePaths[0],
+			};
+		} catch (error) {
+			console.error("Failed to open audio file picker:", error);
+			return {
+				success: false,
+				message: "Failed to open audio file picker",
+				error: String(error),
+			};
+		}
+	});
 
-      approveUserPath(result.filePaths[0])
-      return { success: true, path: result.filePaths[0] }
-    } catch (error) {
-      console.error('Failed to open Whisper executable picker:', error)
-      return { success: false, error: String(error) }
-    }
-  })
+	ipcMain.handle("open-whisper-executable-picker", async () => {
+		try {
+			const result = await dialog.showOpenDialog({
+				title: "Select Whisper Executable",
+				filters: [
+					{
+						name: "Executables",
+						extensions: process.platform === "win32" ? ["exe", "cmd", "bat"] : ["*"],
+					},
+					{ name: "All Files", extensions: ["*"] },
+				],
+				properties: ["openFile"],
+			});
 
-  ipcMain.handle('open-whisper-model-picker', async () => {
-    try {
-      const result = await dialog.showOpenDialog({
-        title: 'Select Whisper Model',
-        filters: [
-          { name: 'Whisper Models', extensions: ['bin'] },
-          { name: 'All Files', extensions: ['*'] },
-        ],
-        properties: ['openFile'],
-      })
+			if (result.canceled || result.filePaths.length === 0) {
+				return { success: false, canceled: true };
+			}
 
-      if (result.canceled || result.filePaths.length === 0) {
-        return { success: false, canceled: true }
-      }
+			approveUserPath(result.filePaths[0]);
+			return { success: true, path: result.filePaths[0] };
+		} catch (error) {
+			console.error("Failed to open Whisper executable picker:", error);
+			return { success: false, error: String(error) };
+		}
+	});
 
-      approveUserPath(result.filePaths[0])
-      return { success: true, path: result.filePaths[0] }
-    } catch (error) {
-      console.error('Failed to open Whisper model picker:', error)
-      return { success: false, error: String(error) }
-    }
-  })
+	ipcMain.handle("open-whisper-model-picker", async () => {
+		try {
+			const result = await dialog.showOpenDialog({
+				title: "Select Whisper Model",
+				filters: [
+					{ name: "Whisper Models", extensions: ["bin"] },
+					{ name: "All Files", extensions: ["*"] },
+				],
+				properties: ["openFile"],
+			});
 
-  ipcMain.handle('get-whisper-small-model-status', async () => {
-    try {
-      return await getWhisperSmallModelStatus()
-    } catch (error) {
-      return { success: false, exists: false, path: null, error: String(error) }
-    }
-  })
+			if (result.canceled || result.filePaths.length === 0) {
+				return { success: false, canceled: true };
+			}
 
-  ipcMain.handle('download-whisper-small-model', async (event) => {
-    try {
-      const existing = await getWhisperSmallModelStatus()
-      if (existing.exists) {
-        sendWhisperModelDownloadProgress(event.sender, {
-          status: 'downloaded',
-          progress: 100,
-          path: existing.path,
-        })
-        return { success: true, path: existing.path, alreadyDownloaded: true }
-      }
+			approveUserPath(result.filePaths[0]);
+			return { success: true, path: result.filePaths[0] };
+		} catch (error) {
+			console.error("Failed to open Whisper model picker:", error);
+			return { success: false, error: String(error) };
+		}
+	});
 
-      const modelPath = await downloadWhisperSmallModel(event.sender)
-      return { success: true, path: modelPath }
-    } catch (error) {
-      console.error('Failed to download Whisper small model:', error)
-      return { success: false, error: String(error) }
-    }
-  })
+	ipcMain.handle("get-whisper-small-model-status", async () => {
+		try {
+			return await getWhisperSmallModelStatus();
+		} catch (error) {
+			return { success: false, exists: false, path: null, error: String(error) };
+		}
+	});
 
-  ipcMain.handle('delete-whisper-small-model', async (event) => {
-    try {
-      await deleteWhisperSmallModel()
-      sendWhisperModelDownloadProgress(event.sender, {
-        status: 'idle',
-        progress: 0,
-        path: null,
-      })
-      return { success: true }
-    } catch (error) {
-      console.error('Failed to delete Whisper small model:', error)
-      // Verify whether the file was actually removed despite the error
-      const status = await getWhisperSmallModelStatus()
-      if (!status.exists) {
-        // File is gone — treat as success
-        sendWhisperModelDownloadProgress(event.sender, {
-          status: 'idle',
-          progress: 0,
-          path: null,
-        })
-        return { success: true }
-      }
-      sendWhisperModelDownloadProgress(event.sender, {
-        status: 'error',
-        progress: 0,
-        path: null,
-        error: String(error),
-      })
-      return { success: false, error: String(error) }
-    }
-  })
+	ipcMain.handle("download-whisper-small-model", async (event) => {
+		try {
+			const existing = await getWhisperSmallModelStatus();
+			if (existing.exists) {
+				sendWhisperModelDownloadProgress(event.sender, {
+					status: "downloaded",
+					progress: 100,
+					path: existing.path,
+				});
+				return { success: true, path: existing.path, alreadyDownloaded: true };
+			}
 
-  ipcMain.handle('generate-auto-captions', async (_, options: {
-    videoPath: string
-    whisperExecutablePath: string
-    whisperModelPath: string
-    language?: string
-  }) => {
-    try {
-      const result = await generateAutoCaptionsFromVideo(options)
-      return {
-        success: true,
-        cues: result.cues,
-        message: result.audioSourceLabel === 'recording'
-          ? `Generated ${result.cues.length} caption cues.`
-          : `Generated ${result.cues.length} caption cues from the ${result.audioSourceLabel}.`,
-      }
-    } catch (error) {
-      console.error('Failed to generate auto captions:', error)
-      return {
-        success: false,
-        error: String(error),
-        message: 'Failed to generate auto captions',
-      }
-    }
-  })
+			const modelPath = await downloadWhisperSmallModel(event.sender);
+			return { success: true, path: modelPath };
+		} catch (error) {
+			console.error("Failed to download Whisper small model:", error);
+			return { success: false, error: String(error) };
+		}
+	});
 
+	ipcMain.handle("delete-whisper-small-model", async (event) => {
+		try {
+			await deleteWhisperSmallModel();
+			sendWhisperModelDownloadProgress(event.sender, {
+				status: "idle",
+				progress: 0,
+				path: null,
+			});
+			return { success: true };
+		} catch (error) {
+			console.error("Failed to delete Whisper small model:", error);
+			// Verify whether the file was actually removed despite the error
+			const status = await getWhisperSmallModelStatus();
+			if (!status.exists) {
+				// File is gone — treat as success
+				sendWhisperModelDownloadProgress(event.sender, {
+					status: "idle",
+					progress: 0,
+					path: null,
+				});
+				return { success: true };
+			}
+			sendWhisperModelDownloadProgress(event.sender, {
+				status: "error",
+				progress: 0,
+				path: null,
+				error: String(error),
+			});
+			return { success: false, error: String(error) };
+		}
+	});
+
+	ipcMain.handle(
+		"generate-auto-captions",
+		async (
+			_,
+			options: {
+				videoPath: string;
+				whisperExecutablePath: string;
+				whisperModelPath: string;
+				language?: string;
+			},
+		) => {
+			try {
+				const result = await generateAutoCaptionsFromVideo(options);
+				return {
+					success: true,
+					cues: result.cues,
+					message:
+						result.audioSourceLabel === "recording"
+							? `Generated ${result.cues.length} caption cues.`
+							: `Generated ${result.cues.length} caption cues from the ${result.audioSourceLabel}.`,
+				};
+			} catch (error) {
+				console.error("Failed to generate auto captions:", error);
+				return {
+					success: false,
+					error: String(error),
+					message: "Failed to generate auto captions",
+				};
+			}
+		},
+	);
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -671,8 +671,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
 			captionSidecar,
 		);
 	},
-	openVideoFilePicker: () => {
-		return ipcRenderer.invoke("open-video-file-picker");
+	openVideoFilePicker: (options?: { includeProjects?: boolean }) => {
+		return ipcRenderer.invoke("open-video-file-picker", options);
 	},
 	openAudioFilePicker: () => {
 		return ipcRenderer.invoke("open-audio-file-picker");

--- a/src/components/launch/hooks/useLaunchWindowActions.ts
+++ b/src/components/launch/hooks/useLaunchWindowActions.ts
@@ -19,8 +19,12 @@ export function useLaunchWindowActions() {
 	}, []);
 
 	const openVideoFile = useCallback(async () => {
-		const result = await window.electronAPI.openVideoFilePicker();
+		const result = await window.electronAPI.openVideoFilePicker({ includeProjects: true });
 		if (result.canceled) return;
+		if (result.success && result.kind === "project") {
+			await window.electronAPI.switchToEditor();
+			return;
+		}
 		if (result.success && result.path) {
 			await window.electronAPI.setCurrentVideoPath(result.path);
 			await window.electronAPI.switchToEditor();

--- a/src/components/video-editor/AnnotationOverlay.tsx
+++ b/src/components/video-editor/AnnotationOverlay.tsx
@@ -4,17 +4,39 @@ import { cn } from "@/lib/utils";
 import { getArrowComponent } from "./ArrowSvgs";
 import { type AnnotationRegion, BASE_PREVIEW_WIDTH, BLUR_ANNOTATION_STRENGTH } from "./types";
 
+type Rect = {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+
+type SceneTransform = {
+	scale: number;
+	x: number;
+	y: number;
+};
+
 interface AnnotationOverlayProps {
 	annotation: AnnotationRegion;
 	isSelected: boolean;
 	containerWidth: number;
 	containerHeight: number;
+	recordingRect: Rect;
+	sceneTransform: SceneTransform;
 	onPositionChange: (id: string, position: { x: number; y: number }) => void;
 	onSizeChange: (id: string, size: { width: number; height: number }) => void;
 	onClick: (id: string) => void;
 	zIndex: number;
 	isSelectedBoost: boolean; // Boost z-index when selected for easy editing
-	scale?: number;
+}
+
+function clampPercent(value: number) {
+	if (!Number.isFinite(value)) {
+		return 0;
+	}
+
+	return Math.min(100, Math.max(0, value));
 }
 
 export function AnnotationOverlay({
@@ -22,19 +44,54 @@ export function AnnotationOverlay({
 	isSelected,
 	containerWidth,
 	containerHeight,
+	recordingRect,
+	sceneTransform,
 	onPositionChange,
 	onSizeChange,
 	onClick,
 	zIndex,
 	isSelectedBoost,
-	scale = 1,
 }: AnnotationOverlayProps) {
-	const x = (annotation.position.x / 100) * containerWidth;
-	const y = (annotation.position.y / 100) * containerHeight;
-	const width = (annotation.size.width / 100) * containerWidth;
-	const height = (annotation.size.height / 100) * containerHeight;
+	const safeRecordingRect =
+		recordingRect.width > 0 && recordingRect.height > 0
+			? recordingRect
+			: { x: 0, y: 0, width: containerWidth, height: containerHeight };
+	const sceneX = safeRecordingRect.x + (annotation.position.x / 100) * safeRecordingRect.width;
+	const sceneY = safeRecordingRect.y + (annotation.position.y / 100) * safeRecordingRect.height;
+	const sceneWidth = (annotation.size.width / 100) * safeRecordingRect.width;
+	const sceneHeight = (annotation.size.height / 100) * safeRecordingRect.height;
+	const x = sceneX * sceneTransform.scale + sceneTransform.x;
+	const y = sceneY * sceneTransform.scale + sceneTransform.y;
+	const width = sceneWidth * sceneTransform.scale;
+	const height = sceneHeight * sceneTransform.scale;
+	const sizeScale = safeRecordingRect.width / BASE_PREVIEW_WIDTH;
+	const blurScaleFactor = sizeScale * sceneTransform.scale;
 
 	const isDraggingRef = useRef(false);
+
+	const screenRectToRecordingPercent = (rect: Rect) => {
+		const nextSceneX = (rect.x - sceneTransform.x) / sceneTransform.scale;
+		const nextSceneY = (rect.y - sceneTransform.y) / sceneTransform.scale;
+		const nextSceneWidth = rect.width / sceneTransform.scale;
+		const nextSceneHeight = rect.height / sceneTransform.scale;
+
+		return {
+			position: {
+				x: clampPercent(
+					((nextSceneX - safeRecordingRect.x) / Math.max(1, safeRecordingRect.width)) *
+						100,
+				),
+				y: clampPercent(
+					((nextSceneY - safeRecordingRect.y) / Math.max(1, safeRecordingRect.height)) *
+						100,
+				),
+			},
+			size: {
+				width: clampPercent((nextSceneWidth / Math.max(1, safeRecordingRect.width)) * 100),
+				height: clampPercent((nextSceneHeight / Math.max(1, safeRecordingRect.height)) * 100),
+			},
+		};
+	};
 
 	const renderArrow = () => {
 		const direction = annotation.figureData?.arrowDirection || "right";
@@ -50,7 +107,7 @@ export function AnnotationOverlay({
 			case "text":
 				return (
 					<div
-						className="w-full h-full flex items-center p-2 overflow-hidden"
+						className="w-full h-full flex items-center overflow-hidden"
 						style={{
 							justifyContent:
 								annotation.style.textAlign === "left"
@@ -59,13 +116,14 @@ export function AnnotationOverlay({
 										? "flex-end"
 										: "center",
 							alignItems: "center",
+							padding: `${8 * sceneTransform.scale}px`,
 						}}
 					>
 						<span
 							style={{
 								color: annotation.style.color,
 								backgroundColor: annotation.style.backgroundColor,
-								fontSize: `${annotation.style.fontSize}px`,
+								fontSize: `${annotation.style.fontSize * sceneTransform.scale}px`,
 								fontFamily: annotation.style.fontFamily,
 								fontWeight: annotation.style.fontWeight,
 								fontStyle: annotation.style.fontStyle,
@@ -76,7 +134,7 @@ export function AnnotationOverlay({
 								boxDecorationBreak: "clone",
 								WebkitBoxDecorationBreak: "clone",
 								padding: "0.1em 0.2em",
-								borderRadius: "4px",
+								borderRadius: `${4 * sceneTransform.scale}px`,
 								lineHeight: "1.4",
 							}}
 						>
@@ -118,9 +176,8 @@ export function AnnotationOverlay({
 				);
 
 			case "blur": {
-				const previewScaleFactor = containerWidth / BASE_PREVIEW_WIDTH;
 				const currentBlurStrength = annotation.blurIntensity ?? BLUR_ANNOTATION_STRENGTH;
-				const blurPx = currentBlurStrength * previewScaleFactor;
+				const blurPx = currentBlurStrength * blurScaleFactor;
 				const blurStyle = `blur(${blurPx}px)`;
 
 				return (
@@ -130,7 +187,7 @@ export function AnnotationOverlay({
 							backdropFilter: blurStyle,
 							WebkitBackdropFilter: blurStyle,
 							backgroundColor: annotation.blurColor || "transparent",
-							borderRadius: `${(annotation.style.borderRadius ?? 0) * previewScaleFactor}px`,
+							borderRadius: `${(annotation.style.borderRadius ?? 0) * blurScaleFactor}px`,
 						}}
 					/>
 				);
@@ -145,14 +202,12 @@ export function AnnotationOverlay({
 		<Rnd
 			position={{ x, y }}
 			size={{ width, height }}
-			scale={scale}
 			onDragStart={() => {
 				isDraggingRef.current = true;
 			}}
 			onDragStop={(_e, d) => {
-				const xPercent = (d.x / containerWidth) * 100;
-				const yPercent = (d.y / containerHeight) * 100;
-				onPositionChange(annotation.id, { x: xPercent, y: yPercent });
+				const next = screenRectToRecordingPercent({ x: d.x, y: d.y, width, height });
+				onPositionChange(annotation.id, next.position);
 
 				// Reset dragging flag after a short delay to prevent click event
 				setTimeout(() => {
@@ -160,12 +215,14 @@ export function AnnotationOverlay({
 				}, 100);
 			}}
 			onResizeStop={(_e, _direction, ref, _delta, position) => {
-				const xPercent = (position.x / containerWidth) * 100;
-				const yPercent = (position.y / containerHeight) * 100;
-				const widthPercent = (ref.offsetWidth / containerWidth) * 100;
-				const heightPercent = (ref.offsetHeight / containerHeight) * 100;
-				onPositionChange(annotation.id, { x: xPercent, y: yPercent });
-				onSizeChange(annotation.id, { width: widthPercent, height: heightPercent });
+				const next = screenRectToRecordingPercent({
+					x: position.x,
+					y: position.y,
+					width: ref.offsetWidth,
+					height: ref.offsetHeight,
+				});
+				onPositionChange(annotation.id, next.position);
+				onSizeChange(annotation.id, next.size);
 			}}
 			onClick={() => {
 				if (isDraggingRef.current) return;

--- a/src/components/video-editor/AnnotationOverlay.tsx
+++ b/src/components/video-editor/AnnotationOverlay.tsx
@@ -24,6 +24,7 @@ interface AnnotationOverlayProps {
 	containerHeight: number;
 	recordingRect: Rect;
 	sceneTransform: SceneTransform;
+	interactionScale?: number;
 	onPositionChange: (id: string, position: { x: number; y: number }) => void;
 	onSizeChange: (id: string, size: { width: number; height: number }) => void;
 	onClick: (id: string) => void;
@@ -46,6 +47,7 @@ export function AnnotationOverlay({
 	containerHeight,
 	recordingRect,
 	sceneTransform,
+	interactionScale = 1,
 	onPositionChange,
 	onSizeChange,
 	onClick,
@@ -202,6 +204,7 @@ export function AnnotationOverlay({
 		<Rnd
 			position={{ x, y }}
 			size={{ width, height }}
+			scale={interactionScale}
 			onDragStart={() => {
 				isDraggingRef.current = true;
 			}}

--- a/src/components/video-editor/AnnotationOverlay.tsx
+++ b/src/components/video-editor/AnnotationOverlay.tsx
@@ -14,6 +14,7 @@ interface AnnotationOverlayProps {
 	onClick: (id: string) => void;
 	zIndex: number;
 	isSelectedBoost: boolean; // Boost z-index when selected for easy editing
+	scale?: number;
 }
 
 export function AnnotationOverlay({
@@ -26,6 +27,7 @@ export function AnnotationOverlay({
 	onClick,
 	zIndex,
 	isSelectedBoost,
+	scale = 1,
 }: AnnotationOverlayProps) {
 	const x = (annotation.position.x / 100) * containerWidth;
 	const y = (annotation.position.y / 100) * containerHeight;
@@ -143,6 +145,7 @@ export function AnnotationOverlay({
 		<Rnd
 			position={{ x, y }}
 			size={{ width, height }}
+			scale={scale}
 			onDragStart={() => {
 				isDraggingRef.current = true;
 			}}

--- a/src/components/video-editor/ProjectBrowserDialog.tsx
+++ b/src/components/video-editor/ProjectBrowserDialog.tsx
@@ -15,6 +15,7 @@ type ProjectBrowserDialogProps = {
 	onOpenChange: (open: boolean) => void;
 	entries: ProjectLibraryEntry[];
 	onOpenProject: (projectPath: string) => void;
+	onImportFile?: () => void;
 	anchorRef?: React.RefObject<HTMLElement | null>;
 	preferredDirection?: "up" | "down" | "auto";
 	onPanelHeightChange?: (height: number) => void;
@@ -25,6 +26,7 @@ export default function ProjectBrowserDialog({
 	onOpenChange,
 	entries,
 	onOpenProject,
+	onImportFile,
 	anchorRef,
 	preferredDirection = "auto",
 	onPanelHeightChange,
@@ -172,10 +174,21 @@ export default function ProjectBrowserDialog({
 				ref={panelRef}
 				role="dialog"
 				aria-label="Projects"
-					className="pointer-events-auto mb-1.5 w-[300px] max-h-[400px] overflow-hidden rounded-[14px] border border-foreground/[0.07] bg-editor-panel/[0.96] text-foreground shadow-[0_12px_32px_rgba(0,0,0,0.22),0_2px_10px_rgba(0,0,0,0.1)] animate-in fade-in-0 duration-150"
+				className="pointer-events-auto mb-1.5 w-[300px] max-h-[400px] overflow-hidden rounded-[14px] border border-foreground/[0.07] bg-editor-panel/[0.96] text-foreground shadow-[0_12px_32px_rgba(0,0,0,0.22),0_2px_10px_rgba(0,0,0,0.1)] animate-in fade-in-0 duration-150"
 			>
-				<div className="border-b border-foreground/10 px-3 py-2.5">
-					<div className="text-sm font-medium tracking-tight text-foreground">Projects</div>
+				<div className="flex items-center justify-between gap-2 border-b border-foreground/10 px-3 py-2.5">
+					<div className="text-sm font-medium tracking-tight text-foreground">
+						Projects
+					</div>
+					{onImportFile ? (
+						<button
+							type="button"
+							onClick={onImportFile}
+							className="rounded-md px-2 py-1 text-xs font-medium text-foreground/70 transition hover:bg-foreground/10 hover:text-foreground"
+						>
+							Import
+						</button>
+					) : null}
 				</div>
 				<div className="max-h-[360px] overflow-y-auto px-2.5 py-2.5">
 					{visibleEntries.length > 0 ? (
@@ -242,8 +255,19 @@ export default function ProjectBrowserDialog({
 				style={{ top: `${position.top}px`, left: `${position.left}px` }}
 				className="pointer-events-auto fixed w-[min(280px,calc(100vw-24px))] overflow-hidden rounded-2xl border border-foreground/10 bg-editor-surface text-foreground shadow-2xl animate-in fade-in-0 duration-150"
 			>
-				<div className="border-b border-foreground/10 px-3 py-2.5">
-					<div className="text-sm font-medium tracking-tight text-foreground">Projects</div>
+				<div className="flex items-center justify-between gap-2 border-b border-foreground/10 px-3 py-2.5">
+					<div className="text-sm font-medium tracking-tight text-foreground">
+						Projects
+					</div>
+					{onImportFile ? (
+						<button
+							type="button"
+							onClick={onImportFile}
+							className="rounded-md px-2 py-1 text-xs font-medium text-foreground/70 transition hover:bg-foreground/10 hover:text-foreground"
+						>
+							Import
+						</button>
+					) : null}
 				</div>
 				<div
 					className="overflow-y-auto px-2.5 py-2.5"

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -3322,22 +3322,19 @@ export function SettingsPanel({
 						)}
 					</div>
 				)}
-				<div className="rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2">
-					<div className="text-[10px] text-muted-foreground">
-						{showDevMotionControls
-							? tSettings(
-									"effects.exportBlurMovedToDev",
-									"Export blur tuning is available in Settings > Dev.",
-								)
-							: tSettings(
-									"effects.exportBlurLocked",
-									"Export blur is fixed for this build.",
-								)}
+				{showDevMotionControls ? (
+					<div className="rounded-lg border border-foreground/10 bg-foreground/[0.03] px-3 py-2">
+						<div className="text-[10px] text-muted-foreground">
+							{tSettings(
+								"effects.exportBlurMovedToDev",
+								"Export blur tuning is available in Settings > Dev.",
+							)}
+						</div>
+						<div className="mt-1 text-[12px] font-medium text-foreground">
+							{`${TEMPORAL_MOTION_BLUR_DEFAULT_SAMPLE_COUNT} samples · ${Math.round(TEMPORAL_MOTION_BLUR_DEFAULT_SHUTTER_FRACTION * 100)}% shutter`}
+						</div>
 					</div>
-					<div className="mt-1 text-[12px] font-medium text-foreground">
-						{`${TEMPORAL_MOTION_BLUR_DEFAULT_SAMPLE_COUNT} samples · ${Math.round(TEMPORAL_MOTION_BLUR_DEFAULT_SHUTTER_FRACTION * 100)}% shutter`}
-					</div>
-				</div>
+				) : null}
 				{selectedZoomId && (
 					<Button
 						onClick={() => {

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -2809,7 +2809,6 @@ export default function VideoEditor() {
 			}
 
 			setAutoCaptions(result.cues);
-			setAutoCaptionSettings((prev) => ({ ...prev, enabled: true }));
 			toast.success(result.message || `Generated ${result.cues.length} captions`);
 		} catch (error) {
 			toast.error(getErrorMessage(error));

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -298,6 +298,10 @@ type SaveProjectOptions = {
 	captureThumbnail?: boolean;
 };
 
+type PendingProjectSaveDialog = {
+	resolve: (saved: boolean) => void;
+};
+
 async function writeSmokeExportReport(
 	outputPath: string | null,
 	report: Record<string, unknown>,
@@ -382,6 +386,9 @@ export default function VideoEditor() {
 	const [isEditingProjectName, setIsEditingProjectName] = useState(false);
 	const [projectNameDraft, setProjectNameDraft] = useState("");
 	const [isSavingProjectName, setIsSavingProjectName] = useState(false);
+	const [projectSaveDialogOpen, setProjectSaveDialogOpen] = useState(false);
+	const [projectSaveDialogDraft, setProjectSaveDialogDraft] = useState("");
+	const [isSavingProjectDialog, setIsSavingProjectDialog] = useState(false);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [isPlaying, setIsPlaying] = useState(false);
@@ -648,6 +655,7 @@ export default function VideoEditor() {
 	const projectBrowserTriggerRef = useRef<HTMLButtonElement | null>(null);
 	const projectBrowserFallbackTriggerRef = useRef<HTMLButtonElement | null>(null);
 	const projectNameInputRef = useRef<HTMLInputElement | null>(null);
+	const projectSaveDialogInputRef = useRef<HTMLInputElement | null>(null);
 	const nextZoomIdRef = useRef(1);
 	const nextClipIdRef = useRef(1);
 	const nextAudioIdRef = useRef(1);
@@ -668,6 +676,7 @@ export default function VideoEditor() {
 	const mp4SupportRequestRef = useRef(0);
 	const smokeExportStartedRef = useRef(false);
 	const projectAutosaveTimeoutRef = useRef<number | null>(null);
+	const pendingProjectSaveDialogRef = useRef<PendingProjectSaveDialog | null>(null);
 	const projectSaveQueueRef = useRef<Promise<unknown>>(Promise.resolve());
 	const smokeExportReadyStateRef = useRef<Record<string, unknown>>({});
 	const [historyVersion, setHistoryVersion] = useState(0);
@@ -1734,6 +1743,21 @@ export default function VideoEditor() {
 		};
 	}, [isEditingProjectName]);
 
+	useEffect(() => {
+		if (!projectSaveDialogOpen) {
+			return;
+		}
+
+		const frameId = window.requestAnimationFrame(() => {
+			projectSaveDialogInputRef.current?.focus();
+			projectSaveDialogInputRef.current?.select();
+		});
+
+		return () => {
+			window.cancelAnimationFrame(frameId);
+		};
+	}, [projectSaveDialogOpen]);
+
 	const currentPersistedEditorState = useMemo(
 		() =>
 			buildPersistedEditorState({
@@ -2126,6 +2150,25 @@ export default function VideoEditor() {
 			lastSavedSnapshot?.projectId ?? null,
 		);
 	}, [currentPersistedEditorState, currentSourcePath, lastSavedSnapshot?.projectId]);
+
+	const resolveProjectSaveDialog = useCallback((saved: boolean) => {
+		const pendingDialog = pendingProjectSaveDialogRef.current;
+		pendingProjectSaveDialogRef.current = null;
+		setProjectSaveDialogOpen(false);
+		setIsSavingProjectDialog(false);
+		pendingDialog?.resolve(saved);
+	}, []);
+
+	const openProjectSaveDialog = useCallback((initialName: string) => {
+		pendingProjectSaveDialogRef.current?.resolve(false);
+		setProjectSaveDialogDraft(initialName);
+		setProjectSaveDialogOpen(true);
+		setIsSavingProjectDialog(false);
+
+		return new Promise<boolean>((resolve) => {
+			pendingProjectSaveDialogRef.current = { resolve };
+		});
+	}, []);
 
 	const syncRecordingSessionWebcam = useCallback(
 		async (webcamPath: string | null, timeOffsetMs?: number) => {
@@ -2831,6 +2874,14 @@ export default function VideoEditor() {
 						}
 					}
 
+					if (forceSaveAs || !targetProjectPath) {
+						if (options?.silent) {
+							return false;
+						}
+
+						return openProjectSaveDialog(projectDisplayName || fileNameBase);
+					}
+
 					const thumbnailDataUrl = shouldCaptureThumbnail
 						? await captureProjectThumbnail()
 						: undefined;
@@ -2891,6 +2942,8 @@ export default function VideoEditor() {
 			currentProjectSnapshot,
 			currentPersistedEditorState,
 			lastSavedSnapshot?.projectId,
+			openProjectSaveDialog,
+			projectDisplayName,
 			queueProjectSave,
 			refreshProjectLibrary,
 			remountPreview,
@@ -3013,6 +3066,38 @@ export default function VideoEditor() {
 		],
 	);
 
+	const handleProjectSaveDialogSubmit = useCallback(
+		async (event?: React.FormEvent<HTMLFormElement>) => {
+			event?.preventDefault();
+			const trimmedProjectName = projectSaveDialogDraft.trim();
+
+			if (!trimmedProjectName) {
+				toast.error("Project name is required");
+				projectSaveDialogInputRef.current?.focus();
+				return;
+			}
+
+			setIsSavingProjectDialog(true);
+			let saved = false;
+			try {
+				saved = await saveProjectWithName(trimmedProjectName);
+			} catch (error) {
+				toast.error(getErrorMessage(error));
+			} finally {
+				setIsSavingProjectDialog(false);
+			}
+
+			if (saved) {
+				resolveProjectSaveDialog(true);
+				return;
+			}
+
+			projectSaveDialogInputRef.current?.focus();
+			projectSaveDialogInputRef.current?.select();
+		},
+		[projectSaveDialogDraft, resolveProjectSaveDialog, saveProjectWithName],
+	);
+
 	/**
 	 * Resets the inline project-name editor back to the current saved display name.
 	 */
@@ -3079,6 +3164,74 @@ export default function VideoEditor() {
 		},
 		[applyLoadedProject, refreshProjectLibrary],
 	);
+
+	const handleImportMediaOrProject = useCallback(async () => {
+		const result = await window.electronAPI.openVideoFilePicker({ includeProjects: true });
+
+		if (result.canceled) {
+			return;
+		}
+
+		if (!result.success) {
+			toast.error(result.message || "Failed to import file");
+			return;
+		}
+
+		if (result.kind === "project" || result.project) {
+			const restored = await applyLoadedProject(result.project, result.path ?? null);
+			if (!restored) {
+				toast.error("Invalid project file format");
+				return;
+			}
+
+			setProjectBrowserOpen(false);
+			await refreshProjectLibrary();
+			toast.success(result.path ? `Project loaded from ${result.path}` : "Project loaded");
+			return;
+		}
+
+		if (!result.path) {
+			toast.error("No media file selected");
+			return;
+		}
+
+		const sourcePath = fromFileUrl(result.path);
+		const sourceVideoUrl = await resolveVideoUrl(sourcePath);
+		try {
+			videoPlaybackRef.current?.pause();
+		} catch {
+			// no-op
+		}
+
+		setIsPlaying(false);
+		setCurrentTime(0);
+		setDuration(0);
+		setVideoSourcePath(sourcePath);
+		setVideoPath(sourceVideoUrl);
+		setCurrentProjectPath(null);
+		setLastSavedSnapshot(null);
+		resetSourceScopedEditorState();
+		pendingFreshRecordingAutoZoomPathRef.current = autoApplyFreshRecordingAutoZooms
+			? sourceVideoUrl
+			: null;
+		setWebcam((prev) => ({
+			...prev,
+			enabled: false,
+			sourcePath: null,
+			timeOffsetMs: DEFAULT_WEBCAM_TIME_OFFSET_MS,
+		}));
+		applySessionPresentation(null);
+		await window.electronAPI.setCurrentVideoPath(sourcePath, { preserveProjectPath: false });
+		setProjectBrowserOpen(false);
+		await refreshProjectLibrary();
+		toast.success("Media imported");
+	}, [
+		applyLoadedProject,
+		applySessionPresentation,
+		autoApplyFreshRecordingAutoZooms,
+		refreshProjectLibrary,
+		resetSourceScopedEditorState,
+	]);
 
 	const handleOpenProjectBrowser = useCallback(async () => {
 		if (projectBrowserOpen) {
@@ -3398,7 +3551,9 @@ export default function VideoEditor() {
 	const handlePreviewSkipBack = useCallback(() => {
 		const currentMs = timelinePlayheadTime * 1000;
 		const keyframes = timelineRef.current?.keyframes ?? [];
-		const previous = [...keyframes].reverse().find((keyframe) => keyframe.time < currentMs - 50);
+		const previous = [...keyframes]
+			.reverse()
+			.find((keyframe) => keyframe.time < currentMs - 50);
 		handleSeek(previous ? previous.time / 1000 : Math.max(0, timelinePlayheadTime - 5));
 	}, [handleSeek, timelinePlayheadTime]);
 
@@ -3406,9 +3561,7 @@ export default function VideoEditor() {
 		const currentMs = timelinePlayheadTime * 1000;
 		const keyframes = timelineRef.current?.keyframes ?? [];
 		const next = keyframes.find((keyframe) => keyframe.time > currentMs + 50);
-		handleSeek(
-			next ? next.time / 1000 : Math.min(timelineDuration, timelinePlayheadTime + 5),
-		);
+		handleSeek(next ? next.time / 1000 : Math.min(timelineDuration, timelinePlayheadTime + 5));
 	}, [handleSeek, timelineDuration, timelinePlayheadTime]);
 
 	const handleSelectZoom = useCallback((id: string | null) => {
@@ -5215,13 +5368,73 @@ export default function VideoEditor() {
 			volume={
 				audio.shouldMutePreviewVideo || audio.isCurrentClipMuted
 					? 0
-					: Math.max(
-							0,
-							Math.min(1, previewVolume * audio.embeddedSourcePreviewGain),
-						)
+					: Math.max(0, Math.min(1, previewVolume * audio.embeddedSourcePreviewGain))
 			}
 			suspendRendering={suspendRendering}
 		/>
+	);
+
+	const projectSaveDialog = (
+		<Dialog
+			open={projectSaveDialogOpen}
+			onOpenChange={(open) => {
+				if (open) {
+					setProjectSaveDialogOpen(true);
+					return;
+				}
+
+				if (!isSavingProjectDialog) {
+					resolveProjectSaveDialog(false);
+				}
+			}}
+		>
+			<DialogContent className="max-w-sm border-foreground/10 bg-editor-dialog text-foreground">
+				<form onSubmit={(event) => void handleProjectSaveDialogSubmit(event)}>
+					<DialogHeader>
+						<DialogTitle>{t("editor.project.saveTitle", "Save Project")}</DialogTitle>
+						<DialogDescription className="text-muted-foreground">
+							{t(
+								"editor.project.saveDescription",
+								"Name this project. It will be saved in your Recordly Projects folder.",
+							)}
+						</DialogDescription>
+					</DialogHeader>
+					<div className="py-4">
+						<label className="mb-2 block text-xs font-medium text-muted-foreground">
+							{t("editor.project.saveNameLabel", "Project name")}
+						</label>
+						<div className="flex items-center overflow-hidden rounded-md border border-foreground/10 bg-editor-panel">
+							<Input
+								ref={projectSaveDialogInputRef}
+								value={projectSaveDialogDraft}
+								onChange={(event) => setProjectSaveDialogDraft(event.target.value)}
+								disabled={isSavingProjectDialog}
+								className="h-10 flex-1 border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0"
+								aria-label={t("editor.project.saveNameLabel", "Project name")}
+							/>
+							<span className="shrink-0 px-3 text-xs font-medium text-muted-foreground/70">
+								.recordly
+							</span>
+						</div>
+					</div>
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="ghost"
+							onClick={() => resolveProjectSaveDialog(false)}
+							disabled={isSavingProjectDialog}
+						>
+							{t("common.actions.cancel", "Cancel")}
+						</Button>
+						<Button type="submit" disabled={isSavingProjectDialog}>
+							{isSavingProjectDialog
+								? t("editor.project.saving", "Saving...")
+								: t("common.actions.save", "Save")}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
 	);
 
 	const projectBrowser = (
@@ -5230,6 +5443,9 @@ export default function VideoEditor() {
 			onOpenChange={setProjectBrowserOpen}
 			entries={projectLibraryEntries}
 			anchorRef={error ? projectBrowserFallbackTriggerRef : projectBrowserTriggerRef}
+			onImportFile={() => {
+				void handleImportMediaOrProject();
+			}}
 			onOpenProject={(projectPath) => {
 				void handleOpenProjectFromLibrary(projectPath);
 			}}
@@ -5269,6 +5485,7 @@ export default function VideoEditor() {
 			<div className="flex h-screen items-center justify-center bg-background">
 				<div className="text-foreground">Loading video...</div>
 				{projectBrowser}
+				{projectSaveDialog}
 				{nativeCaptureUnavailableDialog}
 				<Toaster className="pointer-events-auto" />
 			</div>
@@ -5289,6 +5506,7 @@ export default function VideoEditor() {
 					</button>
 				</div>
 				{projectBrowser}
+				{projectSaveDialog}
 				{nativeCaptureUnavailableDialog}
 				<Toaster className="pointer-events-auto" />
 			</div>
@@ -5736,7 +5954,9 @@ export default function VideoEditor() {
 									onGifLoopChange={setGifLoop}
 									gifSizePreset={gifSizePreset}
 									onGifSizePresetChange={setGifSizePreset}
-									showCaptionSidecarOption={hasCaptionsForSidecar && exportFormat === "mp4"}
+									showCaptionSidecarOption={
+										hasCaptionsForSidecar && exportFormat === "mp4"
+									}
 									includeCaptionSidecar={includeCaptionSidecar}
 									onIncludeCaptionSidecarChange={setIncludeCaptionSidecar}
 									mp4OutputDimensions={mp4OutputDimensions}
@@ -6415,6 +6635,7 @@ export default function VideoEditor() {
 			) : null}
 
 			{projectBrowser}
+			{projectSaveDialog}
 			{nativeCaptureUnavailableDialog}
 
 			<Toaster className="pointer-events-auto" />

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -537,7 +537,7 @@ export default function VideoEditor() {
 	const [autoCaptionSettings, setAutoCaptionSettings] = useState<AutoCaptionSettings>(
 		DEFAULT_AUTO_CAPTION_SETTINGS,
 	);
-	const [includeCaptionSidecar, setIncludeCaptionSidecar] = useState(true);
+	const [includeCaptionSidecar, setIncludeCaptionSidecar] = useState(false);
 	const [whisperExecutablePath, setWhisperExecutablePath] = useState<string | null>(
 		initialEditorPreferences.whisperExecutablePath,
 	);

--- a/src/components/video-editor/VideoEditor.tsx
+++ b/src/components/video-editor/VideoEditor.tsx
@@ -119,6 +119,7 @@ import { extensionHost } from "@/lib/extensions";
 import { useVideoEditorAudio } from "./audio/useVideoEditorAudio";
 import { resolveAutoCaptionSourcePath } from "./autoCaptionSource";
 import { CropControl } from "./CropControl";
+import { type CaptionEditTarget, updateCaptionCuesForEditedTarget } from "./captionEditing";
 import { ExportSettingsMenu } from "./ExportSettingsMenu";
 import ExtensionManager from "./ExtensionManager";
 import {
@@ -2831,6 +2832,14 @@ export default function VideoEditor() {
 		setAutoCaptionSettings((prev) => ({ ...prev, enabled: false }));
 	}, []);
 
+	const handleSaveAutoCaptionEdit = useCallback(
+		(target: CaptionEditTarget, text: string) => {
+			setAutoCaptions((captions) => updateCaptionCuesForEditedTarget(captions, target, text));
+			toast.success(t("settings.captions.editSaved", "Caption updated"));
+		},
+		[t],
+	);
+
 	const saveProject = useCallback(
 		async (forceSaveAs: boolean, options?: SaveProjectOptions) => {
 			clearPendingProjectAutosave();
@@ -5337,6 +5346,7 @@ export default function VideoEditor() {
 			annotationRegions={annotationRegions}
 			autoCaptions={autoCaptions}
 			autoCaptionSettings={autoCaptionSettings}
+			onEditAutoCaption={handleSaveAutoCaptionEdit}
 			selectedAnnotationId={selectedAnnotationId}
 			onSelectAnnotation={handleSelectAnnotation}
 			onAnnotationPositionChange={handleAnnotationPositionChange}

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -206,6 +206,13 @@ type SceneTransformState = {
 	y: number;
 };
 
+type AnnotationRecordingRect = {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+
 function createPlaybackAnimationState(): PlaybackAnimationState {
 	return {
 		scale: 1,
@@ -512,6 +519,13 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				scale: 1,
 				x: 0,
 				y: 0,
+			});
+		const [annotationRecordingRect, setAnnotationRecordingRect] =
+			useState<AnnotationRecordingRect>({
+				x: 0,
+				y: 0,
+				width: 0,
+				height: 0,
 			});
 
 		useEffect(() => {
@@ -1140,6 +1154,23 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 					renderWidth: result.maskRect.width * renderResolution,
 					renderHeight: result.maskRect.height * renderResolution,
 				};
+				setAnnotationRecordingRect((current) => {
+					if (
+						Math.abs(current.x - result.maskRect.x) < 0.1 &&
+						Math.abs(current.y - result.maskRect.y) < 0.1 &&
+						Math.abs(current.width - result.maskRect.width) < 0.1 &&
+						Math.abs(current.height - result.maskRect.height) < 0.1
+					) {
+						return current;
+					}
+
+					return {
+						x: result.maskRect.x,
+						y: result.maskRect.y,
+						width: result.maskRect.width,
+						height: result.maskRect.height,
+					};
+				});
 				cropBoundsRef.current = result.cropBounds;
 
 				// Sync extension cursor effects canvas resolution with renderer
@@ -3331,14 +3362,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 								</div>
 							</div>
 						) : null}
-						<div
-							className="absolute inset-0"
-							style={{
-								pointerEvents: "none",
-								transform: `translate(${annotationSceneTransform.x}px, ${annotationSceneTransform.y}px) scale(${annotationSceneTransform.scale})`,
-								transformOrigin: "top left",
-							}}
-						>
+						<div className="absolute inset-0" style={{ pointerEvents: "none" }}>
 							{(() => {
 								const filtered = (annotationRegions || []).filter((annotation) => {
 									if (
@@ -3383,6 +3407,8 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 										isSelected={annotation.id === selectedAnnotationId}
 										containerWidth={overlayRef.current?.clientWidth || 800}
 										containerHeight={overlayRef.current?.clientHeight || 600}
+												recordingRect={annotationRecordingRect}
+												sceneTransform={annotationSceneTransform}
 										onPositionChange={(id, position) =>
 											onAnnotationPositionChange?.(id, position)
 										}
@@ -3392,7 +3418,6 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 										onClick={handleAnnotationClick}
 										zIndex={annotation.zIndex}
 										isSelectedBoost={annotation.id === selectedAnnotationId}
-										scale={annotationSceneTransform.scale}
 									/>
 								));
 							})()}

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -3363,27 +3363,27 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 							</div>
 						) : null}
 						<div
-							className="absolute"
+							className="absolute inset-0"
 							style={{
 								pointerEvents: "none",
-								left: 0,
-								top: 0,
-								width:
-									annotationRecordingRect.width ||
-									(overlayRef.current?.clientWidth || 800),
-								height:
-									annotationRecordingRect.height ||
-									(overlayRef.current?.clientHeight || 600),
-								transform: `translate(${
-									(annotationRecordingRect.x || 0) * annotationSceneTransform.scale +
-									annotationSceneTransform.x
-								}px, ${
-									(annotationRecordingRect.y || 0) * annotationSceneTransform.scale +
-									annotationSceneTransform.y
-								}px) scale(${annotationSceneTransform.scale})`,
+								transform: `matrix(${annotationSceneTransform.scale}, 0, 0, ${annotationSceneTransform.scale}, ${annotationSceneTransform.x}, ${annotationSceneTransform.y})`,
 								transformOrigin: "top left",
 							}}
 						>
+							<div
+								className="absolute"
+								style={{
+									pointerEvents: "none",
+									left: annotationRecordingRect.x || 0,
+									top: annotationRecordingRect.y || 0,
+									width:
+										annotationRecordingRect.width ||
+										(overlayRef.current?.clientWidth || 800),
+									height:
+										annotationRecordingRect.height ||
+										(overlayRef.current?.clientHeight || 600),
+								}}
+							>
 							{(() => {
 								const filtered = (annotationRegions || []).filter((annotation) => {
 									if (
@@ -3458,6 +3458,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 									/>
 								));
 							})()}
+							</div>
 						</div>
 					</div>
 				)}

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -3362,7 +3362,28 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 								</div>
 							</div>
 						) : null}
-						<div className="absolute inset-0" style={{ pointerEvents: "none" }}>
+						<div
+							className="absolute"
+							style={{
+								pointerEvents: "none",
+								left: 0,
+								top: 0,
+								width:
+									annotationRecordingRect.width ||
+									(overlayRef.current?.clientWidth || 800),
+								height:
+									annotationRecordingRect.height ||
+									(overlayRef.current?.clientHeight || 600),
+								transform: `translate(${
+									(annotationRecordingRect.x || 0) * annotationSceneTransform.scale +
+									annotationSceneTransform.x
+								}px, ${
+									(annotationRecordingRect.y || 0) * annotationSceneTransform.scale +
+									annotationSceneTransform.y
+								}px) scale(${annotationSceneTransform.scale})`,
+								transformOrigin: "top left",
+							}}
+						>
 							{(() => {
 								const filtered = (annotationRegions || []).filter((annotation) => {
 									if (
@@ -3405,10 +3426,26 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 										key={annotation.id}
 										annotation={annotation}
 										isSelected={annotation.id === selectedAnnotationId}
-										containerWidth={overlayRef.current?.clientWidth || 800}
-										containerHeight={overlayRef.current?.clientHeight || 600}
-												recordingRect={annotationRecordingRect}
-												sceneTransform={annotationSceneTransform}
+												containerWidth={
+													annotationRecordingRect.width ||
+													(overlayRef.current?.clientWidth || 800)
+												}
+												containerHeight={
+													annotationRecordingRect.height ||
+													(overlayRef.current?.clientHeight || 600)
+												}
+												recordingRect={{
+													x: 0,
+													y: 0,
+													width:
+														annotationRecordingRect.width ||
+														(overlayRef.current?.clientWidth || 800),
+													height:
+														annotationRecordingRect.height ||
+														(overlayRef.current?.clientHeight || 600),
+												}}
+												sceneTransform={{ scale: 1, x: 0, y: 0 }}
+												interactionScale={annotationSceneTransform.scale}
 										onPositionChange={(id, position) =>
 											onAnnotationPositionChange?.(id, position)
 										}

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -22,6 +22,7 @@ import {
 	DEFAULT_WALLPAPER_RELATIVE_PATH,
 	isVideoWallpaperSource,
 } from "@/lib/wallpapers";
+import { type CaptionEditTarget, normalizeCaptionEditText } from "./captionEditing";
 import { buildActiveCaptionLayout } from "./captionLayout";
 import {
 	CAPTION_FONT_WEIGHT,
@@ -169,10 +170,7 @@ import { clampFocusToStage as clampFocusToStageUtil } from "./videoPlayback/focu
 import { layoutVideoContent as layoutVideoContentUtil } from "./videoPlayback/layoutUtils";
 import { updateOverlayIndicator } from "./videoPlayback/overlayUtils";
 import { createVideoEventHandlers } from "./videoPlayback/videoEventHandlers";
-import {
-	getWebcamMediaTargetTimeSeconds,
-	shouldSeekWebcamMedia,
-} from "./videoPlayback/webcamSync";
+import { getWebcamMediaTargetTimeSeconds, shouldSeekWebcamMedia } from "./videoPlayback/webcamSync";
 import { findDominantRegion } from "./videoPlayback/zoomRegionUtils";
 import {
 	applyZoomTransform,
@@ -195,6 +193,11 @@ type PlaybackAnimationState = {
 	progress: number;
 	x: number;
 	y: number;
+};
+
+type CaptionEditSession = {
+	target: CaptionEditTarget;
+	draft: string;
 };
 
 function createPlaybackAnimationState(): PlaybackAnimationState {
@@ -361,6 +364,7 @@ interface VideoPlaybackProps {
 	annotationRegions?: AnnotationRegion[];
 	autoCaptions?: CaptionCue[];
 	autoCaptionSettings?: AutoCaptionSettings;
+	onEditAutoCaption?: (target: CaptionEditTarget, text: string) => void;
 	selectedAnnotationId?: string | null;
 	onSelectAnnotation?: (id: string | null) => void;
 	onAnnotationPositionChange?: (id: string, position: { x: number; y: number }) => void;
@@ -444,6 +448,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			annotationRegions = [],
 			autoCaptions = [],
 			autoCaptionSettings,
+			onEditAutoCaption,
 			selectedAnnotationId,
 			onSelectAnnotation,
 			onAnnotationPositionChange,
@@ -525,6 +530,11 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			height: number;
 		} | null>(null);
 		const captionBoxRef = useRef<HTMLDivElement | null>(null);
+		const captionEditInputRef = useRef<HTMLTextAreaElement | null>(null);
+		const captionEditSessionRef = useRef<CaptionEditSession | null>(null);
+		const [captionEditSession, setCaptionEditSession] = useState<CaptionEditSession | null>(
+			null,
+		);
 		const currentTimeRef = useRef(0);
 		const zoomRegionsRef = useRef<ZoomRegion[]>([]);
 		const selectedZoomIdRef = useRef<string | null>(null);
@@ -728,6 +738,127 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				measureText: (text) => measurementContext.measureText(text).width,
 			});
 		}, [autoCaptionSettings, autoCaptions, currentTime]);
+		const isCaptionEditing = captionEditSession !== null;
+		const captionEditDraft = captionEditSession?.draft ?? "";
+		const captionEditTargetId = captionEditSession?.target.id ?? null;
+		const captionEditTextMetrics = useMemo(() => {
+			if (!captionEditSession || !autoCaptionSettings || typeof document === "undefined") {
+				return null;
+			}
+
+			const overlayWidth = overlayRef.current?.clientWidth || 960;
+			const fontSize = getCaptionScaledFontSize(
+				autoCaptionSettings.fontSize,
+				overlayWidth,
+				autoCaptionSettings.maxWidth,
+			);
+			const maxTextWidthPx = getCaptionTextMaxWidth(
+				overlayWidth,
+				autoCaptionSettings.maxWidth,
+				fontSize,
+			);
+			const measurementCanvas = document.createElement("canvas");
+			const measurementContext = measurementCanvas.getContext("2d");
+			if (!measurementContext) {
+				return null;
+			}
+
+			measurementContext.font = `${CAPTION_FONT_WEIGHT} ${fontSize}px ${getDefaultCaptionFontFamily()}`;
+			const measuredWidth = Math.max(
+				...captionEditSession.draft
+					.split(/\r?\n/)
+					.map((line) => measurementContext.measureText(line || " ").width),
+			);
+
+			return {
+				fontSize,
+				maxTextWidthPx,
+				widthPx: Math.ceil(
+					Math.min(maxTextWidthPx, Math.max(fontSize * 2, measuredWidth + 2)),
+				),
+			};
+		}, [autoCaptionSettings, captionEditSession]);
+		const captionEditSizeKey = captionEditSession
+			? `${captionEditTextMetrics?.widthPx ?? 0}:${captionEditDraft}`
+			: "";
+
+		const beginCaptionEdit = useCallback(() => {
+			if (!activeCaptionLayout?.editTarget || !onEditAutoCaption) {
+				return;
+			}
+
+			videoRef.current?.pause();
+			onPlayStateChange(false);
+			const nextSession = {
+				target: activeCaptionLayout.editTarget,
+				draft: activeCaptionLayout.editTarget.text,
+			};
+			captionEditSessionRef.current = nextSession;
+			setCaptionEditSession(nextSession);
+		}, [activeCaptionLayout, onEditAutoCaption, onPlayStateChange]);
+
+		const commitCaptionEdit = useCallback(() => {
+			const session = captionEditSessionRef.current;
+			if (!session || !onEditAutoCaption) {
+				captionEditSessionRef.current = null;
+				setCaptionEditSession(null);
+				return;
+			}
+
+			const normalizedDraft = normalizeCaptionEditText(session.draft);
+			captionEditSessionRef.current = null;
+			if (!normalizedDraft) {
+				setCaptionEditSession(null);
+				return;
+			}
+
+			if (normalizedDraft !== normalizeCaptionEditText(session.target.text)) {
+				onEditAutoCaption(session.target, session.draft);
+			}
+			setCaptionEditSession(null);
+		}, [onEditAutoCaption]);
+
+		const cancelCaptionEdit = useCallback(() => {
+			captionEditSessionRef.current = null;
+			setCaptionEditSession(null);
+		}, []);
+
+		useEffect(() => {
+			if (!captionEditTargetId) {
+				return;
+			}
+
+			const frame = requestAnimationFrame(() => {
+				const input = captionEditInputRef.current;
+				if (!input) {
+					return;
+				}
+
+				input.focus();
+				const cursorPosition = input.value.length;
+				input.setSelectionRange(cursorPosition, cursorPosition);
+			});
+
+			return () => cancelAnimationFrame(frame);
+		}, [captionEditTargetId]);
+
+		useEffect(() => {
+			if (!captionEditSizeKey) {
+				return;
+			}
+
+			const frame = requestAnimationFrame(() => {
+				const input = captionEditInputRef.current;
+				if (!input) {
+					return;
+				}
+
+				input.style.height = "auto";
+				input.style.height = `${input.scrollHeight}px`;
+			});
+
+			return () => cancelAnimationFrame(frame);
+		}, [captionEditSizeKey]);
 
 		useEffect(() => {
 			const captionBox = captionBoxRef.current;
@@ -2951,9 +3082,10 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 						) : null}
 						{activeCaptionLayout && autoCaptionSettings ? (
 							<div
-								className="pointer-events-none absolute inset-x-0 flex justify-center"
+								className="absolute inset-x-0 flex justify-center"
 								style={{
 									bottom: `${autoCaptionSettings.bottomOffset}%`,
+									pointerEvents: onEditAutoCaption ? "auto" : "none",
 								}}
 							>
 								<div
@@ -2967,6 +3099,38 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 								>
 									<div
 										ref={captionBoxRef}
+										role={
+											onEditAutoCaption && !isCaptionEditing
+												? "button"
+												: undefined
+										}
+										tabIndex={
+											onEditAutoCaption && !isCaptionEditing ? 0 : undefined
+										}
+										aria-label={
+											onEditAutoCaption && !isCaptionEditing
+												? "Edit current caption"
+												: undefined
+										}
+										onClick={(event) => {
+											event.stopPropagation();
+											if (!isCaptionEditing) {
+												beginCaptionEdit();
+											}
+										}}
+										onPointerDown={(event) => {
+											event.stopPropagation();
+										}}
+										onKeyDown={(event) => {
+											if (!onEditAutoCaption || isCaptionEditing) {
+												return;
+											}
+
+											if (event.key === "Enter" || event.key === " ") {
+												event.preventDefault();
+												beginCaptionEdit();
+											}
+										}}
 										style={{
 											backgroundColor: `rgba(0, 0, 0, ${autoCaptionSettings.backgroundOpacity})`,
 											fontFamily: getDefaultCaptionFontFamily(),
@@ -3004,42 +3168,138 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 												),
 											)}px`,
 											boxSizing: "border-box",
+											cursor:
+												onEditAutoCaption && !isCaptionEditing
+													? "text"
+													: undefined,
+											pointerEvents: onEditAutoCaption ? "auto" : undefined,
 										}}
 									>
-										{activeCaptionLayout.visibleLines.map((line) => (
-											<div
-												key={`${activeCaptionLayout.blockKey}-${line.startWordIndex}`}
-												style={{
-													display: "flex",
-													justifyContent: "center",
-													flexWrap: "nowrap",
-													whiteSpace: "nowrap",
+										{captionEditSession ? (
+											<textarea
+												ref={captionEditInputRef}
+												value={captionEditSession.draft}
+												onChange={(event) => {
+													const draft = event.target.value;
+													setCaptionEditSession((session) => {
+														const nextSession = session
+															? { ...session, draft }
+															: session;
+														captionEditSessionRef.current = nextSession;
+														return nextSession;
+													});
 												}}
-											>
-												{line.words.map((word) => {
-													const visualState = getCaptionWordVisualState(
-														activeCaptionLayout.hasWordTimings,
-														word.state,
-													);
+												onBlur={commitCaptionEdit}
+												onClick={(event) => event.stopPropagation()}
+												onKeyDown={(event) => {
+													if (event.key === "Escape") {
+														event.preventDefault();
+														cancelCaptionEdit();
+														return;
+													}
 
-													return (
-														<span
-															key={`${activeCaptionLayout.blockKey}-${word.index}`}
-															style={{
-																display: "inline-block",
-																whiteSpace: "pre",
-																color: visualState.isInactive
-																	? autoCaptionSettings.inactiveTextColor
-																	: autoCaptionSettings.textColor,
-																opacity: visualState.opacity,
-															}}
-														>
-															{`${word.leadingSpace ? " " : ""}${word.text}`}
-														</span>
-													);
-												})}
-											</div>
-										))}
+													if (event.key === "Enter" && !event.shiftKey) {
+														event.preventDefault();
+														event.currentTarget.blur();
+													}
+												}}
+												rows={Math.max(
+													1,
+													activeCaptionLayout.visibleLines.length,
+												)}
+												aria-label="Edit current caption"
+												style={{
+													display: "block",
+													width: `${
+														captionEditTextMetrics?.widthPx ??
+														Math.max(
+															48,
+															activeCaptionLayout.visibleLines.reduce(
+																(width, line) =>
+																	Math.max(width, line.width),
+																0,
+															),
+														)
+													}px`,
+													maxWidth: `${
+														captionEditTextMetrics?.maxTextWidthPx ??
+														getCaptionTextMaxWidth(
+															overlayRef.current?.clientWidth || 960,
+															autoCaptionSettings.maxWidth,
+															getCaptionScaledFontSize(
+																autoCaptionSettings.fontSize,
+																overlayRef.current?.clientWidth ||
+																	960,
+																autoCaptionSettings.maxWidth,
+															),
+														)
+													}px`,
+													minHeight: `${
+														Math.max(
+															1,
+															activeCaptionLayout.visibleLines.length,
+														) *
+														(
+															captionEditTextMetrics?.fontSize ??
+																getCaptionScaledFontSize(
+																	autoCaptionSettings.fontSize,
+																	overlayRef.current
+																		?.clientWidth || 960,
+																	autoCaptionSettings.maxWidth,
+																)
+														) *
+														CAPTION_LINE_HEIGHT
+													}px`,
+													resize: "none",
+													border: "0",
+													outline: "0",
+													padding: "0",
+													margin: "0",
+													overflow: "hidden",
+													background: "transparent",
+													color: autoCaptionSettings.textColor,
+													font: "inherit",
+													lineHeight: "inherit",
+													textAlign: "center",
+												}}
+											/>
+										) : (
+											activeCaptionLayout.visibleLines.map((line) => (
+												<div
+													key={`${activeCaptionLayout.blockKey}-${line.startWordIndex}`}
+													style={{
+														display: "flex",
+														justifyContent: "center",
+														flexWrap: "nowrap",
+														whiteSpace: "nowrap",
+													}}
+												>
+													{line.words.map((word) => {
+														const visualState =
+															getCaptionWordVisualState(
+																activeCaptionLayout.hasWordTimings,
+																word.state,
+															);
+
+														return (
+															<span
+																key={`${activeCaptionLayout.blockKey}-${word.index}`}
+																style={{
+																	display: "inline-block",
+																	whiteSpace: "pre",
+																	color: visualState.isInactive
+																		? autoCaptionSettings.inactiveTextColor
+																		: autoCaptionSettings.textColor,
+																	opacity: visualState.opacity,
+																}}
+															>
+																{`${word.leadingSpace ? " " : ""}${word.text}`}
+															</span>
+														);
+													})}
+												</div>
+											))
+										)}
 									</div>
 								</div>
 							</div>

--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -200,6 +200,12 @@ type CaptionEditSession = {
 	draft: string;
 };
 
+type SceneTransformState = {
+	scale: number;
+	x: number;
+	y: number;
+};
+
 function createPlaybackAnimationState(): PlaybackAnimationState {
 	return {
 		scale: 1,
@@ -501,6 +507,12 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 			null,
 		);
 		const [frameUpdateCounter, setFrameUpdateCounter] = useState(0);
+		const [annotationSceneTransform, setAnnotationSceneTransform] =
+			useState<SceneTransformState>({
+				scale: 1,
+				x: 0,
+				y: 0,
+			});
 
 		useEffect(() => {
 			let framesSignature = getRegisteredFramesSignature();
@@ -2324,6 +2336,21 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				state.x = appliedTransform.x;
 				state.y = appliedTransform.y;
 				state.appliedScale = appliedTransform.scale;
+				setAnnotationSceneTransform((current) => {
+					if (
+						Math.abs(current.scale - appliedTransform.scale) < 0.001 &&
+						Math.abs(current.x - appliedTransform.x) < 0.1 &&
+						Math.abs(current.y - appliedTransform.y) < 0.1
+					) {
+						return current;
+					}
+
+					return {
+						scale: appliedTransform.scale,
+						x: appliedTransform.x,
+						y: appliedTransform.y,
+					};
+				});
 			};
 
 			const ticker = () => {
@@ -3304,58 +3331,72 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 								</div>
 							</div>
 						) : null}
-						{(() => {
-							const filtered = (annotationRegions || []).filter((annotation) => {
-								if (
-									typeof annotation.startMs !== "number" ||
-									typeof annotation.endMs !== "number"
-								)
-									return false;
+						<div
+							className="absolute inset-0"
+							style={{
+								pointerEvents: "none",
+								transform: `translate(${annotationSceneTransform.x}px, ${annotationSceneTransform.y}px) scale(${annotationSceneTransform.scale})`,
+								transformOrigin: "top left",
+							}}
+						>
+							{(() => {
+								const filtered = (annotationRegions || []).filter((annotation) => {
+									if (
+										typeof annotation.startMs !== "number" ||
+										typeof annotation.endMs !== "number"
+									)
+										return false;
 
-								if (annotation.id === selectedAnnotationId) return true;
+									if (annotation.id === selectedAnnotationId) return true;
 
-								const timeMs = Math.round(currentTime * 1000);
-								return timeMs >= annotation.startMs && timeMs <= annotation.endMs;
-							});
-
-							// Sort by z-index (lowest to highest) so higher z-index renders on top
-							const sorted = [...filtered].sort((a, b) => a.zIndex - b.zIndex);
-
-							// Handle click-through cycling: when clicking same annotation, cycle to next
-							const handleAnnotationClick = (clickedId: string) => {
-								if (!onSelectAnnotation) return;
-
-								// If clicking on already selected annotation and there are multiple overlapping
-								if (clickedId === selectedAnnotationId && sorted.length > 1) {
-									// Find current index and cycle to next
-									const currentIndex = sorted.findIndex(
-										(a) => a.id === clickedId,
+									const timeMs = Math.round(currentTime * 1000);
+									return (
+										timeMs >= annotation.startMs && timeMs <= annotation.endMs
 									);
-									const nextIndex = (currentIndex + 1) % sorted.length;
-									onSelectAnnotation(sorted[nextIndex].id);
-								} else {
-									// First click or clicking different annotation
-									onSelectAnnotation(clickedId);
-								}
-							};
+								});
 
-							return sorted.map((annotation) => (
-								<AnnotationOverlay
-									key={annotation.id}
-									annotation={annotation}
-									isSelected={annotation.id === selectedAnnotationId}
-									containerWidth={overlayRef.current?.clientWidth || 800}
-									containerHeight={overlayRef.current?.clientHeight || 600}
-									onPositionChange={(id, position) =>
-										onAnnotationPositionChange?.(id, position)
+								// Sort by z-index (lowest to highest) so higher z-index renders on top
+								const sorted = [...filtered].sort((a, b) => a.zIndex - b.zIndex);
+
+								// Handle click-through cycling: when clicking same annotation, cycle to next
+								const handleAnnotationClick = (clickedId: string) => {
+									if (!onSelectAnnotation) return;
+
+									// If clicking on already selected annotation and there are multiple overlapping
+									if (clickedId === selectedAnnotationId && sorted.length > 1) {
+										// Find current index and cycle to next
+										const currentIndex = sorted.findIndex(
+											(a) => a.id === clickedId,
+										);
+										const nextIndex = (currentIndex + 1) % sorted.length;
+										onSelectAnnotation(sorted[nextIndex].id);
+									} else {
+										// First click or clicking different annotation
+										onSelectAnnotation(clickedId);
 									}
-									onSizeChange={(id, size) => onAnnotationSizeChange?.(id, size)}
-									onClick={handleAnnotationClick}
-									zIndex={annotation.zIndex}
-									isSelectedBoost={annotation.id === selectedAnnotationId}
-								/>
-							));
-						})()}
+								};
+
+								return sorted.map((annotation) => (
+									<AnnotationOverlay
+										key={annotation.id}
+										annotation={annotation}
+										isSelected={annotation.id === selectedAnnotationId}
+										containerWidth={overlayRef.current?.clientWidth || 800}
+										containerHeight={overlayRef.current?.clientHeight || 600}
+										onPositionChange={(id, position) =>
+											onAnnotationPositionChange?.(id, position)
+										}
+										onSizeChange={(id, size) =>
+											onAnnotationSizeChange?.(id, size)
+										}
+										onClick={handleAnnotationClick}
+										zIndex={annotation.zIndex}
+										isSelectedBoost={annotation.id === selectedAnnotationId}
+										scale={annotationSceneTransform.scale}
+									/>
+								));
+							})()}
+						</div>
 					</div>
 				)}
 				{/* Keep the source video off-screen instead of display:none so the

--- a/src/components/video-editor/captionEditing.test.ts
+++ b/src/components/video-editor/captionEditing.test.ts
@@ -114,4 +114,31 @@ describe("captionEditing", () => {
 
 		expect(updateCaptionCuesForEditedTarget(cues, visibleTarget, " \n\t ")).toBe(cues);
 	});
+
+	it("keeps sound-effect style captions editable when word entries are blank", () => {
+		const cues: CaptionCue[] = [
+			{
+				id: "sound-effect",
+				startMs: 1_000,
+				endMs: 2_000,
+				text: "clears throat",
+				words: [{ text: "", startMs: 1_000, endMs: 2_000 }],
+			},
+		];
+
+		const layout = buildActiveCaptionLayout({
+			cues,
+			timeMs: 1_500,
+			settings: DEFAULT_AUTO_CAPTION_SETTINGS,
+			maxWidthPx: 500,
+			measureText: (text) => text.length * 10,
+		});
+
+		expect(layout?.editTarget.text).toBe("clears throat");
+
+		const updated = updateCaptionCuesForEditedTarget(cues, layout!.editTarget, "coughs");
+
+		expect(updated[0].text).toBe("coughs");
+		expect(updated[0].words).toEqual([{ text: "coughs", startMs: 1_000, endMs: 2_000 }]);
+	});
 });

--- a/src/components/video-editor/captionEditing.ts
+++ b/src/components/video-editor/captionEditing.ts
@@ -56,13 +56,19 @@ function buildCaptionWordsForEditedText(
 }
 
 function normalizeCaptionWords(cue: CaptionCue): CaptionCueWord[] {
+	const validSourceWords = Array.isArray(cue.words)
+		? cue.words.filter((word): word is CaptionCueWord =>
+				Boolean(
+					word && typeof word.text === "string" && normalizeCaptionEditText(word.text),
+				),
+			)
+		: [];
 	const sourceWords =
-		Array.isArray(cue.words) && cue.words.length > 0
-			? cue.words
+		validSourceWords.length > 0
+			? validSourceWords
 			: buildCaptionWordsForEditedText(cue.text, cue.startMs, cue.endMs);
 
 	return sourceWords
-		.filter((word): word is CaptionCueWord => Boolean(word && typeof word.text === "string"))
 		.map((word) => {
 			const startMs = Math.max(
 				cue.startMs,

--- a/src/components/video-editor/captionLayout.ts
+++ b/src/components/video-editor/captionLayout.ts
@@ -95,7 +95,7 @@ function splitCaptionWordsFromText(text: string) {
 
 function splitCaptionWords(cue: CaptionCue) {
 	if (Array.isArray(cue.words) && cue.words.length > 0) {
-		return cue.words
+		const words = cue.words
 			.filter((word): word is CaptionCueWord =>
 				Boolean(word && typeof word.text === "string"),
 			)
@@ -109,6 +109,10 @@ function splitCaptionWords(cue: CaptionCue) {
 				endMs: word.endMs,
 			}))
 			.filter((word) => word.text.length > 0);
+
+		if (words.length > 0) {
+			return words;
+		}
 	}
 
 	return splitCaptionWordsFromText(cue.text).map((word) => ({

--- a/src/components/video-editor/projectDirtyState.test.ts
+++ b/src/components/video-editor/projectDirtyState.test.ts
@@ -64,4 +64,58 @@ describe("hasUnsavedProjectChanges", () => {
 
 		expect(hasUnsavedProjectChanges(current, createProjectData())).toBe(true);
 	});
+
+	it("ignores transient webcam media attachment changes", () => {
+		const saved = createProjectData({
+			editor: {
+				...createProjectData().editor,
+				webcam: {
+					enabled: false,
+					sourcePath: null,
+					timeOffsetMs: 0,
+					size: 28,
+				},
+			},
+		});
+		const current = createProjectData({
+			editor: {
+				...createProjectData().editor,
+				webcam: {
+					enabled: true,
+					sourcePath: "/Users/test/webcam.mp4",
+					timeOffsetMs: 125,
+					size: 28,
+				},
+			},
+		});
+
+		expect(hasUnsavedProjectChanges(current, saved)).toBe(false);
+	});
+
+	it("detects persistent webcam presentation changes", () => {
+		const saved = createProjectData({
+			editor: {
+				...createProjectData().editor,
+				webcam: {
+					enabled: true,
+					sourcePath: "/Users/test/webcam.mp4",
+					timeOffsetMs: 0,
+					size: 28,
+				},
+			},
+		});
+		const current = createProjectData({
+			editor: {
+				...createProjectData().editor,
+				webcam: {
+					enabled: true,
+					sourcePath: "/Users/test/webcam.mp4",
+					timeOffsetMs: 0,
+					size: 36,
+				},
+			},
+		});
+
+		expect(hasUnsavedProjectChanges(current, saved)).toBe(true);
+	});
 });

--- a/src/components/video-editor/projectDirtyState.ts
+++ b/src/components/video-editor/projectDirtyState.ts
@@ -42,12 +42,43 @@ function areDeepEqual(left: unknown, right: unknown): boolean {
 	return true;
 }
 
+function omitTransientWebcamMediaFields(project: EditorProjectData | null) {
+	if (!project?.editor || typeof project.editor !== "object") {
+		return project;
+	}
+
+	const editor = project.editor as Record<string, unknown>;
+	const webcam = editor.webcam;
+	if (!isComparableObject(webcam)) {
+		return project;
+	}
+
+	const {
+		enabled: _enabled,
+		sourcePath: _sourcePath,
+		timeOffsetMs: _timeOffsetMs,
+		...persistentWebcamFields
+	} = webcam;
+
+	return {
+		...project,
+		editor: {
+			...editor,
+			webcam: persistentWebcamFields,
+		},
+	};
+}
+
 export function hasUnsavedProjectChanges(
 	currentProjectSnapshot: EditorProjectData | null,
 	lastSavedSnapshot: EditorProjectData | null,
 ): boolean {
+	const comparableCurrentSnapshot = omitTransientWebcamMediaFields(currentProjectSnapshot);
+	const comparableLastSavedSnapshot = omitTransientWebcamMediaFields(lastSavedSnapshot);
+
 	return Boolean(
-		currentProjectSnapshot &&
-			(!lastSavedSnapshot || !areDeepEqual(currentProjectSnapshot, lastSavedSnapshot)),
+		comparableCurrentSnapshot &&
+			(!comparableLastSavedSnapshot ||
+				!areDeepEqual(comparableCurrentSnapshot, comparableLastSavedSnapshot)),
 	);
 }

--- a/src/components/video-editor/videoPlayback/cursorRenderer.ts
+++ b/src/components/video-editor/videoPlayback/cursorRenderer.ts
@@ -342,7 +342,7 @@ function clamp(value: number, min: number, max: number) {
 
 function configureCursorTexture(texture: Texture) {
 	texture.source.scaleMode = "linear";
-	texture.source.autoGenerateMipmaps = false;
+	texture.source.autoGenerateMipmaps = true;
 	return texture;
 }
 

--- a/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
+++ b/src/components/video-editor/videoPlayback/zoomRegionUtils.ts
@@ -6,7 +6,7 @@ import {
 	ZOOM_OUT_EARLY_START_MS,
 } from "./constants";
 import { clampFocusToScale } from "./focusUtils";
-import { clamp01, cubicBezier, easeOutZoom } from "./mathUtils";
+import { clamp01, easeOutZoom } from "./mathUtils";
 
 const CHAINED_ZOOM_PAN_GAP_MS = 1350;
 const CONNECTED_ZOOM_PAN_DURATION_MS = 1000;
@@ -33,14 +33,6 @@ type ConnectedPanTransition = {
 	startScale: number;
 	endScale: number;
 };
-
-function lerp(start: number, end: number, amount: number) {
-	return start + (end - start) * amount;
-}
-
-function easeConnectedPan(value: number) {
-	return cubicBezier(0.1, 0.0, 0.2, 1.0, value);
-}
 
 export function computeRegionStrength(
 	region: ZoomRegion,
@@ -77,13 +69,6 @@ export function computeRegionStrength(
 
 	const progress = clamp01((adjustedTimeMs - zoomOutStart) / zoomOutDurationMs);
 	return 1 - easeOutZoom(progress);
-}
-
-function getLinearFocus(start: ZoomFocus, end: ZoomFocus, amount: number): ZoomFocus {
-	return {
-		cx: lerp(start.cx, end.cx, amount),
-		cy: lerp(start.cy, end.cy, amount),
-	};
 }
 
 function getResolvedFocus(region: ZoomRegion, zoomScale: number): ZoomFocus {
@@ -194,44 +179,6 @@ function getConnectedRegionHold(timeMs: number, connectedPairs: ConnectedRegionP
 				blendedScale: null,
 			};
 		}
-	}
-
-	return null;
-}
-
-function getConnectedRegionTransition(connectedPairs: ConnectedRegionPair[], timeMs: number) {
-	for (const pair of connectedPairs) {
-		const { currentRegion, nextRegion, transitionStart, transitionEnd } = pair;
-
-		if (timeMs < transitionStart || timeMs > transitionEnd) {
-			continue;
-		}
-
-		const transitionProgress = easeConnectedPan(
-			clamp01((timeMs - transitionStart) / Math.max(1, transitionEnd - transitionStart)),
-		);
-		const currentScale = ZOOM_DEPTH_SCALES[currentRegion.depth];
-		const nextScale = ZOOM_DEPTH_SCALES[nextRegion.depth];
-		const transitionScale = lerp(currentScale, nextScale, transitionProgress);
-		const currentFocus = getResolvedFocus(currentRegion, currentScale);
-		const nextFocus = getResolvedFocus(nextRegion, nextScale);
-		const transitionFocus = getLinearFocus(currentFocus, nextFocus, transitionProgress);
-
-		return {
-			region: {
-				...nextRegion,
-				focus: transitionFocus,
-			},
-			strength: 1,
-			blendedScale: transitionScale,
-			transition: {
-				progress: transitionProgress,
-				startFocus: currentFocus,
-				endFocus: nextFocus,
-				startScale: currentScale,
-				endScale: nextScale,
-			},
-		};
 	}
 
 	return null;

--- a/src/lib/exporter/annotationRenderer.ts
+++ b/src/lib/exporter/annotationRenderer.ts
@@ -14,6 +14,13 @@ interface AnnotationSceneTransform {
 	y: number;
 }
 
+interface AnnotationCoordinateRect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
 function transformAnnotationRect(
 	rect: { x: number; y: number; width: number; height: number },
 	sceneTransform?: AnnotationSceneTransform,
@@ -357,20 +364,22 @@ export async function renderAnnotations(
 	scaleFactor: number = 1.0,
 	assets?: AnnotationRenderAssets,
 	sceneTransform?: AnnotationSceneTransform,
+	coordinateRect?: AnnotationCoordinateRect,
 ): Promise<void> {
 	const activeAnnotations = annotations.filter(
 		(ann) => currentTimeMs >= ann.startMs && currentTimeMs <= ann.endMs,
 	);
 
 	const sortedAnnotations = [...activeAnnotations].sort((a, b) => a.zIndex - b.zIndex);
+	const annotationRect = coordinateRect ?? { x: 0, y: 0, width: canvasWidth, height: canvasHeight };
 
 	for (const annotation of sortedAnnotations) {
 		const rect = transformAnnotationRect(
 			{
-				x: (annotation.position.x / 100) * canvasWidth,
-				y: (annotation.position.y / 100) * canvasHeight,
-				width: (annotation.size.width / 100) * canvasWidth,
-				height: (annotation.size.height / 100) * canvasHeight,
+				x: annotationRect.x + (annotation.position.x / 100) * annotationRect.width,
+				y: annotationRect.y + (annotation.position.y / 100) * annotationRect.height,
+				width: (annotation.size.width / 100) * annotationRect.width,
+				height: (annotation.size.height / 100) * annotationRect.height,
 			},
 			sceneTransform,
 		);

--- a/src/lib/exporter/annotationRenderer.ts
+++ b/src/lib/exporter/annotationRenderer.ts
@@ -8,6 +8,28 @@ export interface AnnotationRenderAssets {
 	imageCache: Map<string, HTMLImageElement>;
 }
 
+interface AnnotationSceneTransform {
+	scale: number;
+	x: number;
+	y: number;
+}
+
+function transformAnnotationRect(
+	rect: { x: number; y: number; width: number; height: number },
+	sceneTransform?: AnnotationSceneTransform,
+) {
+	if (!sceneTransform) {
+		return rect;
+	}
+
+	return {
+		x: rect.x * sceneTransform.scale + sceneTransform.x,
+		y: rect.y * sceneTransform.scale + sceneTransform.y,
+		width: rect.width * sceneTransform.scale,
+		height: rect.height * sceneTransform.scale,
+	};
+}
+
 const annotationImagePromiseCache = new Map<string, Promise<HTMLImageElement | null>>();
 
 let blurBufferCanvas: HTMLCanvasElement | null = null;
@@ -334,6 +356,7 @@ export async function renderAnnotations(
 	currentTimeMs: number,
 	scaleFactor: number = 1.0,
 	assets?: AnnotationRenderAssets,
+	sceneTransform?: AnnotationSceneTransform,
 ): Promise<void> {
 	const activeAnnotations = annotations.filter(
 		(ann) => currentTimeMs >= ann.startMs && currentTimeMs <= ann.endMs,
@@ -342,14 +365,21 @@ export async function renderAnnotations(
 	const sortedAnnotations = [...activeAnnotations].sort((a, b) => a.zIndex - b.zIndex);
 
 	for (const annotation of sortedAnnotations) {
-		const x = (annotation.position.x / 100) * canvasWidth;
-		const y = (annotation.position.y / 100) * canvasHeight;
-		const width = (annotation.size.width / 100) * canvasWidth;
-		const height = (annotation.size.height / 100) * canvasHeight;
+		const rect = transformAnnotationRect(
+			{
+				x: (annotation.position.x / 100) * canvasWidth,
+				y: (annotation.position.y / 100) * canvasHeight,
+				width: (annotation.size.width / 100) * canvasWidth,
+				height: (annotation.size.height / 100) * canvasHeight,
+			},
+			sceneTransform,
+		);
+		const { x, y, width, height } = rect;
+		const effectiveScaleFactor = scaleFactor * (sceneTransform?.scale ?? 1);
 
 		switch (annotation.type) {
 			case "text":
-				renderText(ctx, annotation, x, y, width, height, scaleFactor);
+				renderText(ctx, annotation, x, y, width, height, effectiveScaleFactor);
 				break;
 
 			case "image":
@@ -367,20 +397,20 @@ export async function renderAnnotations(
 						y,
 						width,
 						height,
-						scaleFactor,
+						effectiveScaleFactor,
 					);
 				}
 				break;
 
 			case "blur": {
 				const blurStrength =
-					(annotation.blurIntensity ?? BLUR_ANNOTATION_STRENGTH) * scaleFactor;
+					(annotation.blurIntensity ?? BLUR_ANNOTATION_STRENGTH) * effectiveScaleFactor;
 				const padding = Math.ceil(blurStrength * 2);
 
 				ctx.save();
 
 				ctx.beginPath();
-				const borderRadius = (annotation.style.borderRadius ?? 0) * scaleFactor;
+				const borderRadius = (annotation.style.borderRadius ?? 0) * effectiveScaleFactor;
 				ctx.roundRect(x, y, width, height, borderRadius);
 				ctx.clip();
 

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -1549,6 +1549,7 @@ export class FrameRenderer {
 					scaleFactor,
 					undefined,
 					temporalSnapshot.sceneTransform,
+					this.layoutCache?.maskRect,
 				);
 			}
 
@@ -1739,6 +1740,7 @@ export class FrameRenderer {
 					x: this.animationState.x,
 					y: this.animationState.y,
 				},
+				this.layoutCache?.maskRect,
 			);
 		}
 

--- a/src/lib/exporter/frameRenderer.ts
+++ b/src/lib/exporter/frameRenderer.ts
@@ -5,8 +5,8 @@ import type {
 	AnnotationRegion,
 	AutoCaptionSettings,
 	CaptionCue,
-	CursorClickEffectStyle,
 	CropRegion,
+	CursorClickEffectStyle,
 	CursorStyle,
 	CursorTelemetryPoint,
 	Padding,
@@ -448,14 +448,14 @@ export class FrameRenderer {
 					massMultiplier: this.config.cursorSpringMassMultiplier,
 				},
 				motionBlur: this.config.cursorMotionBlur ?? 0,
-				clickEffect:
-					this.config.cursorClickEffect ?? DEFAULT_CURSOR_CONFIG.clickEffect,
+				clickEffect: this.config.cursorClickEffect ?? DEFAULT_CURSOR_CONFIG.clickEffect,
 				clickEffectColor:
 					this.config.cursorClickEffectColor ?? DEFAULT_CURSOR_CONFIG.clickEffectColor,
 				clickEffectScale:
 					this.config.cursorClickEffectScale ?? DEFAULT_CURSOR_CONFIG.clickEffectScale,
 				clickEffectOpacity:
-					this.config.cursorClickEffectOpacity ?? DEFAULT_CURSOR_CONFIG.clickEffectOpacity,
+					this.config.cursorClickEffectOpacity ??
+					DEFAULT_CURSOR_CONFIG.clickEffectOpacity,
 				clickEffectDurationMs:
 					this.config.cursorClickEffectDurationMs ??
 					DEFAULT_CURSOR_CONFIG.clickEffectDurationMs,
@@ -1547,6 +1547,8 @@ export class FrameRenderer {
 					this.config.height,
 					temporalSnapshot.timeMs,
 					scaleFactor,
+					undefined,
+					temporalSnapshot.sceneTransform,
 				);
 			}
 
@@ -1731,6 +1733,12 @@ export class FrameRenderer {
 				this.config.height,
 				timeMs,
 				scaleFactor,
+				undefined,
+				{
+					scale: this.animationState.appliedScale,
+					x: this.animationState.x,
+					y: this.animationState.y,
+				},
 			);
 		}
 

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -1591,6 +1591,7 @@ export class FrameRenderer {
 				x: this.animationState.x,
 				y: this.animationState.y,
 			},
+			this.layoutCache?.maskRect,
 		);
 
 		this.drawCaptionOverlay(context);
@@ -1614,10 +1615,16 @@ export class FrameRenderer {
 		);
 
 		for (const annotation of annotations) {
-			const x = (annotation.position.x / 100) * this.config.width;
-			const y = (annotation.position.y / 100) * this.config.height;
-			const width = (annotation.size.width / 100) * this.config.width;
-			const height = (annotation.size.height / 100) * this.config.height;
+			const annotationRect = this.layoutCache?.maskRect ?? {
+				x: 0,
+				y: 0,
+				width: this.config.width,
+				height: this.config.height,
+			};
+			const x = annotationRect.x + (annotation.position.x / 100) * annotationRect.width;
+			const y = annotationRect.y + (annotation.position.y / 100) * annotationRect.height;
+			const width = (annotation.size.width / 100) * annotationRect.width;
+			const height = (annotation.size.height / 100) * annotationRect.height;
 
 			if (width <= 0 || height <= 0) {
 				continue;

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -15,8 +15,8 @@ import type {
 	AnnotationRegion,
 	AutoCaptionSettings,
 	CaptionCue,
-	CursorClickEffectStyle,
 	CropRegion,
+	CursorClickEffectStyle,
 	CursorStyle,
 	CursorTelemetryPoint,
 	Padding,
@@ -598,8 +598,8 @@ export class FrameRenderer {
 		this.webcamRootContainer.addChild(this.webcamContainer);
 		this.webcamRootContainer.visible = false;
 
+		this.cameraContainer.addChild(this.annotationContainer);
 		this.overlayContainer.addChild(this.webcamRootContainer);
-		this.overlayContainer.addChild(this.annotationContainer);
 		this.overlayContainer.addChild(this.captionContainer);
 
 		this.videoMaskGraphics = new Graphics();
@@ -622,14 +622,14 @@ export class FrameRenderer {
 					massMultiplier: this.config.cursorSpringMassMultiplier,
 				},
 				motionBlur: this.config.cursorMotionBlur ?? 0,
-				clickEffect:
-					this.config.cursorClickEffect ?? DEFAULT_CURSOR_CONFIG.clickEffect,
+				clickEffect: this.config.cursorClickEffect ?? DEFAULT_CURSOR_CONFIG.clickEffect,
 				clickEffectColor:
 					this.config.cursorClickEffectColor ?? DEFAULT_CURSOR_CONFIG.clickEffectColor,
 				clickEffectScale:
 					this.config.cursorClickEffectScale ?? DEFAULT_CURSOR_CONFIG.clickEffectScale,
 				clickEffectOpacity:
-					this.config.cursorClickEffectOpacity ?? DEFAULT_CURSOR_CONFIG.clickEffectOpacity,
+					this.config.cursorClickEffectOpacity ??
+					DEFAULT_CURSOR_CONFIG.clickEffectOpacity,
 				clickEffectDurationMs:
 					this.config.cursorClickEffectDurationMs ??
 					DEFAULT_CURSOR_CONFIG.clickEffectDurationMs,
@@ -1586,6 +1586,11 @@ export class FrameRenderer {
 			timeMs,
 			this.annotationScaleFactor,
 			this.annotationAssets ?? undefined,
+			{
+				scale: this.animationState.appliedScale,
+				x: this.animationState.x,
+				y: this.animationState.y,
+			},
 		);
 
 		this.drawCaptionOverlay(context);
@@ -2549,15 +2554,10 @@ export class FrameRenderer {
 			const usesDefaultCropRegion = isWebcamCropRegionDefault(this.config.webcam?.cropRegion);
 			const needsCacheBackedSource =
 				!usesDefaultCropRegion ||
-				(typeof HTMLVideoElement !== "undefined" &&
-					liveSource instanceof HTMLVideoElement);
+				(typeof HTMLVideoElement !== "undefined" && liveSource instanceof HTMLVideoElement);
 
 			if (needsCacheBackedSource) {
-				this.refreshWebcamFrameCache(
-					liveSource,
-					liveSourceWidth,
-					liveSourceHeight,
-				);
+				this.refreshWebcamFrameCache(liveSource, liveSourceWidth, liveSourceHeight);
 				const cachedSource = this.getCachedWebcamRenderSource();
 				if (cachedSource) {
 					this.setWebcamRenderMode("live");


### PR DESCRIPTION
## Summary
- allow importing Recordly project files alongside media files from the launch flow and project browser
- replace first-time project save with an in-app modal; existing project Save As uses the named-project rename/update flow
- stop transient webcam attachment fields from causing unsaved-change prompts while still tracking webcam presentation edits
- validate project file shape before committing imported project state
- register `.recordly` as a macOS document type using the Recordly app icon

## Validation
- npm exec -- vitest run src/components/video-editor/captionEditing.test.ts src/components/video-editor/autoCaptionSource.test.ts src/components/video-editor/projectDirtyState.test.ts electron/ipc/project/manager.test.ts
- npm exec -- biome check electron-builder.json5 electron/ipc/project/manager.ts electron/ipc/project/manager.test.ts src/components/video-editor/projectDirtyState.ts src/components/video-editor/projectDirtyState.test.ts electron/electron-env.d.ts electron/ipc/register/captions.ts electron/preload.ts src/components/launch/hooks/useLaunchWindowActions.ts src/components/video-editor/ProjectBrowserDialog.tsx src/components/video-editor/VideoEditor.tsx src/components/video-editor/videoPlayback/zoomRegionUtils.ts
- npm exec -- tsc --noEmit
- node JSON5 parse check for electron-builder.json5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import Recordly projects (and media) from the media picker and jump straight into editing.
  * Added an **Import** button to the project browser.
  * Added promise-based **Save Project / Save As** flow.
  * Enabled editing active auto-captions from playback UI (including sound-effect cues).
* **Bug Fixes**
  * Unsaved changes detection now ignores transient webcam attachment/media fields.
  * Invalid project files are rejected cleanly before media handling.
  * Caption editing/generation now better handles empty/invalid word entries.
* **Refactor**
  * Improved preview skipping between keyframes; reduced zoom/pan animation transitions.
  * Updated annotation rendering to better track transformed viewports.
* **Packaging**
  * macOS now advertises the Recordly Project file type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->