### PR TITLE
Fix macOS recording duration when final frames stop updating

### DIFF
--- a/electron/native/ScreenCaptureKitRecorder.swift
+++ b/electron/native/ScreenCaptureKitRecorder.swift
@@ -370,16 +370,13 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 		stream = nil
 		isRecording = false
 
-		if let originalBuffer = lastSampleBuffer, let videoInput = videoInput {
-			let additionalTime = lastVideoPresentationTime + frameDuration(for: originalBuffer)
-			let timing = CMSampleTimingInfo(duration: originalBuffer.duration, presentationTimeStamp: additionalTime, decodeTimeStamp: originalBuffer.decodeTimeStamp)
-			if let additionalSampleBuffer = try? CMSampleBuffer(copying: originalBuffer, withNewTiming: [timing]) {
-				videoInput.append(additionalSampleBuffer)
-			}
-		}
-
 		let videoEndTime = lastVideoPresentationTime + (lastSampleBuffer.map { frameDuration(for: $0) } ?? .zero)
-		let endTime = resolvedCaptureEndTime(videoEndTime: videoEndTime)
+		let captureEndTime = currentAdjustedCaptureTime()
+		let paddedVideoEndTime = appendFinalVideoFrameIfNeeded(
+			videoEndTime: videoEndTime,
+			captureEndTime: captureEndTime
+		)
+		let endTime = resolvedCaptureEndTime(videoEndTime: paddedVideoEndTime)
 		assetWriter?.endSession(atSourceTime: endTime)
 		videoInput?.markAsFinished()
 		inlineAudioInput?.markAsFinished()
@@ -467,6 +464,48 @@ final class ScreenCaptureRecorder: NSObject, SCStreamOutput, SCStreamDelegate {
 		}
 
 		return CMTime(value: 1, timescale: CMTimeScale(targetCaptureFPS))
+	}
+
+	private func currentAdjustedCaptureTime() -> CMTime {
+		guard firstSampleTime != .zero else {
+			return .zero
+		}
+
+		let now = CMClockGetTime(CMClockGetHostTimeClock())
+		let pauseDurationInProgress: CMTime
+		if isPaused, let pauseStartedHostTime {
+			pauseDurationInProgress = max(.zero, now - pauseStartedHostTime)
+		} else {
+			pauseDurationInProgress = .zero
+		}
+
+		return max(.zero, now - firstSampleTime - accumulatedPausedDuration - pauseDurationInProgress)
+	}
+
+	private func appendFinalVideoFrameIfNeeded(videoEndTime: CMTime, captureEndTime: CMTime) -> CMTime {
+		guard let originalBuffer = lastSampleBuffer, let videoInput else {
+			return videoEndTime
+		}
+
+		let duration = frameDuration(for: originalBuffer)
+		let minimumAdditionalTime = videoEndTime
+		let targetPresentationTime = max(
+			minimumAdditionalTime,
+			captureEndTime - duration
+		)
+		let timing = CMSampleTimingInfo(
+			duration: duration,
+			presentationTimeStamp: targetPresentationTime,
+			decodeTimeStamp: originalBuffer.decodeTimeStamp
+		)
+		if let finalSampleBuffer = try? CMSampleBuffer(copying: originalBuffer, withNewTiming: [timing]),
+		   videoInput.append(finalSampleBuffer) {
+			lastVideoPresentationTime = targetPresentationTime
+			lastVideoDuration = duration
+			return targetPresentationTime + duration
+		}
+
+		return videoEndTime
 	}
 
 	private func latestInlineAudioEndTime() -> CMTime {
@@ -715,4 +754,3 @@ DispatchQueue.global(qos: .utility).async {
 }
 
 service.waitUntilFinished()
-


### PR DESCRIPTION
## Summary
- Pad the final macOS ScreenCaptureKit video sample to the actual adjusted capture end time before finishing the asset writer.
- Preserve pause accounting when computing the final capture duration.
- Prevent recordings with little or no screen-frame activity near the end from finalizing at the timestamp of the last emitted video frame.

## Background
On macOS, ScreenCaptureKit may stop delivering new screen samples when the captured display/window is visually static. Recordly hides the native cursor and records cursor telemetry separately, so a session can continue collecting cursor data while the video track remains stuck at the last screen sample timestamp. The old finalization path appended only one extra frame, so the resulting MP4 duration could be much shorter than the real recording session.

## Validation
- `npm run build:native-helpers`

No user recording paths, filenames, or private recording content are included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved video capture timing accuracy when pauses occur during recording.
  * Enhanced handling of final video frames to ensure proper padding at the end of captures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->