### PR TITLE
fix: allow clicks to pass through recording control overlay

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -605,7 +605,7 @@ export function reassertHudOverlayMousePassthrough(): void {
 	}
 
 	if (hudOverlayRecordingActive) {
-		hud.setIgnoreMouseEvents(true, { forward: true });
+		setHudOverlayMousePassthrough(hudOverlayIgnoringMouse);
 		return;
 	}
 

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -192,7 +192,7 @@ function getHudOverlayBounds() {
 	const { workArea } = getHudOverlayDisplay();
 	return getHudOverlayWindowBounds(
 		workArea,
-		isHudOverlayMousePassthroughSupported() && !hudOverlayRecordingActive,
+		isHudOverlayMousePassthroughSupported(),
 		hudOverlayFallbackExpanded,
 	);
 }
@@ -278,11 +278,7 @@ function setHudOverlayFallbackExpanded(expanded: boolean) {
 
 function setHudOverlayMousePassthrough(ignore: boolean) {
 	hudOverlayIgnoringMouse =
-		hudOverlaySourceSelectionActive && !hudOverlayRecordingActive
-			? true
-			: hudOverlayRecordingActive
-				? false
-				: ignore;
+		hudOverlaySourceSelectionActive && !hudOverlayRecordingActive ? true : ignore;
 
 	if (hudOverlayMouseReassertTimer) {
 		clearTimeout(hudOverlayMouseReassertTimer);
@@ -293,9 +289,7 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 		return;
 	}
 
-	if (hudOverlayRecordingActive) {
-		hudOverlayFallbackExpanded = false;
-		applyHudOverlayBounds();
+	if (hudOverlayRecordingActive && !isHudOverlayMousePassthroughSupported()) {
 		hudOverlayWindow.setIgnoreMouseEvents(false);
 		return;
 	}
@@ -480,13 +474,8 @@ export function createHudOverlayWindow(): BrowserWindow {
 	}
 
 	if (isHudOverlayMousePassthroughSupported()) {
-		if (hudOverlayRecordingActive) {
-			hudOverlayIgnoringMouse = false;
-			win.setIgnoreMouseEvents(false);
-		} else {
-			hudOverlayIgnoringMouse = true;
-			win.setIgnoreMouseEvents(true, { forward: true });
-		}
+		hudOverlayIgnoringMouse = true;
+		win.setIgnoreMouseEvents(true, { forward: true });
 	}
 
 	// On Windows 11+, focus changes (e.g. showing a native notification) can break
@@ -616,7 +605,7 @@ export function reassertHudOverlayMousePassthrough(): void {
 	}
 
 	if (hudOverlayRecordingActive) {
-		hud.setIgnoreMouseEvents(false);
+		hud.setIgnoreMouseEvents(true, { forward: true });
 		return;
 	}
 
@@ -638,7 +627,7 @@ export function setHudOverlayRecordingActive(recording: boolean): void {
 	hudOverlayRecordingActive = Boolean(recording);
 	hudOverlayFallbackExpanded = false;
 	applyHudOverlayBounds();
-	setHudOverlayMousePassthrough(!hudOverlayRecordingActive);
+	setHudOverlayMousePassthrough(hudOverlayIgnoringMouse);
 }
 
 export function createUpdateToastWindow(): BrowserWindow {

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -442,12 +442,13 @@ function LaunchWindowContent() {
 					className="flex items-center overflow-visible flex-col-reverse pointer-events-none"
 				>
 					<div
-						className="flex flex-col items-center pointer-events-auto p-2"
-						onMouseEnter={handleHudMouseEnter}
-						onMouseLeave={handleHudMouseLeave}
+						className="flex flex-col items-center p-2"
 					>
 						<div
 							ref={hudBarTransformRef}
+							className="pointer-events-auto"
+							onMouseEnter={handleHudMouseEnter}
+							onMouseLeave={handleHudMouseLeave}
 							style={{
 								transform: `translate3d(${recordingHudOffset.x}px, ${recordingHudOffset.y}px, 0)`,
 							}}


### PR DESCRIPTION
## Summary

- Moves `pointer-events-auto` and mouse enter/leave handlers from the static wrapper div onto the `hudBarTransformRef` element that moves with the dragged recording controls, so the interactive hit area follows the bar
- Keeps the HUD overlay window at full work-area bounds during recording on platforms with passthrough support, using Electron's mouse event forwarding to let clicks pass through transparent areas
- On non-passthrough platforms (Win10, Linux), behavior is unchanged — the compact window remains fully interactive

Closes #687

## Test plan

- [ ] Start a full-screen recording on macOS
- [ ] Verify the recording controls are visible and clickable
- [ ] Verify clicking anywhere outside the control bar passes through to other apps
- [ ] Drag the recording controls to a new position — verify clicks still pass through the original position
- [ ] Verify idle (pre-recording) HUD still works correctly with hover detection
- [ ] Test on Windows 10 (non-passthrough fallback) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD overlay mouse passthrough behavior so overlay interactions remain consistent and responsive during recording, including when passthrough support is available.
  * Updated HUD bar pointer-event handling by adjusting where mouse enter/leave behavior is applied, resulting in more reliable control responsiveness within the HUD bar area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->