### PR TITLE
fix(recording): avoid doubled mic audio (echo) on macOS system+mic captures

### DIFF
--- a/electron/ipc/recording/diagnostics.ts
+++ b/electron/ipc/recording/diagnostics.ts
@@ -527,6 +527,8 @@ export async function getCompanionAudioFallbackInfo(videoPath: string) {
 
 		if (!hasUsableMacSystemCompanion && usableMacMicOnlyCompanions.length > 0) {
 			paths = usableMacMicOnlyCompanions;
+		} else if (hasUsableMacSystemCompanion) {
+			paths = [videoPath];
 		} else {
 			const companionPaths = Array.from(
 				new Set(


### PR DESCRIPTION
## Description
Recording on macOS with both system audio and the microphone enabled played the mic twice, producing an echo that drifted out of sync over the take. This is a two-line fix.

## Motivation
On macOS the system-audio capture already includes the microphone, so the recording on disk is already a complete system + mic mix. The companion-audio fallback still added the separate mic sidecar on top, so every system+mic recording played the microphone twice. The two copies come from independently clocked capture paths, so they drift apart as the recording continues — that growing drift is the echo users hear. Disabling system audio "fixed" it only by removing the duplicate source. Reported in #628.

## The fix
When a usable macOS system-audio companion exists, use the embedded recording alone instead of also layering the mic sidecar. The embedded mix already contains both system audio and the mic, so the duplicate and its drift are gone. The branch is macOS-scoped, so Windows and mic-only recordings are unchanged. Net change: two lines, one file.

## Type of Change
- [x] Bug Fix

## Related Issue(s)
Fixes #628

## Screenshots / Video
No UI change — this is an audio-routing fix. Happy to add a short before/after clip if useful.

## Testing Guide
On macOS, record with system audio and the built-in mic both on, talking while some system audio plays. Before: the mic is doubled and drifts further out of sync the longer you record. After: a single clean mic, in sync for the whole take.

Tested this end to end on an M4 Mac, built the DMG from this branch, installed it, and recorded on a machine that was reproducing the bug. The echo was present before the change and gone immediately after. Existing companion-audio tests pass.

## Checklist
- [x] Self-review performed.
- [x] Related issue linked.
- [ ] Screenshots/video — not applicable (audio-only fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS recording audio fallback logic to correctly select companion audio paths when system audio is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->