### PR TITLE
fix(linux): make the recording HUD usable on Wayland/Hyprland

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -670,7 +670,15 @@ export function setHudOverlayRecordingActive(recording: boolean): void {
 	hudOverlayRecordingActive = Boolean(recording);
 	hudOverlayFallbackExpanded = false;
 	applyHudOverlayBounds();
-	setHudOverlayMousePassthrough(!hudOverlayRecordingActive);
+	// On Linux the recording HUD keeps the full work area and stays click-through, so it
+	// must start in pass-through (otherwise the full-screen window would capture every
+	// click and block the content being recorded). The renderer's hover logic re-asserts
+	// capture over the controls. Other platforms shrink to a compact, always-capturing bar.
+	const startIgnoringMouse =
+		process.platform === "linux" && isHudOverlayMousePassthroughSupported()
+			? true
+			: !hudOverlayRecordingActive;
+	setHudOverlayMousePassthrough(startIgnoringMouse);
 }
 
 export function createUpdateToastWindow(): BrowserWindow {
@@ -899,6 +907,12 @@ export function createEditorWindow(): BrowserWindow {
 	win.once("ready-to-show", () => {
 		console.log(`[PERF:MAIN] Editor Window: ready-to-show in ${Date.now() - perfStart}ms`);
 		win.show();
+		// On Linux/Wayland the compositor ignores the requested x/y, so the editor can
+		// land partly under reserved areas (panels/bars). Maximizing lets the compositor
+		// fit it to the available work area instead.
+		if (process.platform === "linux") {
+			win.maximize();
+		}
 	});
 
 	win.webContents.on("did-finish-load", () => {
@@ -908,6 +922,9 @@ export function createEditorWindow(): BrowserWindow {
 		if (!win.isDestroyed() && !win.isVisible()) {
 			console.log("[editor-window] forcing show after did-finish-load");
 			win.show();
+			if (process.platform === "linux") {
+				win.maximize();
+			}
 		}
 	});
 

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -123,8 +123,14 @@ function getWindowsBuildNumber(): number | null {
 }
 
 export function isHudOverlayMousePassthroughSupported(): boolean {
+	// On Linux (X11 and Wayland), Electron's setIgnoreMouseEvents(true, { forward: true })
+	// is supported and is required for the HUD to behave correctly. The HUD is a
+	// transparent, always-on-top overlay; without mouse pass-through every transparent
+	// pixel captures the cursor, which on Wayland compositors with focus-follows-mouse
+	// (e.g. Hyprland) makes the control bar flicker/disappear on hover and blocks clicks
+	// on the windows underneath it. See #638, #657, #687.
 	if (process.platform === "linux") {
-		return false;
+		return true;
 	}
 
 	const build = getWindowsBuildNumber();
@@ -190,9 +196,18 @@ function getHudOverlayDisplay() {
 
 function getHudOverlayBounds() {
 	const { workArea } = getHudOverlayDisplay();
+	// On platforms with mouse pass-through the HUD spans the whole work area and stays
+	// click-through except over the interactive controls. On Linux/Wayland the compositor
+	// ignores programmatic window placement (BrowserWindow.setBounds x/y is silently
+	// dropped), so a window that shrinks to a compact bar while recording cannot move
+	// itself back to the bottom-centre and ends up stranded (e.g. top-left on Hyprland).
+	// Keep the full-work-area, click-through window while recording on Linux so the bar
+	// stays put; other platforms keep the compact recording bar they can reposition.
+	const keepFullBoundsWhileRecording = process.platform === "linux";
 	return getHudOverlayWindowBounds(
 		workArea,
-		isHudOverlayMousePassthroughSupported() && !hudOverlayRecordingActive,
+		isHudOverlayMousePassthroughSupported() &&
+			(keepFullBoundsWhileRecording || !hudOverlayRecordingActive),
 		hudOverlayFallbackExpanded,
 	);
 }
@@ -277,10 +292,15 @@ function setHudOverlayFallbackExpanded(expanded: boolean) {
 }
 
 function setHudOverlayMousePassthrough(ignore: boolean) {
+	// While recording, non-Linux platforms shrink the HUD to a compact bar that always
+	// captures the mouse. On Linux the window stays full-work-area and click-through, so
+	// the renderer-driven `ignore` value is honoured (see getHudOverlayBounds / the
+	// recording branch below).
+	const recordingForcesCapture = hudOverlayRecordingActive && process.platform !== "linux";
 	hudOverlayIgnoringMouse =
 		hudOverlaySourceSelectionActive && !hudOverlayRecordingActive
 			? true
-			: hudOverlayRecordingActive
+			: recordingForcesCapture
 				? false
 				: ignore;
 
@@ -296,7 +316,19 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 	if (hudOverlayRecordingActive) {
 		hudOverlayFallbackExpanded = false;
 		applyHudOverlayBounds();
-		hudOverlayWindow.setIgnoreMouseEvents(false);
+		if (process.platform === "linux" && isHudOverlayMousePassthroughSupported()) {
+			// Linux keeps the full-work-area, always-on-top window while recording.
+			// Honour the renderer-driven pass-through so the controls stay clickable
+			// while clicks fall through everywhere else (the compositor cannot move a
+			// shrunken bar back into place, so we never shrink it here).
+			if (ignore) {
+				hudOverlayWindow.setIgnoreMouseEvents(true, { forward: true });
+			} else {
+				hudOverlayWindow.setIgnoreMouseEvents(false);
+			}
+		} else {
+			hudOverlayWindow.setIgnoreMouseEvents(false);
+		}
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Makes the recording control HUD usable on Linux, particularly on Wayland compositors with focus‑follows‑mouse such as Hyprland.

The HUD is a transparent, always‑on‑top overlay. On Linux, mouse pass‑through (`setIgnoreMouseEvents(true, { forward: true })`) was disabled, so every transparent pixel of the overlay captured the cursor. The result:

- the control bar **flickers and disappears on hover** under focus‑follows‑mouse compositors;
- its **buttons cannot be clicked**;
- it **blocks clicks on the windows underneath it**.

This is the behaviour reported in #638 ("Hyprland not support"), and is closely related to #657 and #687.

## Changes (all gated to Linux — Windows/macOS unchanged)

1. **Enable HUD mouse pass‑through on Linux** (`isHudOverlayMousePassthroughSupported`). Electron's `setIgnoreMouseEvents(true, { forward: true })` works on X11 and Wayland, so the HUD now behaves like it does on Windows 11: click‑through everywhere except over the interactive controls.

2. **Keep the HUD full‑work‑area while recording on Linux** (`getHudOverlayBounds`). On other platforms the HUD shrinks to a compact bar and repositions itself while recording. Wayland ignores programmatic window placement (`BrowserWindow.setBounds` x/y is silently dropped — already documented in the drag handler), so a shrunken bar cannot move back to the bottom‑centre and ends up stranded (top‑left on Hyprland). Keeping the full‑work‑area, click‑through window avoids any repositioning.

3. **Honour renderer‑driven pass‑through while recording on Linux** (`setHudOverlayMousePassthrough`), so the controls stay clickable while clicks fall through everywhere else.

## Testing

- `npx vitest --run electron/hudOverlayBounds.test.ts src/components/launch/hudMousePassthrough.test.ts` → 14/14 pass.
- `npx biome check electron/windows.ts` → clean.
- Type‑checked; no new errors in the changed file.
- Verified on Arch Linux + Hyprland 0.55 (Wayland): the bar no longer disappears on hover, the buttons are clickable, and clicks pass through to the windows behind the overlay.

### Note for tiling‑compositor users

On tiling Wayland compositors the full‑work‑area HUD window may be tiled instead of floated. On Hyprland this is resolved with a window rule, e.g.:

```
windowrule = float on, class:^(Recordly)$
windowrule = center on, class:^(Recordly)$
windowrule = border_size 0, class:^(Recordly)$
```

## Out of scope / follow‑ups

- The HUD "minimize" button maps to `BrowserWindow.minimize()`, which is unreliable on Wayland (the window stays on screen). Left for a separate change since the HUD is `skipTaskbar` and there is currently no restore path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD mouse click-through behavior on Linux while recording.
  * Linux now preserves the expected HUD overlay bounds during recording.
  * Recording no longer forces mouse capture on Linux, so the overlay honors the intended ignore-mouse setting.
* **Platform Improvements**
  * Enhanced Linux/Wayland editor window maximize behavior for more consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->