### PR TITLE
i18n: add missing zh-CN translations and fix language name

### DIFF
--- a/src/components/launch/popovers/MorePopover.tsx
+++ b/src/components/launch/popovers/MorePopover.tsx
@@ -29,7 +29,7 @@ const LOCALE_LABELS: Record<string, string> = {
 	nl: "Nederlands",
 	ko: "한국어",
 	"pt-BR": "Português",
-	"zh-CN": "簡體中文",
+	"zh-CN": "简体中文",
 	"zh-TW": "繁體中文",
 };
 

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -914,7 +914,7 @@ const APP_LANGUAGE_LABELS: Record<AppLocale, string> = {
 	nl: "Nederlands",
 	ko: "한국어",
 	"pt-BR": "Português",
-	"zh-CN": "簡體中文",
+	"zh-CN": "简体中文",
 	"zh-TW": "繁體中文",
 };
 

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -122,7 +122,38 @@
 		"paddingBottom": "下",
 		"paddingLeft": "左",
 		"paddingRight": "右",
-		"removeBackground": "移除背景"
+		"removeBackground": "移除背景",
+		"auto": "自动",
+		"temporalZoomMotionBlur": "时序缩放模糊",
+		"temporalZoomMotionBlurDescription": "控制新版缩放模糊通道使用的快门窗口和帧采样。",
+		"zoomMotionBlurSamples": "模糊采样数",
+		"zoomMotionBlurShutter": "快门",
+		"cursorClickEffects": {
+			"title": "点击效果",
+			"advanced": "高级",
+			"advancedShow": "显示高级点击效果控制",
+			"advancedHide": "隐藏高级点击效果控制",
+			"color": "效果颜色",
+			"size": "效果大小",
+			"opacity": "效果不透明度",
+			"duration": "效果持续时间",
+			"none": {
+				"label": "关闭",
+				"description": "无点击图形。仅在点击时改变光标运动。"
+			},
+			"ripple": {
+				"label": "涟漪",
+				"description": "从每次点击处向外扩散的圆环，使点击在运动中清晰可见。"
+			},
+			"spotlight": {
+				"label": "聚光灯",
+				"description": "指针周围闪烁的柔和光晕，突出点击区域。"
+			},
+			"echo": {
+				"label": "回声",
+				"description": "一对柔和的圆环以更干净的脉冲向外扩散。"
+			}
+		}
 	},
 	"sections": {
 		"scene": "场景",
@@ -161,7 +192,15 @@
 		"maxWidth": "最大宽度",
 		"boxRadius": "字幕框圆角",
 		"backgroundOpacity": "背景透明度",
-		"textColor": "文字颜色"
+		"textColor": "文字颜色",
+		"editor": {
+			"text": "文本",
+			"start": "开始",
+			"end": "结束",
+			"split": "拆分",
+			"merge": "合并",
+			"delete": "删除"
+		}
 	},
 	"crop": {
 		"title": "裁剪视频",


### PR DESCRIPTION
What does this PR do?
This PR completes the Simplified Chinese (zh-CN) locale by adding 27 missing translation keys across effect settings and caption editor controls, and fixes the language selector label that incorrectly used Traditional Chinese characters for the Simplified Chinese option.
Background
I noticed the zh-CN translation was partially incomplete. Several settings were still falling back to English, including click effect options (Ripple/Spotlight/Echo), temporal zoom blur parameters, and all caption editor action buttons, which creates an inconsistent experience for Simplified Chinese users. I also spotted that the "Simplified Chinese" label in both language dropdowns used Traditional Chinese glyphs, so I corrected that as well.
Type of change
Bug fix
Changes made
src/i18n/locales/zh-CN/settings.json: Added 27 missing translation keys for click effects, zoom blur, caption editor functions and related settings
src/components/launch/popovers/MorePopover.tsx: Updated language label from "簡體中文" to "简体中文"
src/components/video-editor/SettingsPanel.tsx: Updated language label from "簡體中文" to "简体中文"
How to test
Open Recordly → Settings → Language, verify the Simplified Chinese option displays as "简体中文" in the dropdown
Open the recording editor, go to the Settings Panel, and confirm:
All click effect labels (Ripple, Spotlight, Echo) are rendered in Simplified Chinese
Temporal zoom blur parameter labels are in Simplified Chinese
Caption editor controls (Text, Start, End, Split, Merge, Delete) all show Simplified Chinese text
Checklist
 Self-review completed
 Screenshots attached (if applicable)