### PR TITLE
i18n: Improve zh-CN localization & fix Simplified Chinese label glyph

### DIFF
--- a/src/components/launch/popovers/MorePopover.tsx
+++ b/src/components/launch/popovers/MorePopover.tsx
@@ -29,7 +29,7 @@ const LOCALE_LABELS: Record<string, string> = {
 	nl: "Nederlands",
 	ko: "한국어",
 	"pt-BR": "Português",
-	"zh-CN": "簡體中文",
+	"zh-CN": "简体中文",
 	"zh-TW": "繁體中文",
 };
 

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -2514,7 +2514,7 @@ export function SettingsPanel({
 				{availableFrames.length > 0 && (
 					<div className="flex flex-col gap-1.5 mt-1">
 						<div className="flex items-center justify-between">
-							<span className="text-[10px] text-muted-foreground">{tSettings("sections.frame", "Frame")</span>
+							<span className="text-[10px] text-muted-foreground">{tSettings("sections.frame", "Frame")}</span>
 							{frame && (
 								<button
 									type="button"

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -914,7 +914,7 @@ const APP_LANGUAGE_LABELS: Record<AppLocale, string> = {
 	nl: "Nederlands",
 	ko: "한국어",
 	"pt-BR": "Português",
-	"zh-CN": "簡體中文",
+	"zh-CN": "简体中文",
 	"zh-TW": "繁體中文",
 };
 
@@ -2514,7 +2514,7 @@ export function SettingsPanel({
 				{availableFrames.length > 0 && (
 					<div className="flex flex-col gap-1.5 mt-1">
 						<div className="flex items-center justify-between">
-							<span className="text-[10px] text-muted-foreground">Frame</span>
+							<span className="text-[10px] text-muted-foreground">{tSettings("sections.frame", "Frame")</span>
 							{frame && (
 								<button
 									type="button"

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -44,7 +44,6 @@
 		"solidColor": "Solid Color (Censorship)",
 		"borderRadius": "Border Radius"
 	},
-
 	"fontStyles": {
 		"classic": "Classic",
 		"editor": "Editor",
@@ -111,7 +110,13 @@
 		"showInFolder": "Show In Folder"
 	},
 	"project": {
-		"untitled": "Untitled"
+		"untitled": "Untitled",
+		"browserTitle": "Projects",
+		"import": "Import",
+		"noProjects": "No saved projects yet",
+		"saveTitle": "Save Project",
+		"saveDescription": "Name this project.",
+		"saveNameLabel": "Project name"
 	},
 	"nativeCaptureUnavailable": {
 		"title": "Nothing’s broken, but we won’t be able to render an animated cursor overlay.",
@@ -125,7 +130,9 @@
 		"completePercent": "{{percent}}% complete",
 		"issue": "Export issue",
 		"complete": "Export complete",
-		"savedSuccessfully": "Your file was saved successfully."
+		"savedSuccessfully": "Your file was saved successfully.",
+		"exportedSuccess": "Exported successfully to {{path}}",
+		"showInFolder": "Show in Folder"
 	},
 	"export": {
 		"processingAudioEdits": "Processing audio with speed/overlay edits"
@@ -136,7 +143,51 @@
 	},
 	"timeline": {
 		"expand": "Expand Timeline",
-		"collapse": "Collapse Timeline"
+		"collapse": "Collapse Timeline",
+		"noVideoLoaded": "No Video Loaded",
+		"custom": "Custom",
+		"set": "Set",
+		"sideScroll": "Side Scroll",
+		"pan": "Pan",
+		"zoom": "Zoom"
 	},
-	"openRecordingsFolder": "Open recordings folder"
+	"openRecordingsFolder": "Open recordings folder",
+	"presets": {
+		"label": "Presets",
+		"empty": "No presets yet.",
+		"open": "Open presets",
+		"saveCurrentAs": "Save current preset as",
+		"savedList": "Saved presets",
+		"namePlaceholder": "Preset name",
+		"errors": {
+			"nameRequired": "Enter a preset name.",
+			"duplicateName": "A preset with that name already exists.",
+			"saveFailed": "Could not save that preset.",
+			"deleteFailed": "Could not delete that preset."
+		},
+		"toasts": {
+			"applied": "Applied preset \"{{name}}\"",
+			"saved": "Saved preset \"{{name}}\"",
+			"deleted": "Deleted preset \"{{name}}\""
+		}
+	},
+	"theme": {
+		"appearance": "Appearance",
+		"light": "Light",
+		"dark": "Dark",
+		"system": "System"
+	},
+	"unsavedChanges": {
+		"title": "Unsaved changes",
+		"description": "Save your current project before you {{action}}?",
+		"discard": "Discard changes",
+		"save": "Save project",
+		"youHave": "You have unsaved changes.",
+		"beforeClosing": "Do you want to save your project before closing?",
+		"saveClose": "Save & Close",
+		"discardClose": "Discard & Close"
+	},
+	"common": {
+		"accountComingSoon": "Account coming soon"
+	}
 }

--- a/src/i18n/locales/en/shortcuts.json
+++ b/src/i18n/locales/en/shortcuts.json
@@ -12,5 +12,12 @@
 		"deleteSelectedAlt": "Delete Selected (alt)",
 		"panTimeline": "Pan Timeline",
 		"zoomTimeline": "Zoom Timeline"
+	},
+	"fixed": {
+		"Cycle Annotations Forward": "Cycle Annotations Forward",
+		"Cycle Annotations Backward": "Cycle Annotations Backward",
+		"Delete Selected (alt)": "Delete Selected (alt)",
+		"Pan Timeline": "Pan Timeline",
+		"Zoom Timeline": "Zoom Timeline"
 	}
 }

--- a/src/i18n/locales/zh-CN/editor.json
+++ b/src/i18n/locales/zh-CN/editor.json
@@ -44,7 +44,6 @@
 		"solidColor": "纯色 (审查)",
 		"borderRadius": "边框半径"
 	},
-
 	"fontStyles": {
 		"classic": "经典",
 		"editor": "编辑器",
@@ -111,7 +110,13 @@
 		"showInFolder": "在文件夹中显示"
 	},
 	"project": {
-		"untitled": "未命名"
+		"untitled": "未命名",
+		"browserTitle": "项目",
+		"import": "导入",
+		"noProjects": "暂无已保存的项目",
+		"saveTitle": "保存项目",
+		"saveDescription": "为项目命名。",
+		"saveNameLabel": "项目名称"
 	},
 	"nativeCaptureUnavailable": {
 		"title": "没有出错，但我们无法渲染动画光标叠加层。",
@@ -125,7 +130,9 @@
 		"completePercent": "已完成 {{percent}}%",
 		"issue": "导出问题",
 		"complete": "导出完成",
-		"savedSuccessfully": "文件已成功保存。"
+		"savedSuccessfully": "文件已成功保存。",
+		"exportedSuccess": "已成功导出到 {{path}}",
+		"showInFolder": "在文件夹中显示"
 	},
 	"export": {
 		"processingAudioEdits": "正在处理带有速度/叠加编辑的音频"
@@ -136,7 +143,51 @@
 	},
 	"timeline": {
 		"expand": "展开时间轴",
-		"collapse": "折叠时间轴"
+		"collapse": "折叠时间轴",
+		"noVideoLoaded": "未加载视频",
+		"custom": "自定义",
+		"set": "设置",
+		"sideScroll": "侧边滚动",
+		"pan": "平移",
+		"zoom": "缩放"
 	},
-	"openRecordingsFolder": "打开录制文件夹"
+	"openRecordingsFolder": "打开录制文件夹",
+	"presets": {
+		"label": "预设",
+		"empty": "暂无预设。",
+		"open": "打开预设",
+		"saveCurrentAs": "将当前预设保存为",
+		"savedList": "已保存的预设",
+		"namePlaceholder": "预设名称",
+		"errors": {
+			"nameRequired": "请输入预设名称。",
+			"duplicateName": "已存在同名预设。",
+			"saveFailed": "无法保存预设。",
+			"deleteFailed": "无法删除预设。"
+		},
+		"toasts": {
+			"applied": "已应用预设\"{{name}}\"",
+			"saved": "已保存预设\"{{name}}\"",
+			"deleted": "已删除预设\"{{name}}\""
+		}
+	},
+	"theme": {
+		"appearance": "外观",
+		"light": "浅色",
+		"dark": "深色",
+		"system": "系统"
+	},
+	"unsavedChanges": {
+		"title": "未保存的更改",
+		"description": "在打开另一个项目之前，是否保存当前项目？",
+		"discard": "放弃更改",
+		"save": "保存项目",
+		"youHave": "您有未保存的更改。",
+		"beforeClosing": "关闭前是否保存项目？",
+		"saveClose": "保存并关闭",
+		"discardClose": "放弃并关闭"
+	},
+	"common": {
+		"accountComingSoon": "账号功能即将推出"
+	}
 }

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -122,7 +122,46 @@
 		"paddingBottom": "下",
 		"paddingLeft": "左",
 		"paddingRight": "右",
-		"removeBackground": "移除背景"
+		"removeBackground": "移除背景",
+		"auto": "自动",
+		"temporalZoomMotionBlur": "时序缩放模糊",
+		"temporalZoomMotionBlurDescription": "控制新版缩放模糊通道使用的快门窗口和帧采样。",
+		"zoomMotionBlurSamples": "模糊采样数",
+		"zoomMotionBlurShutter": "快门",
+		"cursorClickEffects": {
+			"title": "点击效果",
+			"advanced": "高级",
+			"advancedShow": "显示高级点击效果控制",
+			"advancedHide": "隐藏高级点击效果控制",
+			"color": "效果颜色",
+			"size": "效果大小",
+			"opacity": "效果不透明度",
+			"duration": "效果持续时间",
+			"none": {
+				"label": "关闭",
+				"description": "无点击图形。仅在点击时改变光标运动。"
+			},
+			"ripple": {
+				"label": "涟漪",
+				"description": "从每次点击处向外扩散的圆环，使点击在运动中清晰可见。"
+			},
+			"spotlight": {
+				"label": "聚光灯",
+				"description": "指针周围闪烁的柔和光晕，突出点击区域。"
+			},
+			"echo": {
+				"label": "回声",
+				"description": "一对柔和的圆环以更干净的脉冲向外扩散。"
+			}
+		},
+		"webcamPosition": "位置",
+		"webcamCustomPosition": "自定义位置",
+		"webcamMargin": "外边距",
+		"webcamHorizontal": "水平",
+		"webcamVertical": "垂直",
+		"paddingAdvanced": "高级",
+		"paddingAdvancedHide": "隐藏高级内边距控制",
+		"paddingAdvancedShow": "显示高级内边距控制"
 	},
 	"sections": {
 		"scene": "场景",
@@ -161,7 +200,34 @@
 		"maxWidth": "最大宽度",
 		"boxRadius": "字幕框圆角",
 		"backgroundOpacity": "背景透明度",
-		"textColor": "文字颜色"
+		"textColor": "文字颜色",
+		"editor": {
+			"text": "文本",
+			"start": "开始",
+			"end": "结束",
+			"split": "拆分",
+			"merge": "合并",
+			"delete": "删除"
+		},
+		"selectModel": "选择模型",
+		"generatingStatus": "正在生成字幕，可能需要一些时间。",
+		"langOption": {
+			"auto": "自动检测",
+			"en": "英语",
+			"es": "西班牙语",
+			"fr": "法语",
+			"de": "德语",
+			"it": "意大利语",
+			"pt": "葡萄牙语",
+			"nl": "荷兰语",
+			"ja": "日语",
+			"ko": "韩语",
+			"zh": "中文",
+			"ru": "俄语",
+			"ar": "阿拉伯语",
+			"hi": "印地语",
+			"tr": "土耳其语"
+		}
 	},
 	"crop": {
 		"title": "裁剪视频",
@@ -181,7 +247,9 @@
 		"uploadCustom": "上传自定义",
 		"uploadSuccess": "自定义图片上传成功！",
 		"uploadError": "请上传 JPG 或 JPEG 图片文件。",
-		"uploadErrorDescription": "仅支持 JPG 和 JPEG 图片。"
+		"uploadErrorDescription": "仅支持 JPG 和 JPEG 图片。",
+		"uploadCustomVideo": "上传视频",
+		"video": "视频"
 	},
 	"export": {
 		"title": "导出",
@@ -215,5 +283,13 @@
 		"micLabel": "麦克风",
 		"mixedLabel": "来源",
 		"deleteRegion": "删除音频"
+	},
+	"settingsSections": {
+		"scene": "场景",
+		"captions": "字幕",
+		"cursor": "光标",
+		"webcam": "摄像头",
+		"extensions": "扩展",
+		"settings": "设置"
 	}
 }

--- a/src/i18n/locales/zh-CN/shortcuts.json
+++ b/src/i18n/locales/zh-CN/shortcuts.json
@@ -12,5 +12,12 @@
 		"deleteSelectedAlt": "删除选中（替代）",
 		"panTimeline": "平移时间线",
 		"zoomTimeline": "缩放时间线"
+	},
+	"fixed": {
+		"Cycle Annotations Forward": "向前循环切换注释",
+		"Cycle Annotations Backward": "向后循环切换注释",
+		"Delete Selected (alt)": "删除选中（替代）",
+		"Pan Timeline": "平移时间线",
+		"Zoom Timeline": "缩放时间线"
 	}
 }


### PR DESCRIPTION
While using Recordly on Windows, I found multiple flawed points in Simplified Chinese localization.
The language dropdown uses wrong Traditional glyph "簡體中文" instead of standard Simplified writing, fixed in MorePopover.tsx and SettingsPanel.tsx.
Many UI areas lack complete zh-CN localized text and fall back to raw English, including click effect configs, zoom blur parameters, caption editor buttons, preset & theme panels, project brow
ser, unsaved changes pop-up and timeline toolbar.
I refined zh-CN locale entries inside settings.json, editor.json and shortcuts.json, and added matching base English keys to support further language expansion.
Full local test finished on Windows 11. UI screenshots and code diffs are attached below.
<img width="450" alt="image" src="https://github.com/user-attachments/assets/a381a58a-8762-4535-8d44-b641cbfefb58" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/9cc2e1be-c827-41c0-9ac6-3560a5d5fea1" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/f0c081ad-07e6-4738-8c85-dc047ae4bbdd" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/018273b6-82b6-4c0b-8fcc-30144e9a8215" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/fe0e1882-fb87-4629-a236-1df20ac8b3ec" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/63945a24-a4e4-41e8-a934-6b8d0966d703" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/0ad849e8-2e2f-442e-87d3-c72d3fc49c19" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/13d2689a-9ecf-408d-ad65-62b6d1c2521d" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/3de0a3be-1c7d-42a9-8ff2-ed0f8127de6a" />
<img width="600" alt="屏幕截图_5-7-2026_212639_github com" src="https://github.com/user-attachments/assets/903ee83c-cd2c-48a7-8b56-23aa6eb25a80" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization / UI Text Updates**
  * Added and expanded translated labels across the editor and settings, including projects, export status (success + “show in folder”), timeline controls, presets, theme selection, and unsaved-changes prompts.
  * Enhanced Chinese settings text for motion/visual effects, cursor click effects presets, improved captions editor labels/actions, and additional background/video upload messaging.
  * Updated Simplified Chinese language naming and localized the “Frame” header in the settings UI.
* **New Features**
  * Added fixed shortcut/label mappings for annotation cycling, delete selected, pan, and zoom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->