### PR TITLE
chore(deps): upgrade Electron to 43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.3.13",
-				"@electron/rebuild": "^4.0.3",
+				"@electron/rebuild": "^4.2.0",
 				"@fix-webm-duration/fix": "^1.0.1",
 				"@radix-ui/react-accordion": "^1.2.12",
 				"@radix-ui/react-dialog": "^1.1.15",
@@ -918,227 +918,24 @@
 			}
 		},
 		"node_modules/@electron/rebuild": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.3.tgz",
-			"integrity": "sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
+			"integrity": "sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@malept/cross-spawn-promise": "^2.0.0",
 				"debug": "^4.1.1",
-				"detect-libc": "^2.0.1",
-				"got": "^11.7.0",
-				"graceful-fs": "^4.2.11",
 				"node-abi": "^4.2.0",
 				"node-api-version": "^0.2.1",
-				"node-gyp": "^11.2.0",
-				"ora": "^5.1.0",
-				"read-binary-file-arch": "^1.0.6",
-				"semver": "^7.3.5",
-				"tar": "^7.5.6",
-				"yargs": "^17.0.1"
+				"node-gyp": "^12.2.0",
+				"read-binary-file-arch": "^1.0.6"
 			},
 			"bin": {
 				"electron-rebuild": "lib/cli.js"
 			},
 			"engines": {
 				"node": ">=22.12.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/@npmcli/fs": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
-			"integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/abbrev": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-			"integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/cacache": {
-			"version": "19.0.1",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
-			"integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^4.0.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^7.0.2",
-				"ssri": "^12.0.0",
-				"tar": "^7.4.3",
-				"unique-filename": "^4.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/isexe": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@electron/rebuild/node_modules/make-fetch-happen": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
-			"integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/agent": "^3.0.0",
-				"cacache": "^19.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^4.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^1.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^12.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minipass-collect": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-			"integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minipass-fetch": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
-			"integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^3.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/negotiator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/node-api-version": {
@@ -1149,142 +946,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/node-gyp": {
-			"version": "11.5.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
-			"integrity": "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"env-paths": "^2.2.0",
-				"exponential-backoff": "^3.1.1",
-				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^14.0.3",
-				"nopt": "^8.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.3.5",
-				"tar": "^7.4.3",
-				"tinyglobby": "^0.2.12",
-				"which": "^5.0.0"
-			},
-			"bin": {
-				"node-gyp": "bin/node-gyp.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/nopt": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-			"integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"abbrev": "^3.0.0"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/p-map": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/ssri": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
-			"integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/tar": {
-			"version": "7.5.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-			"integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/unique-filename": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
-			"integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/unique-slug": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
-			"integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/which": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@electron/universal": {
@@ -2068,16 +1729,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@isaacs/fs-minipass/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2272,83 +1923,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/@npmcli/agent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
-			"integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"socks": "^2.8.3"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/@oxc-project/types": {
@@ -4394,6 +3968,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/abbrev": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+			"integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4635,16 +4219,6 @@
 				"node": "20 || >=22"
 			}
 		},
-		"node_modules/app-builder-lib/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/app-builder-lib/node_modules/ci-info": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -4751,46 +4325,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/app-builder-lib/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/tar": {
-			"version": "7.5.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-			"integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/app-builder-lib/node_modules/which": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -4805,16 +4339,6 @@
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/arg": {
@@ -4998,18 +4522,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/bl": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
-			}
-		},
 		"node_modules/boolean": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -5096,6 +4608,7 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
@@ -5378,6 +4891,16 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chromium-pickle-js": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
@@ -5414,32 +4937,6 @@
 				"url": "https://polar.sh/cva"
 			}
 		},
-		"node_modules/cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"restore-cursor": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cli-spinners": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/cli-truncate": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -5471,16 +4968,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/clone": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8"
 			}
 		},
 		"node_modules/clone-response": {
@@ -5676,19 +5163,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/defaults": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"clone": "^1.0.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6280,17 +5754,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"iconv-lite": "^0.6.2"
-			}
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
@@ -7243,17 +6706,8 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/imurmurhash": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.19"
-			}
+			"license": "BSD-3-Clause",
+			"optional": true
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
@@ -7272,16 +6726,6 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
-		},
-		"node_modules/ip-address": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-			"integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -7345,16 +6789,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-interactive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7363,19 +6797,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/is-unicode-supported": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/isbinaryfile": {
@@ -7848,23 +7269,6 @@
 			"deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
 			"license": "MIT"
 		},
-		"node_modules/log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8068,113 +7472,27 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=8"
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/minipass-flush": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+		"node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "MIT",
 			"dependencies": {
-				"minipass": "^3.0.0"
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 18"
 			}
-		},
-		"node_modules/minipass-flush/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-flush/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/minipass-pipeline": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-pipeline/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-pipeline/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/minipass-sized": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-sized/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-sized/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/motion": {
 			"version": "12.23.24",
@@ -8288,6 +7606,31 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/node-gyp": {
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+			"integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"exponential-backoff": "^3.1.1",
+				"graceful-fs": "^4.2.6",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"tar": "^7.5.4",
+				"tinyglobby": "^0.2.12",
+				"undici": "^6.25.0",
+				"which": "^6.0.0"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/node-gyp-build": {
 			"version": "4.8.4",
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -8299,12 +7642,64 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
+		"node_modules/node-gyp/node_modules/isexe": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/node-gyp/node_modules/undici": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
+		"node_modules/node-gyp/node_modules/which": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^4.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.23",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
 			"integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/nopt": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+			"integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^4.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -8413,30 +7808,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bl": "^4.1.0",
-				"chalk": "^4.1.0",
-				"cli-cursor": "^3.1.0",
-				"cli-spinners": "^2.5.0",
-				"is-interactive": "^1.0.0",
-				"is-unicode-supported": "^0.1.0",
-				"log-symbols": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"wcwidth": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8845,13 +8216,13 @@
 			}
 		},
 		"node_modules/proc-log": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
-			"integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/progress": {
@@ -9300,27 +8671,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/restore-cursor/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -9647,23 +8997,9 @@
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ip-address": "^10.0.1",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
@@ -9871,16 +9207,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/sucrase/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/sumchecker": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -9977,6 +9303,33 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"tailwindcss": ">=3.0.0 || insiders"
+			}
+		},
+		"node_modules/tar": {
+			"version": "7.5.19",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+			"integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tar/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/temp": {
@@ -11211,16 +10564,6 @@
 				"yaml": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/wcwidth": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"defaults": "^1.0.3"
 			}
 		},
 		"node_modules/web-demuxer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
 				"dnd-timeline": "^2.2.0",
-				"electron": "^39.8.10",
+				"electron": "^43.1.0",
 				"electron-builder": "^26.7.0",
 				"emoji-picker-react": "^4.16.1",
 				"fast-check": "^4.5.2",
@@ -650,6 +650,16 @@
 				"react": ">=16.8.0"
 			}
 		},
+		"node_modules/@electron-internal/extract-zip": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+			"integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
 		"node_modules/@electron/asar": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -747,35 +757,37 @@
 			}
 		},
 		"node_modules/@electron/get": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+			"integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.1.1",
-				"env-paths": "^2.2.0",
-				"fs-extra": "^8.1.0",
-				"got": "^11.8.5",
+				"env-paths": "^3.0.0",
+				"graceful-fs": "^4.2.11",
 				"progress": "^2.0.3",
-				"semver": "^6.2.0",
+				"semver": "^7.6.3",
 				"sumchecker": "^3.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=22.12.0"
 			},
 			"optionalDependencies": {
-				"global-agent": "^3.0.0"
+				"undici": "^7.24.4"
 			}
 		},
-		"node_modules/@electron/get/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+		"node_modules/@electron/get/node_modules/env-paths": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
 			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@electron/notarize": {
@@ -1127,19 +1139,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/node-abi": {
-			"version": "4.26.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.26.0.tgz",
-			"integrity": "sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"semver": "^7.6.3"
-			},
-			"engines": {
-				"node": ">=22.12.0"
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/node-api-version": {
@@ -4198,17 +4197,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/@types/yauzl": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@uiw/color-convert": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.9.2.tgz",
@@ -5113,16 +5101,6 @@
 				"ieee754": "^1.1.13"
 			}
 		},
-		"node_modules/buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6017,22 +5995,22 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "39.8.10",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
-			"integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
+			"version": "43.1.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-43.1.0.tgz",
+			"integrity": "sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron/get": "^2.0.0",
-				"@types/node": "^22.7.7",
-				"extract-zip": "^2.0.1"
+				"@electron-internal/extract-zip": "^1.0.1",
+				"@electron/get": "^5.0.0",
+				"@types/node": "^24.9.0"
 			},
 			"bin": {
-				"electron": "cli.js"
+				"electron": "cli.js",
+				"install-electron": "install.js"
 			},
 			"engines": {
-				"node": ">= 12.20.55"
+				"node": ">= 22.12.0"
 			}
 		},
 		"node_modules/electron-builder": {
@@ -6264,19 +6242,19 @@
 			}
 		},
 		"node_modules/electron/node_modules/@types/node": {
-			"version": "22.19.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
-			"integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+			"version": "24.13.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+			"integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.21.0"
+				"undici-types": "~7.18.0"
 			}
 		},
 		"node_modules/electron/node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -6554,27 +6532,6 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/extract-zip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
-			}
-		},
 		"node_modules/extsprintf": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
@@ -6661,16 +6618,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
-			}
-		},
-		"node_modules/fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/ffmpeg-static": {
@@ -6812,21 +6759,6 @@
 				"react-dom": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -8335,6 +8267,19 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/node-abi": {
+			"version": "4.33.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+			"integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.6.3"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
 		"node_modules/node-addon-api": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
@@ -8613,13 +8558,6 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/jet2jet"
 			}
-		},
-		"node_modules/pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -10384,6 +10322,17 @@
 				"node": ">= 16"
 			}
 		},
+		"node_modules/undici": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -11414,17 +11363,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"dnd-timeline": "^2.2.0",
-		"electron": "^39.8.10",
+		"electron": "^43.1.0",
 		"electron-builder": "^26.7.0",
 		"emoji-picker-react": "^4.16.1",
 		"fast-check": "^4.5.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.13",
-		"@electron/rebuild": "^4.0.3",
+		"@electron/rebuild": "^4.2.0",
 		"@fix-webm-duration/fix": "^1.0.1",
 		"@radix-ui/react-accordion": "^1.2.12",
 		"@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## Description
Upgrade Electron from 39.8.10 to 43.1.0. The net diff is only `package.json` and `package-lock.json`; Vitest remains 4.1.10 and `node-abi` remains deduped at 4.33.0 for Electron 43 ABI metadata.

## Motivation
Electron 39 is end-of-life. This moves Recordly to a supported major without changing product source or runtime policy.

## Prerequisite checkpoint
#753 merged first at `0933eeca`, adding `@electron/rebuild` 4.2 / node-gyp 12.4, VS 2026 + v143 CMake support, and fail-fast Windows CI. Its four-platform build workflow and resulting main Code Quality passed. This PR now inherits that tooling rather than duplicating it.

## Type of Change
- [x] Other: dependency compatibility upgrade

## Verification
- npm 10 clean install/postinstall and Electron on-demand install
- exact `electron-builder install-app-deps`
- Electron 43 runtime + `uiohook-napi` ABI load: 374 passed, 1 skipped
- full suite: 995 passed, 1 skipped
- strict TypeScript, focused Biome, production build/CJS smoke
- Windows directory package and packaged-binary smoke
- packaged Windows WGC record -> editor -> modern/Breeze export with system audio: H.264 + AAC, 264 frames, 8.8 seconds

## Risk
Windows x64 is runtime-tested. Build smoke does not prove Wayland frameless-window geometry or macOS notification behavior; those remain explicit beta runtime risks.

## Related Issue(s)
None.

## Checklist
- [x] Self-reviewed
- [x] No UI screenshot applies
- [x] No changelog entry before maintainer acceptance