### PR TITLE
fix(ci): support Visual Studio 2026 native builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,11 @@ jobs:
         shell: pwsh
         run: |
           npm run build:platform-native-helpers
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           npx tsc
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           npx vite build
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           npx electron-builder --win dir nsis --x64 --publish never
 
       - name: Smoke test packaged Windows paths

--- a/electron/windowsCmakeGenerators.test.mjs
+++ b/electron/windowsCmakeGenerators.test.mjs
@@ -19,7 +19,7 @@ describe("configureWithWindowsCmakeGenerator", () => {
 
 		expect(selected).toBe("Visual Studio 18 2026");
 		expect(WINDOWS_VISUAL_STUDIO_INSTALL_DIRS[0]).toBe("18");
-		expect(configure).toHaveBeenCalledTimes(1);
+		expect(configure).toHaveBeenCalledWith("Visual Studio 18 2026", "v143");
 		expect(clearCache).toHaveBeenCalledTimes(1);
 	});
 
@@ -32,15 +32,17 @@ describe("configureWithWindowsCmakeGenerator", () => {
 			prefix: "test",
 			clearCache,
 			log,
-			configure: (generator) => {
-				attempted.push(generator);
+			configure: (generator, toolset) => {
+				attempted.push({ name: generator, toolset });
 				if (generator !== "Visual Studio 16 2019") {
 					throw new Error(`${generator} unavailable`);
 				}
 			},
 		});
 
-		expect(attempted).toEqual(WINDOWS_CMAKE_GENERATORS.map(({ name }) => name));
+		expect(attempted).toEqual(
+			WINDOWS_CMAKE_GENERATORS.map(({ name, toolset }) => ({ name, toolset })),
+		);
 		expect(clearCache).toHaveBeenCalledTimes(3);
 		expect(log).toHaveBeenCalledTimes(2);
 		expect(selected).toBe("Visual Studio 16 2019");

--- a/electron/windowsCmakeGenerators.test.mjs
+++ b/electron/windowsCmakeGenerators.test.mjs
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	configureWithWindowsCmakeGenerator,
+	WINDOWS_CMAKE_GENERATORS,
+	WINDOWS_VISUAL_STUDIO_INSTALL_DIRS,
+} from "../scripts/windows-cmake-generators.mjs";
+
+describe("configureWithWindowsCmakeGenerator", () => {
+	it("uses Visual Studio 2026 first", () => {
+		const configure = vi.fn();
+		const clearCache = vi.fn();
+
+		const selected = configureWithWindowsCmakeGenerator({
+			prefix: "test",
+			configure,
+			clearCache,
+		});
+
+		expect(selected).toBe("Visual Studio 18 2026");
+		expect(WINDOWS_VISUAL_STUDIO_INSTALL_DIRS[0]).toBe("18");
+		expect(configure).toHaveBeenCalledTimes(1);
+		expect(clearCache).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back in supported-version order and clears stale CMake state", () => {
+		const attempted = [];
+		const clearCache = vi.fn();
+		const log = vi.fn();
+
+		const selected = configureWithWindowsCmakeGenerator({
+			prefix: "test",
+			clearCache,
+			log,
+			configure: (generator) => {
+				attempted.push(generator);
+				if (generator !== "Visual Studio 16 2019") {
+					throw new Error(`${generator} unavailable`);
+				}
+			},
+		});
+
+		expect(attempted).toEqual(WINDOWS_CMAKE_GENERATORS.map(({ name }) => name));
+		expect(clearCache).toHaveBeenCalledTimes(3);
+		expect(log).toHaveBeenCalledTimes(2);
+		expect(selected).toBe("Visual Studio 16 2019");
+	});
+
+	it("rethrows the final configure error when no supported generator exists", () => {
+		const finalError = new Error("VS 2019 unavailable");
+
+		expect(() =>
+			configureWithWindowsCmakeGenerator({
+				prefix: "test",
+				clearCache: vi.fn(),
+				log: vi.fn(),
+				configure: (generator) => {
+					if (generator === "Visual Studio 16 2019") throw finalError;
+					throw new Error(`${generator} unavailable`);
+				},
+			}),
+		).toThrow(finalError);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.3.13",
-				"@electron/rebuild": "^4.0.3",
+				"@electron/rebuild": "^4.2.0",
 				"@fix-webm-duration/fix": "^1.0.1",
 				"@radix-ui/react-accordion": "^1.2.12",
 				"@radix-ui/react-dialog": "^1.1.15",
@@ -906,227 +906,24 @@
 			}
 		},
 		"node_modules/@electron/rebuild": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.3.tgz",
-			"integrity": "sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
+			"integrity": "sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@malept/cross-spawn-promise": "^2.0.0",
 				"debug": "^4.1.1",
-				"detect-libc": "^2.0.1",
-				"got": "^11.7.0",
-				"graceful-fs": "^4.2.11",
 				"node-abi": "^4.2.0",
 				"node-api-version": "^0.2.1",
-				"node-gyp": "^11.2.0",
-				"ora": "^5.1.0",
-				"read-binary-file-arch": "^1.0.6",
-				"semver": "^7.3.5",
-				"tar": "^7.5.6",
-				"yargs": "^17.0.1"
+				"node-gyp": "^12.2.0",
+				"read-binary-file-arch": "^1.0.6"
 			},
 			"bin": {
 				"electron-rebuild": "lib/cli.js"
 			},
 			"engines": {
 				"node": ">=22.12.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/@npmcli/fs": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
-			"integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/abbrev": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-			"integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/cacache": {
-			"version": "19.0.1",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
-			"integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^4.0.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^7.0.2",
-				"ssri": "^12.0.0",
-				"tar": "^7.4.3",
-				"unique-filename": "^4.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/fs-minipass": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-			"integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/isexe": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@electron/rebuild/node_modules/make-fetch-happen": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
-			"integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/agent": "^3.0.0",
-				"cacache": "^19.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^4.0.0",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^1.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^12.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minipass-collect": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-			"integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minipass-fetch": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
-			"integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
-				"minizlib": "^3.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			},
-			"optionalDependencies": {
-				"encoding": "^0.1.13"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/negotiator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/node-abi": {
@@ -1150,142 +947,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/node-gyp": {
-			"version": "11.5.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
-			"integrity": "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"env-paths": "^2.2.0",
-				"exponential-backoff": "^3.1.1",
-				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^14.0.3",
-				"nopt": "^8.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.3.5",
-				"tar": "^7.4.3",
-				"tinyglobby": "^0.2.12",
-				"which": "^5.0.0"
-			},
-			"bin": {
-				"node-gyp": "bin/node-gyp.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/nopt": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-			"integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"abbrev": "^3.0.0"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/p-map": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/ssri": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
-			"integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.3"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/tar": {
-			"version": "7.5.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-			"integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/unique-filename": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
-			"integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/unique-slug": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
-			"integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/which": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^3.1.1"
-			},
-			"bin": {
-				"node-which": "bin/which.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@electron/rebuild/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@electron/universal": {
@@ -2069,16 +1730,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@isaacs/fs-minipass/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2273,83 +1924,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/@npmcli/agent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
-			"integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@npmcli/agent/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"socks": "^2.8.3"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/@oxc-project/types": {
@@ -4406,6 +3980,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/abbrev": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+			"integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4647,16 +4231,6 @@
 				"node": "20 || >=22"
 			}
 		},
-		"node_modules/app-builder-lib/node_modules/chownr": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/app-builder-lib/node_modules/ci-info": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -4763,46 +4337,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/app-builder-lib/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/minizlib": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/tar": {
-			"version": "7.5.7",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-			"integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.1.0",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/app-builder-lib/node_modules/which": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -4817,16 +4351,6 @@
 			},
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/app-builder-lib/node_modules/yallist": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/arg": {
@@ -5010,18 +4534,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/bl": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer": "^5.5.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.4.0"
-			}
-		},
 		"node_modules/boolean": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -5108,6 +4620,7 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
@@ -5400,6 +4913,16 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chromium-pickle-js": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
@@ -5436,32 +4959,6 @@
 				"url": "https://polar.sh/cva"
 			}
 		},
-		"node_modules/cli-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"restore-cursor": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/cli-spinners": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/cli-truncate": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -5493,16 +4990,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/clone": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8"
 			}
 		},
 		"node_modules/clone-response": {
@@ -5698,19 +5185,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/defaults": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"clone": "^1.0.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6302,17 +5776,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/encoding": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"iconv-lite": "^0.6.2"
-			}
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
@@ -7311,17 +6774,8 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/imurmurhash": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.19"
-			}
+			"license": "BSD-3-Clause",
+			"optional": true
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
@@ -7340,16 +6794,6 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
-		},
-		"node_modules/ip-address": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-			"integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -7413,16 +6857,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-interactive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7431,19 +6865,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/is-unicode-supported": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/isbinaryfile": {
@@ -7916,23 +7337,6 @@
 			"deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
 			"license": "MIT"
 		},
-		"node_modules/log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8136,113 +7540,27 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=8"
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/minipass-flush": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+		"node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
 			"dev": true,
-			"license": "ISC",
+			"license": "MIT",
 			"dependencies": {
-				"minipass": "^3.0.0"
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 18"
 			}
-		},
-		"node_modules/minipass-flush/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-flush/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/minipass-pipeline": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-pipeline/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-pipeline/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/minipass-sized": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-sized/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minipass-sized/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/motion": {
 			"version": "12.23.24",
@@ -8343,6 +7661,31 @@
 			"license": "MIT",
 			"optional": true
 		},
+		"node_modules/node-gyp": {
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+			"integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"exponential-backoff": "^3.1.1",
+				"graceful-fs": "^4.2.6",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"tar": "^7.5.4",
+				"tinyglobby": "^0.2.12",
+				"undici": "^6.25.0",
+				"which": "^6.0.0"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/node-gyp-build": {
 			"version": "4.8.4",
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -8354,12 +7697,54 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
+		"node_modules/node-gyp/node_modules/isexe": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/node-gyp/node_modules/which": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^4.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.23",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
 			"integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/nopt": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+			"integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^4.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -8468,30 +7853,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ora": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bl": "^4.1.0",
-				"chalk": "^4.1.0",
-				"cli-cursor": "^3.1.0",
-				"cli-spinners": "^2.5.0",
-				"is-interactive": "^1.0.0",
-				"is-unicode-supported": "^0.1.0",
-				"log-symbols": "^4.1.0",
-				"strip-ansi": "^6.0.0",
-				"wcwidth": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8907,13 +8268,13 @@
 			}
 		},
 		"node_modules/proc-log": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
-			"integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/progress": {
@@ -9362,27 +8723,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/restore-cursor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/restore-cursor/node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -9709,23 +9049,9 @@
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
 				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ip-address": "^10.0.1",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
@@ -9933,16 +9259,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/sucrase/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/sumchecker": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -10039,6 +9355,33 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"tailwindcss": ">=3.0.0 || insiders"
+			}
+		},
+		"node_modules/tar": {
+			"version": "7.5.19",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+			"integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tar/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/temp": {
@@ -10382,6 +9725,16 @@
 			},
 			"engines": {
 				"node": ">= 16"
+			}
+		},
+		"node_modules/undici": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/undici-types": {
@@ -11262,16 +10615,6 @@
 				"yaml": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/wcwidth": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"defaults": "^1.0.3"
 			}
 		},
 		"node_modules/web-demuxer": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.13",
-		"@electron/rebuild": "^4.0.3",
+		"@electron/rebuild": "^4.2.0",
 		"@fix-webm-duration/fix": "^1.0.1",
 		"@radix-ui/react-accordion": "^1.2.12",
 		"@radix-ui/react-dialog": "^1.1.15",

--- a/scripts/build-cursor-monitor.mjs
+++ b/scripts/build-cursor-monitor.mjs
@@ -124,8 +124,8 @@ try {
 	configureWithWindowsCmakeGenerator({
 		prefix: "build-cursor-monitor",
 		clearCache: clearCmakeCache,
-		configure: (generator) =>
-			execSync(`${cmake} .. -G "${generator}" -A x64`, {
+		configure: (generator, toolset) =>
+			execSync(`${cmake} .. -G "${generator}" -A x64${toolset ? ` -T ${toolset}` : ""}`, {
 				cwd: buildDir,
 				stdio: "inherit",
 				timeout: 120000,

--- a/scripts/build-cursor-monitor.mjs
+++ b/scripts/build-cursor-monitor.mjs
@@ -7,6 +7,10 @@ import {
 	updateNativeHelperManifest,
 	verifyNativeHelperManifest,
 } from "./native-helper-manifest.mjs";
+import {
+	configureWithWindowsCmakeGenerator,
+	WINDOWS_VISUAL_STUDIO_INSTALL_DIRS,
+} from "./windows-cmake-generators.mjs";
 
 const projectRoot = process.cwd();
 const sourceDir = path.join(projectRoot, "electron", "native", "cursor-monitor");
@@ -56,7 +60,7 @@ function findCmake() {
 		path.join("C:", "Program Files (x86)", "Microsoft Visual Studio"),
 	];
 	const vsEditions = ["Community", "Professional", "Enterprise", "BuildTools"];
-	const vsVersions = ["2022", "2019"];
+	const vsVersions = WINDOWS_VISUAL_STUDIO_INSTALL_DIRS;
 	for (const root of vsRoots) {
 		for (const version of vsVersions) {
 			for (const edition of vsEditions) {
@@ -117,25 +121,19 @@ function clearCmakeCache() {
 
 console.log("[build-cursor-monitor] Configuring CMake...");
 try {
-	clearCmakeCache();
-	execSync(`${cmake} .. -G "Visual Studio 17 2022" -A x64`, {
-		cwd: buildDir,
-		stdio: "inherit",
-		timeout: 120000,
+	configureWithWindowsCmakeGenerator({
+		prefix: "build-cursor-monitor",
+		clearCache: clearCmakeCache,
+		configure: (generator) =>
+			execSync(`${cmake} .. -G "${generator}" -A x64`, {
+				cwd: buildDir,
+				stdio: "inherit",
+				timeout: 120000,
+			}),
 	});
-} catch {
-	console.log("[build-cursor-monitor] VS 2022 generator not found, trying VS 2019...");
-	try {
-		clearCmakeCache();
-		execSync(`${cmake} .. -G "Visual Studio 16 2019" -A x64`, {
-			cwd: buildDir,
-			stdio: "inherit",
-			timeout: 120000,
-		});
-	} catch (innerError) {
-		console.error("[build-cursor-monitor] CMake configure failed:", innerError.message);
-		process.exit(1);
-	}
+} catch (error) {
+	console.error("[build-cursor-monitor] CMake configure failed:", error.message);
+	process.exit(1);
 }
 
 console.log("[build-cursor-monitor] Building...");

--- a/scripts/build-nvidia-cuda-compositor.mjs
+++ b/scripts/build-nvidia-cuda-compositor.mjs
@@ -244,9 +244,9 @@ try {
 	configureWithWindowsCmakeGenerator({
 		prefix: "build-nvidia-cuda-compositor",
 		clearCache: clearCmakeCache,
-		configure: (generator) =>
+		configure: (generator, toolset) =>
 			execSync(
-				`${cmake} .. -G "${generator}" -A ${generatorArch} -DRECORDLY_NVIDIA_VIDEO_CODEC_SDK_ROOT="${videoCodecSdkRoot}"`,
+				`${cmake} .. -G "${generator}" -A ${generatorArch}${toolset ? ` -T ${toolset}` : ""} -DRECORDLY_NVIDIA_VIDEO_CODEC_SDK_ROOT="${videoCodecSdkRoot}"`,
 				{
 					cwd: buildDir,
 					stdio: "inherit",

--- a/scripts/build-nvidia-cuda-compositor.mjs
+++ b/scripts/build-nvidia-cuda-compositor.mjs
@@ -7,6 +7,10 @@ import {
 	updateNativeHelperManifest,
 	verifyNativeHelperManifest,
 } from "./native-helper-manifest.mjs";
+import {
+	configureWithWindowsCmakeGenerator,
+	WINDOWS_VISUAL_STUDIO_INSTALL_DIRS,
+} from "./windows-cmake-generators.mjs";
 
 const projectRoot = process.cwd();
 const sourceDir = path.join(projectRoot, "electron", "native", "nvidia-cuda-compositor");
@@ -84,7 +88,7 @@ function findCmake() {
 		path.join("C:", "Program Files (x86)", "Microsoft Visual Studio"),
 	];
 	const vsEditions = ["Preview", "Community", "Professional", "Enterprise", "BuildTools"];
-	const vsVersions = ["2022", "2019"];
+	const vsVersions = WINDOWS_VISUAL_STUDIO_INSTALL_DIRS;
 	for (const root of vsRoots) {
 		for (const version of vsVersions) {
 			for (const edition of vsEditions) {
@@ -237,32 +241,23 @@ function clearCmakeCache() {
 
 console.log("[build-nvidia-cuda-compositor] Configuring CMake...");
 try {
-	clearCmakeCache();
-	execSync(
-		`${cmake} .. -G "Visual Studio 17 2022" -A ${generatorArch} -DRECORDLY_NVIDIA_VIDEO_CODEC_SDK_ROOT="${videoCodecSdkRoot}"`,
-		{
-			cwd: buildDir,
-			stdio: "inherit",
-			timeout: 120000,
-		},
+	configureWithWindowsCmakeGenerator({
+		prefix: "build-nvidia-cuda-compositor",
+		clearCache: clearCmakeCache,
+		configure: (generator) =>
+			execSync(
+				`${cmake} .. -G "${generator}" -A ${generatorArch} -DRECORDLY_NVIDIA_VIDEO_CODEC_SDK_ROOT="${videoCodecSdkRoot}"`,
+				{
+					cwd: buildDir,
+					stdio: "inherit",
+					timeout: 120000,
+				},
+			),
+	});
+} catch (error) {
+	fallbackToBundledHelperOrExit(
+		`CMake configure failed: ${error instanceof Error ? error.message : String(error)}`,
 	);
-} catch {
-	console.log("[build-nvidia-cuda-compositor] VS 2022 generator not found, trying VS 2019...");
-	try {
-		clearCmakeCache();
-		execSync(
-			`${cmake} .. -G "Visual Studio 16 2019" -A ${generatorArch} -DRECORDLY_NVIDIA_VIDEO_CODEC_SDK_ROOT="${videoCodecSdkRoot}"`,
-			{
-				cwd: buildDir,
-				stdio: "inherit",
-				timeout: 120000,
-			},
-		);
-	} catch (error) {
-		fallbackToBundledHelperOrExit(
-			`CMake configure failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
-	}
 }
 
 console.log("[build-nvidia-cuda-compositor] Building NVIDIA CUDA compositor...");

--- a/scripts/build-whisper-runtime.mjs
+++ b/scripts/build-whisper-runtime.mjs
@@ -1,8 +1,13 @@
 import { execFileSync, execSync } from "node:child_process";
-import { createWriteStream, existsSync } from "node:fs";
+import { createWriteStream, existsSync, rmSync } from "node:fs";
 import { chmod, cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { get as httpsGet } from "node:https";
 import path from "node:path";
+
+import {
+	configureWithWindowsCmakeGenerator,
+	WINDOWS_VISUAL_STUDIO_INSTALL_DIRS,
+} from "./windows-cmake-generators.mjs";
 
 const projectRoot = process.cwd();
 const whisperVersion = "v1.8.4";
@@ -101,12 +106,7 @@ function getTargetConfigs() {
 				archTag,
 				buildRoot: path.join(cacheRoot, `build-${archTag}`),
 				outputDir: path.join(nativeRoot, "bin", archTag),
-				configureArgs: [
-					"-G",
-					"Visual Studio 17 2022",
-					"-A",
-					arch === "arm64" ? "ARM64" : "x64",
-				],
+				configureArgs: ["-A", arch === "arm64" ? "ARM64" : "x64"],
 			},
 		];
 	}
@@ -143,24 +143,26 @@ function findCmake() {
 
 	if (process.platform === "win32") {
 		const vsEditions = ["Community", "Professional", "Enterprise", "BuildTools"];
-		for (const edition of vsEditions) {
-			const cmakePath = path.join(
-				"C:",
-				"Program Files",
-				"Microsoft Visual Studio",
-				"2022",
-				edition,
-				"Common7",
-				"IDE",
-				"CommonExtensions",
-				"Microsoft",
-				"CMake",
-				"CMake",
-				"bin",
-				"cmake.exe",
-			);
-			if (existsSync(cmakePath)) {
-				return cmakePath;
+		for (const version of WINDOWS_VISUAL_STUDIO_INSTALL_DIRS) {
+			for (const edition of vsEditions) {
+				const cmakePath = path.join(
+					"C:",
+					"Program Files",
+					"Microsoft Visual Studio",
+					version,
+					edition,
+					"Common7",
+					"IDE",
+					"CommonExtensions",
+					"Microsoft",
+					"CMake",
+					"CMake",
+					"bin",
+					"cmake.exe",
+				);
+				if (existsSync(cmakePath)) {
+					return cmakePath;
+				}
 			}
 		}
 	}
@@ -272,7 +274,7 @@ async function shouldSkipBuild(target) {
 	}
 }
 
-function getConfigureArgs(sourceDir, target) {
+function getConfigureArgs(sourceDir, target, generator) {
 	const args = [
 		"-S",
 		sourceDir,
@@ -281,6 +283,7 @@ function getConfigureArgs(sourceDir, target) {
 		"-DWHISPER_BUILD_TESTS=OFF",
 		"-DWHISPER_BUILD_SERVER=OFF",
 		"-DBUILD_SHARED_LIBS=OFF",
+		...(generator ? ["-G", generator] : []),
 		...target.configureArgs,
 	];
 
@@ -424,36 +427,27 @@ async function main() {
 		console.log(
 			`[build-whisper-runtime] Configuring whisper.cpp ${whisperVersion} for ${target.archTag}...`,
 		);
-		try {
+		if (target.platform === "win32") {
+			configureWithWindowsCmakeGenerator({
+				prefix: "build-whisper-runtime",
+				clearCache: () => {
+					rmSync(path.join(target.buildRoot, "CMakeCache.txt"), { force: true });
+					rmSync(path.join(target.buildRoot, "CMakeFiles"), {
+						recursive: true,
+						force: true,
+					});
+				},
+				configure: (generator) =>
+					execFileSync(cmake, getConfigureArgs(sourceDir, target, generator), {
+						stdio: "inherit",
+						timeout: 300000,
+					}),
+			});
+		} else {
 			execFileSync(cmake, getConfigureArgs(sourceDir, target), {
 				stdio: "inherit",
 				timeout: 300000,
 			});
-		} catch (error) {
-			if (target.platform === "win32" && target.arch !== "arm64") {
-				console.log(
-					"[build-whisper-runtime] VS 2022 generator unavailable, retrying with VS 2019...",
-				);
-				execFileSync(
-					cmake,
-					[
-						"-S",
-						sourceDir,
-						"-B",
-						target.buildRoot,
-						"-G",
-						"Visual Studio 16 2019",
-						"-A",
-						"x64",
-						"-DWHISPER_BUILD_TESTS=OFF",
-						"-DWHISPER_BUILD_SERVER=OFF",
-						"-DBUILD_SHARED_LIBS=OFF",
-					],
-					{ stdio: "inherit", timeout: 300000 },
-				);
-			} else {
-				throw error;
-			}
 		}
 
 		console.log(

--- a/scripts/build-whisper-runtime.mjs
+++ b/scripts/build-whisper-runtime.mjs
@@ -274,7 +274,7 @@ async function shouldSkipBuild(target) {
 	}
 }
 
-function getConfigureArgs(sourceDir, target, generator) {
+function getConfigureArgs(sourceDir, target, generator, toolset) {
 	const args = [
 		"-S",
 		sourceDir,
@@ -284,6 +284,7 @@ function getConfigureArgs(sourceDir, target, generator) {
 		"-DWHISPER_BUILD_SERVER=OFF",
 		"-DBUILD_SHARED_LIBS=OFF",
 		...(generator ? ["-G", generator] : []),
+		...(toolset ? ["-T", toolset] : []),
 		...target.configureArgs,
 	];
 
@@ -437,8 +438,8 @@ async function main() {
 						force: true,
 					});
 				},
-				configure: (generator) =>
-					execFileSync(cmake, getConfigureArgs(sourceDir, target, generator), {
+				configure: (generator, toolset) =>
+					execFileSync(cmake, getConfigureArgs(sourceDir, target, generator, toolset), {
 						stdio: "inherit",
 						timeout: 300000,
 					}),

--- a/scripts/build-windows-capture.mjs
+++ b/scripts/build-windows-capture.mjs
@@ -7,6 +7,10 @@ import {
 	updateNativeHelperManifest,
 	verifyNativeHelperManifest,
 } from "./native-helper-manifest.mjs";
+import {
+	configureWithWindowsCmakeGenerator,
+	WINDOWS_VISUAL_STUDIO_INSTALL_DIRS,
+} from "./windows-cmake-generators.mjs";
 
 const projectRoot = process.cwd();
 const sourceDir = path.join(projectRoot, "electron", "native", "wgc-capture");
@@ -59,7 +63,7 @@ function findCmake() {
 		path.join("C:", "Program Files (x86)", "Microsoft Visual Studio"),
 	];
 	const vsEditions = ["Community", "Professional", "Enterprise", "BuildTools"];
-	const vsVersions = ["2022", "2019"];
+	const vsVersions = WINDOWS_VISUAL_STUDIO_INSTALL_DIRS;
 	for (const root of vsRoots) {
 		for (const version of vsVersions) {
 			for (const edition of vsEditions) {
@@ -120,25 +124,19 @@ function clearCmakeCache() {
 
 console.log("[build-windows-capture] Configuring CMake...");
 try {
-	clearCmakeCache();
-	execSync(`${cmake} .. -G "Visual Studio 17 2022" -A ${generatorArch}`, {
-		cwd: buildDir,
-		stdio: "inherit",
-		timeout: 120000,
+	configureWithWindowsCmakeGenerator({
+		prefix: "build-windows-capture",
+		clearCache: clearCmakeCache,
+		configure: (generator) =>
+			execSync(`${cmake} .. -G "${generator}" -A ${generatorArch}`, {
+				cwd: buildDir,
+				stdio: "inherit",
+				timeout: 120000,
+			}),
 	});
-} catch {
-	console.log("[build-windows-capture] VS 2022 generator not found, trying VS 2019...");
-	try {
-		clearCmakeCache();
-		execSync(`${cmake} .. -G "Visual Studio 16 2019" -A ${generatorArch}`, {
-			cwd: buildDir,
-			stdio: "inherit",
-			timeout: 120000,
-		});
-	} catch (innerError) {
-		console.error("[build-windows-capture] CMake configure failed:", innerError.message);
-		process.exit(1);
-	}
+} catch (error) {
+	console.error("[build-windows-capture] CMake configure failed:", error.message);
+	process.exit(1);
 }
 
 console.log("[build-windows-capture] Building native Windows capture helper...");

--- a/scripts/build-windows-capture.mjs
+++ b/scripts/build-windows-capture.mjs
@@ -127,8 +127,8 @@ try {
 	configureWithWindowsCmakeGenerator({
 		prefix: "build-windows-capture",
 		clearCache: clearCmakeCache,
-		configure: (generator) =>
-			execSync(`${cmake} .. -G "${generator}" -A ${generatorArch}`, {
+		configure: (generator, toolset) =>
+			execSync(`${cmake} .. -G "${generator}" -A ${generatorArch}${toolset ? ` -T ${toolset}` : ""}`, {
 				cwd: buildDir,
 				stdio: "inherit",
 				timeout: 120000,

--- a/scripts/build-windows-gpu-export.mjs
+++ b/scripts/build-windows-gpu-export.mjs
@@ -122,8 +122,8 @@ try {
 	configureWithWindowsCmakeGenerator({
 		prefix: "build-windows-gpu-export",
 		clearCache: clearCmakeCache,
-		configure: (generator) =>
-			execSync(`${cmake} .. -G "${generator}" -A ${generatorArch}`, {
+		configure: (generator, toolset) =>
+			execSync(`${cmake} .. -G "${generator}" -A ${generatorArch}${toolset ? ` -T ${toolset}` : ""}`, {
 				cwd: buildDir,
 				stdio: "inherit",
 				timeout: 120000,

--- a/scripts/build-windows-gpu-export.mjs
+++ b/scripts/build-windows-gpu-export.mjs
@@ -7,6 +7,10 @@ import {
 	updateNativeHelperManifest,
 	verifyNativeHelperManifest,
 } from "./native-helper-manifest.mjs";
+import {
+	configureWithWindowsCmakeGenerator,
+	WINDOWS_VISUAL_STUDIO_INSTALL_DIRS,
+} from "./windows-cmake-generators.mjs";
 
 const projectRoot = process.cwd();
 const sourceDir = path.join(projectRoot, "electron", "native", "gpu-export-probe");
@@ -55,7 +59,7 @@ function findCmake() {
 		path.join("C:", "Program Files (x86)", "Microsoft Visual Studio"),
 	];
 	const vsEditions = ["Community", "Professional", "Enterprise", "BuildTools"];
-	const vsVersions = ["2022", "2019"];
+	const vsVersions = WINDOWS_VISUAL_STUDIO_INSTALL_DIRS;
 	for (const root of vsRoots) {
 		for (const version of vsVersions) {
 			for (const edition of vsEditions) {
@@ -115,25 +119,19 @@ function clearCmakeCache() {
 
 console.log("[build-windows-gpu-export] Configuring CMake...");
 try {
-	clearCmakeCache();
-	execSync(`${cmake} .. -G "Visual Studio 17 2022" -A ${generatorArch}`, {
-		cwd: buildDir,
-		stdio: "inherit",
-		timeout: 120000,
+	configureWithWindowsCmakeGenerator({
+		prefix: "build-windows-gpu-export",
+		clearCache: clearCmakeCache,
+		configure: (generator) =>
+			execSync(`${cmake} .. -G "${generator}" -A ${generatorArch}`, {
+				cwd: buildDir,
+				stdio: "inherit",
+				timeout: 120000,
+			}),
 	});
-} catch {
-	console.log("[build-windows-gpu-export] VS 2022 generator not found, trying VS 2019...");
-	try {
-		clearCmakeCache();
-		execSync(`${cmake} .. -G "Visual Studio 16 2019" -A ${generatorArch}`, {
-			cwd: buildDir,
-			stdio: "inherit",
-			timeout: 120000,
-		});
-	} catch (error) {
-		console.error("[build-windows-gpu-export] CMake configure failed:", error.message);
-		process.exit(1);
-	}
+} catch (error) {
+	console.error("[build-windows-gpu-export] CMake configure failed:", error.message);
+	process.exit(1);
 }
 
 console.log("[build-windows-gpu-export] Building Windows GPU export helper...");

--- a/scripts/windows-cmake-generators.mjs
+++ b/scripts/windows-cmake-generators.mjs
@@ -1,5 +1,5 @@
 export const WINDOWS_CMAKE_GENERATORS = Object.freeze([
-	{ name: "Visual Studio 18 2026", label: "VS 2026" },
+	{ name: "Visual Studio 18 2026", label: "VS 2026", toolset: "v143" },
 	{ name: "Visual Studio 17 2022", label: "VS 2022" },
 	{ name: "Visual Studio 16 2019", label: "VS 2019" },
 ]);
@@ -19,7 +19,7 @@ export function configureWithWindowsCmakeGenerator({
 		clearCache();
 
 		try {
-			configure(generator.name);
+			configure(generator.name, generator.toolset);
 			return generator.name;
 		} catch (error) {
 			lastError = error;

--- a/scripts/windows-cmake-generators.mjs
+++ b/scripts/windows-cmake-generators.mjs
@@ -1,0 +1,36 @@
+export const WINDOWS_CMAKE_GENERATORS = Object.freeze([
+	{ name: "Visual Studio 18 2026", label: "VS 2026" },
+	{ name: "Visual Studio 17 2022", label: "VS 2022" },
+	{ name: "Visual Studio 16 2019", label: "VS 2019" },
+]);
+
+export const WINDOWS_VISUAL_STUDIO_INSTALL_DIRS = Object.freeze(["18", "2022", "2019"]);
+
+export function configureWithWindowsCmakeGenerator({
+	prefix,
+	configure,
+	clearCache,
+	log = console.log,
+}) {
+	let lastError;
+
+	for (let index = 0; index < WINDOWS_CMAKE_GENERATORS.length; index += 1) {
+		const generator = WINDOWS_CMAKE_GENERATORS[index];
+		clearCache();
+
+		try {
+			configure(generator.name);
+			return generator.name;
+		} catch (error) {
+			lastError = error;
+			const nextGenerator = WINDOWS_CMAKE_GENERATORS[index + 1];
+			if (nextGenerator) {
+				log(
+					`[${prefix}] ${generator.label} generator unavailable, trying ${nextGenerator.label}...`,
+				);
+			}
+		}
+	}
+
+	throw lastError;
+}


### PR DESCRIPTION
## Description
Restore Windows native builds on GitHub's Visual Studio 2026 runner:

- update `@electron/rebuild` to 4.2.0 / node-gyp 12.4.0
- try CMake generators VS 2026 with v143 -> VS 2022 -> VS 2019, clearing cache between attempts
- apply the same contract to WGC, GPU export, cursor, NVIDIA, and Whisper
- stop the Windows workflow immediately after a failed helper, TypeScript, or Vite command

## Motivation
`windows-latest` migrated to VS 2026. Current main fails rebuilding `uiohook-napi` with node-gyp 11.5; after that is fixed, Recordly's CMake scripts still request only VS 2022/2019. VS 2026's default MSVC 14.51 also rejects the C++/WinRT experimental coroutine header, so the generator uses the runner's installed v143 compatibility toolset. PowerShell previously continued after helper failure and produced a misleading green build step until packaged smoke found missing Whisper.

## Type of Change
- [x] Bug Fix

## Verification
- npm 10 exact clean install and `electron-builder install-app-deps`
- generator selection/fallback/toolset/final-error tests: 3 passed
- full suite: 995 passed, 1 skipped
- strict TypeScript, targeted Biome lint, Node syntax checks
- local VS 2022: controlled VS 2026 attempt -> cache clear -> VS 2022 fallback; helper chain reaches Whisper
- Electron 39 production build/CJS smoke, Windows directory package, packaged-binary smoke
- audit: 13 findings, 0 critical (was 15)

## Risk
Build tooling only; no native helper source or product runtime behavior changes. The exact-head workflow must still prove VS 2026 + v143 and unaffected macOS/Linux paths before merge.

## Related
Unblocks cross-platform validation for #752.

## Checklist
- [x] Self-reviewed
- [x] No UI screenshot applies
- [x] No changelog entry is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows build reliability by automatically discovering and selecting a compatible CMake generator across supported Visual Studio versions.
  - Standardized cache cleanup, generator fallback, and configure-time error reporting across Windows build scripts.
  - Enhanced generator configuration for newer Visual Studio tooling (including toolset handling where applicable).

- **Chores**
  - Windows builds now stop immediately when key build commands fail (preventing cascading errors).
  - Updated a development dependency used for Electron rebuild.

- **Tests**
  - Added tests covering generator selection order, fallback behavior, and failure handling on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->