### PR TITLE
chore(release): prepare 1.3.5-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recordly",
-	"version": "1.3.4",
+	"version": "1.3.5-beta.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recordly",
-			"version": "1.3.4",
+			"version": "1.3.5-beta.2",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "https://github.com/webadderallorg/Recordly/issues"
 	},
 	"private": true,
-	"version": "1.3.4",
+	"version": "1.3.5-beta.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite --config vite.config.ts",


### PR DESCRIPTION
## Summary

Prepare the reviewed and merged `main` branch for the `v1.3.5-beta.2` prerelease.

- set the package version to `1.3.5-beta.2`
- keep the npm lockfile root/package metadata in sync
- leave product code, dependencies, and release workflow unchanged

## Why

The selected fixes were merged as focused rollback checkpoints, culminating in Electron 43 PR #752. Its exact-head four-platform build workflow and resulting-main Code Quality run passed. A dedicated version PR keeps release chronology reviewable and ensures the tag will match `package.json`, as required by the release workflow.

`beta.1` is intentionally not reused because an earlier assetless prerelease was removed after it was created before the underlying PRs were merged.

## Verification

- package/lock version consistency assertion: `1.3.5-beta.2`
- `npx tsc --noEmit`
- `npm run lint` (pass; inherited warnings only)
- `npm test` — 106 files passed, 995 tests passed, 1 skipped
- `git diff --check`

## Risk and rollback

Risk is limited to release metadata: this changes only three version fields across two files. The merge commit for this PR will be the release rollback checkpoint; the tag and prerelease will be created only from green merged `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.3.5-beta.2 as a beta update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->