### PR TITLE
fix(ipc): allow media in configured recordings directory

### DIFF
--- a/electron/ipc/project/manager.test.ts
+++ b/electron/ipc/project/manager.test.ts
@@ -82,6 +82,23 @@ describe("local media path policy", () => {
 		await expect(isAllowedLocalMediaPath(pendingExportPath)).resolves.toBe(true);
 	});
 
+	it("allows media files in the configured recordings directory", async () => {
+		const configuredRecordingsDir = path.join(tempRoot, "Configured recordings");
+		const recordingPath = path.join(configuredRecordingsDir, "recording-123.mic.wav");
+		await fs.mkdir(configuredRecordingsDir, { recursive: true });
+		await fs.writeFile(recordingPath, "audio");
+		await fs.writeFile(
+			path.join(userDataPath, "recordings-settings.json"),
+			JSON.stringify({ recordingsDir: configuredRecordingsDir }),
+		);
+
+		const { resolveApprovedLocalMediaPath } = await import("./manager");
+
+		await expect(resolveApprovedLocalMediaPath(recordingPath)).resolves.toBe(
+			await fs.realpath(recordingPath),
+		);
+	});
+
 	it("approves media-server access for approved external files resolved through the URL policy", async () => {
 		const downloadsPath = path.join(tempRoot, "Downloads");
 		const videoPath = path.join(downloadsPath, "external-video.mp4");

--- a/electron/ipc/project/manager.ts
+++ b/electron/ipc/project/manager.ts
@@ -100,6 +100,18 @@ export function isAllowedLocalReadPath(candidatePath: string) {
 // become fetchable inside the app.
 export async function isAllowedLocalMediaPath(candidatePath: string) {
 	const normalizedCandidatePath = normalizePath(candidatePath);
+	// The recordings location can be changed in settings, so the compile-time
+	// default RECORDINGS_DIR alone is not sufficient for media created there.
+	// Canonicalize the configured root as well as the candidate to retain the
+	// symlink protection enforced by isAllowedLocalReadPath.
+	const recordingsDir = await getRecordingsDir();
+	const canonicalRecordingsDir = await fs
+		.realpath(recordingsDir)
+		.catch(() => normalizePath(recordingsDir));
+	if (isPathInsideDirectory(normalizedCandidatePath, canonicalRecordingsDir)) {
+		return true;
+	}
+
 	return isAllowedLocalReadPath(normalizedCandidatePath);
 }
 


### PR DESCRIPTION
# Allow media in configured recordings directory

## Description
Fixes Recordly blocking audio/media files stored in a user-configured recordings directory.

## Motivation
The editor rejected recording audio files as “disallowed” when the recordings location was changed in settings. This prevented microphone and system audio tracks from loading.

## Type of Change
- [x] Bug Fix

## Related Issue(s)
N/A

## Screenshots / Video
N/A, this is a backend media-path validation fix with no UI changes.


## Testing Guide
1. Set a custom recordings directory in Recordly settings.
2. Create or open a recording with microphone/system audio.
3. Confirm audio tracks load in the editor without Blocked disallowed path warnings.

Automated validation:
```
npm test -- electron/ipc/project/manager.test.ts
npx biome lint electron/ipc/project/manager.ts electron/ipc/project/manager.test.ts
npm run build:linux
```

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media files stored in the configured recordings directory are now recognized and accessible correctly.
  * Improved handling of recordings directories when paths use symbolic links or other alternate path representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->