### PR TITLE
fix(release): support Windows and Linux prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,17 +53,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BODY: ${{ github.event.release.body }}
           REQUESTED_SCOPE: ${{ github.event.inputs.release_scope }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG_NAME: ${{ github.event.inputs.tag_name }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAG_NAME="${{ github.event.release.tag_name }}"
+            TAG_NAME="$RELEASE_TAG_NAME"
             IS_PRERELEASE="${{ github.event.release.prerelease }}"
             RELEASE_SCOPE="all"
             if [ "$IS_PRERELEASE" = "true" ] && grep -Fq '<!-- release-scope: windows-linux -->' <<< "$RELEASE_BODY"; then
               RELEASE_SCOPE="windows-linux"
             fi
           else
-            TAG_NAME="${{ github.event.inputs.tag_name }}"
+            TAG_NAME="$DISPATCH_TAG_NAME"
             IS_PRERELEASE="$(gh release view "$TAG_NAME" --repo "${{ github.repository }}" --json isPrerelease --jq '.isPrerelease' 2>/dev/null || echo false)"
             RELEASE_SCOPE="${REQUESTED_SCOPE:-all}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,14 @@ on:
         description: Existing release tag to rebuild and publish
         required: true
         type: string
+      release_scope:
+        description: Platforms to publish
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - windows-linux
 
 permissions:
   contents: write
@@ -30,6 +38,7 @@ jobs:
       package_version: ${{ steps.prepare.outputs.package_version }}
       source_sha: ${{ steps.prepare.outputs.source_sha }}
       prerelease: ${{ steps.prepare.outputs.prerelease }}
+      release_scope: ${{ steps.prepare.outputs.release_scope }}
     steps:
       - name: Checkout release source
         uses: actions/checkout@v4
@@ -42,14 +51,21 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          REQUESTED_SCOPE: ${{ github.event.inputs.release_scope }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "release" ]; then
             TAG_NAME="${{ github.event.release.tag_name }}"
             IS_PRERELEASE="${{ github.event.release.prerelease }}"
+            RELEASE_SCOPE="all"
+            if [ "$IS_PRERELEASE" = "true" ] && grep -Fq '<!-- release-scope: windows-linux -->' <<< "$RELEASE_BODY"; then
+              RELEASE_SCOPE="windows-linux"
+            fi
           else
             TAG_NAME="${{ github.event.inputs.tag_name }}"
             IS_PRERELEASE="$(gh release view "$TAG_NAME" --repo "${{ github.repository }}" --json isPrerelease --jq '.isPrerelease' 2>/dev/null || echo false)"
+            RELEASE_SCOPE="${REQUESTED_SCOPE:-all}"
           fi
 
           if [ -z "$TAG_NAME" ]; then
@@ -65,6 +81,19 @@ jobs:
             exit 1
           fi
 
+          case "$RELEASE_SCOPE" in
+            all|windows-linux) ;;
+            *)
+              echo "Unsupported release scope: $RELEASE_SCOPE"
+              exit 1
+              ;;
+          esac
+
+          if [ "$IS_PRERELEASE" != "true" ] && [ "$RELEASE_SCOPE" != "all" ]; then
+            echo "Partial platform scope is allowed only for prereleases."
+            exit 1
+          fi
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             gh release view "$TAG_NAME" --repo "${{ github.repository }}" >/dev/null 2>&1 || \
               gh release create "$TAG_NAME" --repo "${{ github.repository }}" --verify-tag --draft --title "$TAG_NAME"
@@ -74,9 +103,11 @@ jobs:
           echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
           echo "source_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "release_scope=$RELEASE_SCOPE" >> "$GITHUB_OUTPUT"
   build-macos-x64:
     name: Build macOS x64
     needs: prepare-release
+    if: needs.prepare-release.outputs.release_scope == 'all'
     runs-on: macos-15-intel
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -178,6 +209,7 @@ jobs:
   build-macos-arm64:
     name: Build macOS arm64
     needs: prepare-release
+    if: needs.prepare-release.outputs.release_scope == 'all'
     runs-on: macos-14
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -282,6 +314,7 @@ jobs:
       - prepare-release
       - build-macos-x64
       - build-macos-arm64
+    if: needs.prepare-release.outputs.release_scope == 'all'
     runs-on: ubuntu-latest
     steps:
       - name: Download macOS x64 artifacts
@@ -521,21 +554,37 @@ jobs:
       - merge-macos-update-metadata
       - build-windows-x64
       - build-linux-x64
+    if: |
+      always() &&
+      needs.prepare-release.result == 'success' &&
+      needs.build-windows-x64.result == 'success' &&
+      needs.build-linux-x64.result == 'success' &&
+      (
+        needs.prepare-release.outputs.release_scope == 'windows-linux' ||
+        (
+          needs.build-macos-x64.result == 'success' &&
+          needs.build-macos-arm64.result == 'success' &&
+          needs.merge-macos-update-metadata.result == 'success'
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Download macOS x64 artifacts
+        if: needs.prepare-release.outputs.release_scope == 'all'
         uses: actions/download-artifact@v4
         with:
           name: macos-x64-release
           path: release-assets/macos-x64
 
       - name: Download macOS arm64 artifacts
+        if: needs.prepare-release.outputs.release_scope == 'all'
         uses: actions/download-artifact@v4
         with:
           name: macos-arm64-release
           path: release-assets/macos-arm64
 
       - name: Download merged macOS metadata
+        if: needs.prepare-release.outputs.release_scope == 'all'
         uses: actions/download-artifact@v4
         with:
           name: macos-merged-metadata
@@ -557,23 +606,29 @@ jobs:
         shell: bash
         env:
           IS_PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
+          RELEASE_SCOPE: ${{ needs.prepare-release.outputs.release_scope }}
         run: |
           set -euo pipefail
           shopt -s nullglob
 
           mkdir -p release-assets/upload
           assets=(
-            release-assets/macos-x64/*.dmg
-            release-assets/macos-x64/*.zip
-            release-assets/macos-x64/*.blockmap
-            release-assets/macos-arm64/*.dmg
-            release-assets/macos-arm64/*.zip
-            release-assets/macos-arm64/*.blockmap
             release-assets/windows-x64/*.exe
             release-assets/windows-x64/*.blockmap
             release-assets/linux-x64/*.AppImage
             release-assets/linux-x64/*.blockmap
           )
+
+          if [ "$RELEASE_SCOPE" = "all" ]; then
+            assets+=(
+              release-assets/macos-x64/*.dmg
+              release-assets/macos-x64/*.zip
+              release-assets/macos-x64/*.blockmap
+              release-assets/macos-arm64/*.dmg
+              release-assets/macos-arm64/*.zip
+              release-assets/macos-arm64/*.blockmap
+            )
+          fi
 
           if [ "$IS_PRERELEASE" != "true" ]; then
             assets+=(
@@ -638,7 +693,7 @@ jobs:
       - prepare-release
       - publish-release-assets
     runs-on: ubuntu-latest
-    if: needs.prepare-release.outputs.prerelease != 'true'
+    if: needs.prepare-release.outputs.prerelease != 'true' && needs.prepare-release.outputs.release_scope == 'all'
     steps:
       - name: Dispatch Homebrew tap workflow
         shell: bash


### PR DESCRIPTION
## Summary

Add an explicit `windows-linux` scope for prereleases while keeping stable and ordinary release runs fail-closed on every platform.

## Problem and root cause

The reviewed `v1.3.5-beta.2` source builds on Windows and Linux, but both signed macOS jobs are blocked by invalid Apple notarization credentials. The existing workflow requires all four platforms, so its publish job correctly skips every release asset.

## Focused change

- expose `all` / `windows-linux` on manual release dispatch
- recognize `<!-- release-scope: windows-linux -->` only on prerelease publication
- skip macOS jobs only for that explicit scope
- require both Windows and Linux build jobs before publishing
- upload only their installers/blockmaps plus a combined attested checksum
- reject partial stable releases and suppress stable update/Homebrew metadata

The default remains `all`; no product source, version, tag, dependency, or signing policy changes.

## Verification

- PyYAML parse and Bash syntax checks
- checksum-verified `actionlint` 1.7.12
- marked/default/manual scope scenarios
- stable partial rejection scenario
- partial/full/stable asset-set simulations
- `npx tsc --noEmit`
- `npm run lint` (pass; inherited warnings)
- `npm test` — 106 files, 995 pass, 1 skip
- `git diff --check`

## Risk and rollback

Risk is limited to release orchestration. The partial path is prerelease-only and opt-in; removing the merge commit restores the all-platform gate. `v1.3.5-beta.2` will be labeled Windows/Linux only, with macOS unavailable and the Windows installer disclosed as unsigned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable release scope for publishing all platforms or Windows/Linux only.
  * Enabled macOS publishing to be automatically skipped for partial scope releases (when applicable).
* **Bug Fixes**
  * Prevented Homebrew updates for partial releases and for prereleases.
  * Ensured release assets are staged/published only for the platforms included in the selected scope.
* **Chores**
  * Improved release validation and conditional execution to match the chosen scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->