### PR TITLE
fix(linux): use a real screen source on X11 instead of the portal sen…

### DIFF
--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -121,6 +121,34 @@ const LINUX_PORTAL_SOURCE: ProcessedDesktopSource = {
 	sourceType: "screen",
 };
 
+// The Linux HUD has no source picker, so recording starts with no selected
+// source. Main already resolves screens per session type: the portal sentinel
+// on Wayland, a real desktop-capturer id on X11. Prefer a real id when one
+// exists, because the X11 portal dialog never opens and capture then fails
+// with "Could not start video source".
+async function resolveDefaultLinuxSource(): Promise<ProcessedDesktopSource> {
+	try {
+		const sources = await window.electronAPI.getSources({
+			types: ["screen"],
+			thumbnailSize: { width: 1, height: 1 },
+			fetchWindowIcons: false,
+		});
+		const captureableScreen = sources.find(
+			(candidate) =>
+				candidate.id?.startsWith("screen:") &&
+				candidate.id !== LINUX_PORTAL_SOURCE.id &&
+				!candidate.id.startsWith("screen:fallback:"),
+		);
+		if (captureableScreen) {
+			return captureableScreen;
+		}
+	} catch (error) {
+		console.warn("Failed to resolve a default Linux screen source:", error);
+	}
+
+	return LINUX_PORTAL_SOURCE;
+}
+
 type DesktopCaptureMediaDevices = {
 	getUserMedia: (constraints: unknown) => Promise<MediaStream>;
 	getDisplayMedia: (constraints: unknown) => Promise<MediaStream>;
@@ -1379,7 +1407,7 @@ export function useScreenRecorder(): UseScreenRecorderReturn {
 			hideEditorOverlayCursorByDefault.current = false;
 			const existingSource = await window.electronAPI.getSelectedSource();
 			const selectedSource =
-				existingSource ?? (platform === "linux" ? LINUX_PORTAL_SOURCE : null);
+				existingSource ?? (platform === "linux" ? await resolveDefaultLinuxSource() : null);
 			if (!selectedSource) {
 				alert("Please select a source to record");
 				return;


### PR DESCRIPTION
## Description

The Linux HUD renders no source picker, so `getSelectedSource()` is always null when recording starts. `startRecording` then substitutes the `screen:linux-portal` sentinel for every Linux session, forcing capture through `getDisplayMedia` and the xdg-desktop-portal ScreenCast dialog. On X11 that dialog never opens, so recording fails with `Could not start video source`.

Main already resolves screens correctly per session type via `getScreenSourceIdForDisplay()` — the portal sentinel on Wayland, a real desktop-capturer id on X11. The renderer just never asked for it. This adds `resolveDefaultLinuxSource()`, which prefers a real screen id when available and keeps the sentinel as fallback.

Part of a series of Linux fixes for Ubuntu 24.04; each PR is standalone and touches disjoint files.

## Motivation

X11 users cannot record at all — capture fails immediately with `Could not start video source`, confirmed by #137. Wayland is unaffected today and stays unaffected here: it still resolves to the portal sentinel and the single-dialog flow. Only X11 changes, moving to direct capture with a real source id. Fallback ids (`screen:fallback:*`) are skipped so the existing "Selected display is not available" guard still applies.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

Refs #137, #364, #441

## Screenshots / Video

Not a UI change — the observable difference is that recording starts instead of throwing. On X11, source resolution now yields a real id (e.g. `screen:661:0`) and capture begins; before, it threw `Could not start video source` before any frame.

## Testing Guide

```bash
npx vitest --run
npm run dev   # on a Linux X11 session, press record without picking a source — it should record
```

Verified on Ubuntu 24.04 (GNOME, X11): resolves a real source id and captures at 3840x2160@60 from a fresh profile with no source selected. Wayland unchanged — still resolves to the portal sentinel.

Note: `resolveDefaultLinuxSource` is module-private and depends on `window.electronAPI`, so a unit test means exporting it and mocking that. Happy to add if wanted.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

## Notes

Investigated and drafted with Claude Code. The error message and the X11/Wayland behaviour described are from real runs on the hardware listed, not generated — I can re-run either on request.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linux screen recording now automatically selects the first available captureable screen source.
  - If no suitable source is found, recording continues using the standard fallback option.

- **Bug Fixes**
  - Improved Linux recording startup by avoiding unavailable or non-captureable screen sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->