### PR TITLE
fix(exporter): set default render backend for ModernVideoExporter

### DIFF
--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -52,6 +52,7 @@ import {
 } from "@/lib/wallpapers";
 import { AudioProcessor, isAacAudioEncodingSupported } from "./audioEncoder";
 import {
+	getDefaultLightningRenderBackend,
 	normalizeLightningRuntimePlatform,
 	shouldPreferNativeAutoBackend,
 	shouldPreferNativeStaticLayoutBeforeBreeze,
@@ -586,7 +587,7 @@ export class ModernVideoExporter {
 				this.renderer = new ModernFrameRenderer({
 					width: this.config.width,
 					height: this.config.height,
-					preferredRenderBackend: undefined,
+					preferredRenderBackend: getDefaultLightningRenderBackend(),
 					wallpaper: this.config.wallpaper,
 					zoomRegions: this.config.zoomRegions,
 					showShadow: this.config.showShadow,


### PR DESCRIPTION
## Description

`ModernVideoExporter` passes `preferredRenderBackend: undefined` to `ModernFrameRenderer`. With no preference and `navigator.gpu` present (always, in Electron), the backend order becomes `["webgpu", "webgl"]`, so Lightning renders through Pixi's WebGPU path — which is broken on Linux across GPU vendors (#644 has Intel, AMD, and NVIDIA reporters).

`backendPolicy` already exports `getDefaultLightningRenderBackend()`, which returns `"webgl"` and has a passing test, but the exporter never called it. This wires it up, flipping the order to `["webgl", "webgpu"]` — the same order the Legacy pipeline uses, which reporters confirm works — while keeping WebGPU as a fallback if WebGL fails to init.

Part of a series of Linux fixes for Ubuntu 24.04; each PR is standalone and touches disjoint files.

## Motivation

WebGPU `requestAdapter()` succeeds, then rendering crashes deeper inside Pixi's bind-group system, so the renderer's init-time fallback never fires and export dies with:

> Lightning (Beta) export failed. Reason: Cannot read properties of undefined (reading '_resourceType')
> Renderer: webgpu

Because the adapter check passes, gating on `requestAdapter()` would not help — the WebGPU path itself is the flaw, not the presence check. Preferring WebGL avoids it entirely.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

Fixes #644

## Screenshots / Video

Not a UI change. The observable difference is the export banner: `Renderer: webgpu` (crashes) before, `Renderer: webgl` (completes) after.

## Testing Guide

```bash
npx vitest --run
npm run dev   # export with Lightning (Beta); banner should read "Renderer: webgl"
```

Confirmed on Ubuntu 24.04 (X11, hybrid Intel iGPU + NVIDIA RTX 3070): with WebGPU, `requestAdapter()` returns a valid adapter yet Pixi still crashes as above; WebGL initializes cleanly as `ANGLE (Intel, Mesa Intel(R) UHD Graphics (CML GT2), OpenGL 4.6)`.

## Scope

`getDefaultLightningRenderBackend()` returns `"webgl"` unconditionally, so this applies to all platforms, not just Linux. #644 notes a possibly-related macOS variant (#501). If you'd rather keep WebGPU-first on macOS/Windows, I can gate this on `platform === "linux"` instead — happy to adjust.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

## Notes

Investigated and drafted with Claude Code. The error and adapter behaviour described are from real runs on the hardware listed, not generated — I can re-run on request.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video export rendering by selecting the recommended default rendering backend automatically.
  * Enhanced export reliability and consistency across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->