### PR TITLE
feat(hud): add shouldResizeHudOverlayFallback function and tests

### DIFF
--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -4,6 +4,7 @@ import {
 	getHudOverlayWindowBounds,
 	resizeHudOverlayFallbackBounds,
 	shouldExpandHudOverlayFallback,
+	shouldResizeHudOverlayFallback,
 } from "./hudOverlayBounds";
 
 describe("getHudOverlayWindowBounds", () => {
@@ -184,5 +185,19 @@ describe("shouldExpandHudOverlayFallback", () => {
 				webcamPreviewVisible: true,
 			}),
 		).toBe(false);
+	});
+});
+
+describe("shouldResizeHudOverlayFallback", () => {
+	it("allows non-passthrough HUD windows to expand for menus when idle", () => {
+		expect(shouldResizeHudOverlayFallback(false, false)).toBe(true);
+	});
+
+	it("does not resize full passthrough HUD windows", () => {
+		expect(shouldResizeHudOverlayFallback(true, false)).toBe(false);
+	});
+
+	it("keeps the recording HUD compact in non-passthrough mode", () => {
+		expect(shouldResizeHudOverlayFallback(false, true)).toBe(false);
 	});
 });

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -50,6 +50,13 @@ export function shouldExpandHudOverlayFallback({
 	return fallbackExpanded || (recordingActive && webcamPreviewVisible);
 }
 
+export function shouldResizeHudOverlayFallback(
+	mousePassthroughSupported: boolean,
+	recordingActive: boolean,
+): boolean {
+	return !mousePassthroughSupported && !recordingActive;
+}
+
 export function resizeHudOverlayFallbackBounds(
 	workArea: HudOverlayWorkArea,
 	currentBounds: HudOverlayWorkArea,

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -9,7 +9,6 @@ import {
 	getHudOverlayWindowBounds,
 	resizeHudOverlayFallbackBounds,
 	shouldExpandHudOverlayFallback,
-	shouldResizeHudOverlayFallback,
 } from "./hudOverlayBounds";
 import { getPackagedRendererBaseUrl } from "./rendererServer";
 
@@ -313,9 +312,7 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 
 	const mousePassthroughSupported = isHudOverlayMousePassthroughSupported();
 	if (!mousePassthroughSupported) {
-		if (shouldResizeHudOverlayFallback(mousePassthroughSupported, hudOverlayRecordingActive)) {
-			setHudOverlayFallbackExpanded(!ignore);
-		}
+		setHudOverlayFallbackExpanded(!ignore);
 		hudOverlayWindow.setIgnoreMouseEvents(false);
 		return;
 	}

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -9,6 +9,7 @@ import {
 	getHudOverlayWindowBounds,
 	resizeHudOverlayFallbackBounds,
 	shouldExpandHudOverlayFallback,
+	shouldResizeHudOverlayFallback,
 } from "./hudOverlayBounds";
 import { getPackagedRendererBaseUrl } from "./rendererServer";
 
@@ -310,8 +311,9 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 		return;
 	}
 
-	if (!isHudOverlayMousePassthroughSupported()) {
-		if (process.platform !== "linux") {
+	const mousePassthroughSupported = isHudOverlayMousePassthroughSupported();
+	if (!mousePassthroughSupported) {
+		if (shouldResizeHudOverlayFallback(mousePassthroughSupported, hudOverlayRecordingActive)) {
 			setHudOverlayFallbackExpanded(!ignore);
 		}
 		hudOverlayWindow.setIgnoreMouseEvents(false);


### PR DESCRIPTION
## Description

Re-lands `e2802bf` (#612), which was reverted as collateral in `d2796fb` (#656). On Linux `isHudOverlayMousePassthroughSupported()` is always false, so the HUD is a fixed 860x160 window instead of a full work-area overlay. Menus taller than 160 DIP get clipped at the window edge. #612 grew the window to 540 DIP while a menu is open; the revert restored the `process.platform !== "linux"` guard that skips that resize.

Part of a series of Linux fixes for Ubuntu 24.04; each PR is standalone and touches disjoint files.

## Motivation

#656 set out to revert **Windows** HUD passthrough regressions introduced after v1.3.1, and swept up the Linux HUD fallback in the same "revert the whole area" pass. No issue or review comment attributes any regression to the Linux part.

Confirmed with `git merge-base`: v1.3.3 contains `e2802bf` and **not** `d2796fb`. That is exactly why the shipped 1.3.3 AppImage renders HUD menus correctly while current `main` clips them.

This restores the fix as a small predicate — `shouldResizeHudOverlayFallback(mousePassthroughSupported, recordingActive)` — that only expands the non-passthrough HUD when idle, and keeps it compact while recording. It does not touch the Windows passthrough paths #656 was protecting.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

Re-lands #612 (reverted by #656).

## Screenshots / Video

Not a new UI feature — the difference is that Linux HUD menus render fully instead of clipping at the 160 DIP window edge. A before/after of an open HUD menu (e.g. the language menu) on Linux shows the clipped vs. full menu.

## Testing Guide

```bash
npx vitest --run electron/hudOverlayBounds.test.ts
npm run dev   # on Linux, open a HUD menu (e.g. language); it should render fully, not clip
```

Verified on Ubuntu 24.04 (GNOME, X11): HUD menus render fully instead of clipping. The predicate keeps the HUD compact while recording is active and only expands when idle.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

## Notes

If the Linux fallback was reverted deliberately rather than as collateral, say so and I'll close this — but I could not find any report attributing a regression to it.

Investigated and drafted with Claude Code. The behaviour described is from real runs on Ubuntu 24.04, not generated — I can re-run on request.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD overlay fallback resizing when mouse passthrough isn’t available.
  * Ensured fallback resizing/expansion won’t trigger while recording is active.
* **Tests**
  * Added automated coverage to confirm the HUD overlay fallback resizing decision across recording and passthrough-supported states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->