### PR TITLE
feat(launch): auto-start recording once a source is selected

### DIFF
--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -83,6 +83,7 @@ function LaunchWindowContent() {
 	const { elapsed, formatTime } = useRecordingTimer(recording, paused);
 	const hudContentRef = useRef<HTMLDivElement>(null);
 	const hudBarRef = useRef<HTMLDivElement>(null);
+	const pendingAutoStartRef = useRef(false);
 
 	const {
 		selectedSource,
@@ -162,6 +163,12 @@ function LaunchWindowContent() {
 		};
 	}, []);
 
+	useEffect(() => {
+		if (openId !== "sources") {
+			pendingAutoStartRef.current = false;
+		}
+	}, [openId]);
+
 	const {
 		recordingHudOffset,
 		isHudDragging,
@@ -226,7 +233,13 @@ function LaunchWindowContent() {
 				<>
 					<SourcePopover
 						selectedSource={selectedSource}
-						onSourceSelect={handleSourceSelect}
+						onSourceSelect={async (source) => {
+							await handleSourceSelect(source);
+							if (pendingAutoStartRef.current) {
+								pendingAutoStartRef.current = false;
+								void toggleRecording();
+							}
+						}}
 						onOpen={beginInteractiveHudAction}
 						trigger={
 							<Button
@@ -353,6 +366,7 @@ function LaunchWindowContent() {
 						: () => {
 								beginInteractiveHudAction();
 								requestOpen("sources");
+								pendingAutoStartRef.current = true;
 							}
 				}
 				disabled={countdownActive}


### PR DESCRIPTION
## Summary

Tightens the very first recording flow: when the user's first click is on the **Record** button but they haven't chosen a source yet, that click opens the source picker. After the user picks a source, the recording now starts immediately — they no longer have to click Record a second time.

## Motivation (UX)

If the user's intent is already sitting on the Record button, the selection of a window/screen should finish the "start recording" action instead of forcing a redundant second click. This removes a source of confusion where the first click appears to "do nothing" (it only opened the picker).

## How it works

- The Record button (idle, no source chosen, non-Linux) opens the source popover and arms a one-shot `pendingAutoStartRef`.
- Once a source is selected successfully, `handleSourceSelect` runs first (persisting the selection via `selectSource`, as before), then `toggleRecording()` is fired to begin recording while the popover closes in the background.
- The pending flag is disarmed whenever the popover closes without a selection (outside click, Esc, blur), so a later pick from the dropdown cannot unexpectedly start a recording.

## Behavior preserved

- Picking a source from the **dropdown** source button still only changes the selection (no auto-start).
- The Linux portal flow is untouched.
- The user's countdown preference is still honored, since auto-start routes through the existing `toggleRecording` path.
- No changes to recording internals (`useScreenRecorder`, `useLaunchWindowActions`, `SourcePopover`); this is a single-file composition change in `LaunchWindow.tsx`.

## Validation

- `npm test`: 106 files, 1027 tests passed (1 pre-existing skip).
- `npx tsc --noEmit`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recording now starts automatically after selecting a source when recording was initiated without one.
  * The source picker opens automatically when no recording source is selected.
* **Bug Fixes**
  * Pending recording requests are cleared when the source picker closes or recording begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->