### PR TITLE
fix(hud): stop the recording overlay from swallowing clicks

### DIFF
--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	getHudOverlayWindowBounds,
+	recordingForcesHudOverlayFallback,
 	resizeHudOverlayFallbackBounds,
 	shouldExpandHudOverlayFallback,
 } from "./hudOverlayBounds";
@@ -142,6 +143,32 @@ describe("resizeHudOverlayFallbackBounds", () => {
 			width: 860,
 			height: 540,
 		});
+	});
+});
+
+describe("recordingForcesHudOverlayFallback", () => {
+	it("pins the HUD to the compact fallback while recording on Windows", () => {
+		expect(
+			recordingForcesHudOverlayFallback({ platform: "win32", recordingActive: true }),
+		).toBe(true);
+	});
+
+	it("keeps the full-work-area click-through overlay while recording on macOS", () => {
+		expect(
+			recordingForcesHudOverlayFallback({ platform: "darwin", recordingActive: true }),
+		).toBe(false);
+	});
+
+	it("keeps the full-work-area click-through overlay while recording on Linux", () => {
+		expect(
+			recordingForcesHudOverlayFallback({ platform: "linux", recordingActive: true }),
+		).toBe(false);
+	});
+
+	it("never forces the fallback outside recording", () => {
+		expect(
+			recordingForcesHudOverlayFallback({ platform: "win32", recordingActive: false }),
+		).toBe(false);
 	});
 });
 

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -13,6 +13,26 @@ function clamp(value: number, min: number, max: number): number {
 	return Math.min(Math.max(value, min), max);
 }
 
+/**
+ * While recording, Windows pins the HUD to a small, always-interactive window
+ * because focus changes there silently corrupt the WS_EX_TRANSPARENT flag that
+ * backs setIgnoreMouseEvents forwarding, which would leave the stop button
+ * unclickable.  Every other platform keeps the full-work-area click-through
+ * overlay: shrinking it to a fixed rectangle turns the transparent margins
+ * around the bar into a dead zone that swallows clicks aimed at the app being
+ * recorded, and the bar can only be dragged inside that rectangle so moving it
+ * never frees the blocked area.
+ */
+export function recordingForcesHudOverlayFallback({
+	platform,
+	recordingActive,
+}: {
+	platform: string;
+	recordingActive: boolean;
+}): boolean {
+	return recordingActive && platform === "win32";
+}
+
 export function getHudOverlayWindowBounds(
 	workArea: HudOverlayWorkArea,
 	mousePassthroughSupported: boolean,

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -7,6 +7,7 @@ import { app, BrowserWindow, ipcMain } from "electron";
 import { USER_DATA_PATH } from "./appPaths";
 import {
 	getHudOverlayWindowBounds,
+	recordingForcesHudOverlayFallback,
 	resizeHudOverlayFallbackBounds,
 	shouldExpandHudOverlayFallback,
 } from "./hudOverlayBounds";
@@ -193,6 +194,13 @@ function getHudOverlayDisplay() {
 	return getScreen().getPrimaryDisplay();
 }
 
+function recordingForcesHudFallback(): boolean {
+	return recordingForcesHudOverlayFallback({
+		platform: process.platform,
+		recordingActive: hudOverlayRecordingActive,
+	});
+}
+
 function getHudOverlayBounds() {
 	const { workArea } = getHudOverlayDisplay();
 	const fallbackExpanded = shouldExpandHudOverlayFallback({
@@ -202,7 +210,7 @@ function getHudOverlayBounds() {
 	});
 	return getHudOverlayWindowBounds(
 		workArea,
-		isHudOverlayMousePassthroughSupported() && !hudOverlayRecordingActive,
+		isHudOverlayMousePassthroughSupported() && !recordingForcesHudFallback(),
 		fallbackExpanded,
 	);
 }
@@ -259,7 +267,7 @@ function positionUpdateToastWindow() {
 }
 
 function setHudOverlayFallbackExpanded(expanded: boolean) {
-	if (hudOverlayRecordingActive) {
+	if (recordingForcesHudFallback()) {
 		hudOverlayFallbackExpanded = false;
 		return;
 	}
@@ -290,7 +298,7 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 	hudOverlayIgnoringMouse =
 		hudOverlaySourceSelectionActive && !hudOverlayRecordingActive
 			? true
-			: hudOverlayRecordingActive
+			: recordingForcesHudFallback()
 				? false
 				: ignore;
 
@@ -303,7 +311,7 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 		return;
 	}
 
-	if (hudOverlayRecordingActive) {
+	if (recordingForcesHudFallback()) {
 		hudOverlayFallbackExpanded = false;
 		applyHudOverlayBounds();
 		hudOverlayWindow.setIgnoreMouseEvents(false);
@@ -503,7 +511,7 @@ export function createHudOverlayWindow(): BrowserWindow {
 	}
 
 	if (isHudOverlayMousePassthroughSupported()) {
-		if (hudOverlayRecordingActive) {
+		if (recordingForcesHudFallback()) {
 			hudOverlayIgnoringMouse = false;
 			win.setIgnoreMouseEvents(false);
 		} else {
@@ -638,7 +646,7 @@ export function reassertHudOverlayMousePassthrough(): void {
 		return;
 	}
 
-	if (hudOverlayRecordingActive) {
+	if (recordingForcesHudFallback()) {
 		hud.setIgnoreMouseEvents(false);
 		return;
 	}
@@ -658,10 +666,31 @@ export function reassertHudOverlayMousePassthrough(): void {
 }
 
 export function setHudOverlayRecordingActive(recording: boolean): void {
+	const wasFallbackForced = recordingForcesHudFallback();
 	hudOverlayRecordingActive = Boolean(recording);
 	hudOverlayFallbackExpanded = false;
 	applyHudOverlayBounds();
-	setHudOverlayMousePassthrough(!hudOverlayRecordingActive);
+
+	if (recordingForcesHudFallback()) {
+		// Compact, always-interactive HUD window: the whole window is the bar.
+		setHudOverlayMousePassthrough(false);
+		return;
+	}
+
+	if (wasFallbackForced) {
+		// Leaving the compact fallback re-expands the overlay to the whole work
+		// area, so it has to become click-through again before it swallows every
+		// click on the desktop.
+		setHudOverlayMousePassthrough(true);
+		return;
+	}
+
+	// The overlay already spans the work area and stays click-through while
+	// recording; the renderer's hover tracking owns the interactive state, so
+	// preserve it instead of forcing the window interactive (which would block
+	// clicks everywhere) or click-through (which would drop a click already
+	// aimed at the bar).
+	setHudOverlayMousePassthrough(hudOverlayIgnoringMouse);
 }
 
 export function createUpdateToastWindow(): BrowserWindow {

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -451,13 +451,17 @@ function LaunchWindowContent() {
 					ref={hudContentRef}
 					className="flex items-center overflow-visible flex-col-reverse pointer-events-none"
 				>
-					<div
-						className="flex flex-col items-center pointer-events-auto p-2"
-						onMouseEnter={handleHudMouseEnter}
-						onMouseLeave={handleHudMouseLeave}
-					>
+					<div className="flex flex-col items-center pointer-events-none p-2">
+						{/* The interactive area has to sit on the transformed wrapper, not on
+						    the static column above it: transforms do not move layout boxes, so
+						    a pointer-events-auto parent would keep swallowing clicks at the
+						    bar's original bottom-centre position after the bar is dragged
+						    away. */}
 						<div
 							ref={hudBarTransformRef}
+							className="pointer-events-auto"
+							onMouseEnter={handleHudMouseEnter}
+							onMouseLeave={handleHudMouseLeave}
 							style={{
 								transform: `translate3d(${recordingHudOffset.x}px, ${recordingHudOffset.y}px, 0)`,
 							}}


### PR DESCRIPTION
## Problem

While recording, the HUD overlay swaps its full-work-area click-through window for a fixed **860×160** rectangle (**860×540** when the webcam preview is up) anchored bottom-centre of the work area, and enables mouse events on the whole window (`setIgnoreMouseEvents(false)`).

The window is transparent but still a native window, so its empty margins around the bar swallow every click aimed at the app being recorded. Reported symptom: a Save button near the bottom of the screen stops responding as soon as recording starts.

Moving the HUD does not help, for two independent reasons:

1. On passthrough-capable platforms the bar is dragged by `useHudBarDrag`, which only translates DOM content *inside* the HUD window — the window, and therefore the dead rectangle, never moves.
2. In `LaunchWindow.tsx` the `pointer-events-auto` box was the **parent** of the transformed wrapper. CSS transforms do not move layout boxes, so that box stayed at the bar's original bottom-centre position, kept matching the `.pointer-events-auto` hover check, and kept eating clicks there.

## Fix

**1. Scope the compact recording fallback to Windows** (`recordingForcesHudOverlayFallback`, new pure helper in `hudOverlayBounds.ts`).

The fallback earns its keep on Windows only: focus changes there silently corrupt the `WS_EX_TRANSPARENT` flag behind `setIgnoreMouseEvents` forwarding — the reason for the surrounding win32-gated reassert machinery — which would leave the stop button unclickable mid-recording. macOS has no such failure mode, and its renderer is already written for the full-work-area model (JS content-drag; the webcam-preview drag clamp uses `screen.width`, which was silently clipped to the 860 px window before).

`setHudOverlayRecordingActive()` now distinguishes three transitions instead of forcing `!recording`:

| transition | passthrough |
|---|---|
| entering the win32 fallback | off (compact window *is* the bar) |
| leaving the win32 fallback | on (window re-expands to the work area) |
| macOS/Linux start & stop | preserved — the renderer's hover tracking owns it |

That last one matters: forcing the now-fullscreen window interactive at recording start would block clicks everywhere until the first mouseleave, and forcing it click-through would drop a click already aimed at the bar.

**2. Move the interactive box onto the transformed wrapper** so it travels with the bar.

## Behaviour by platform

- **macOS** — full-work-area click-through overlay during recording; no dead zone; webcam preview can now be dragged across the whole screen as its clamp always intended.
- **Windows 11 / Windows 10** — unchanged (compact interactive fallback while recording).
- **Linux** — unchanged; passthrough is unsupported there, and the ignore argument only feeds `setHudOverlayFallbackExpanded`, which Linux skips.

## Testing

- `npm test` — 1000 passed, including 4 new cases for `recordingForcesHudOverlayFallback`.
- `tsc --noEmit` and `biome check` clean on the changed files.
- Manual on macOS: start a recording, click in the bottom-centre strip that was previously dead (with and without the webcam preview), drag the bar away and click its original position, confirm stop/pause still respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD behavior while recording on Windows by using compact fallback mode when needed.
  * Preserved full overlay behavior during recording on macOS and Linux.
  * Fixed click-through and pointer interactions after moving the HUD.
  * Improved hover behavior on the transformed HUD bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->