### PR TITLE
ci(macos): fail fast on invalid notary credentials

### DIFF
--- a/.github/workflows/macos-release-candidate.yml
+++ b/.github/workflows/macos-release-candidate.yml
@@ -131,11 +131,9 @@ jobs:
           npm run normalize:electron-main-cjs
           npm run smoke:electron-main-cjs
 
-      - name: Validate Apple credentials and signing certificate
+      - name: Validate Apple signing certificate
         shell: bash
         env:
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_SIGNING_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_SIGNING_CERTIFICATE_P12_BASE64 }}
           APPLE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -143,7 +141,7 @@ jobs:
           set -euo pipefail
           umask 077
 
-          for name in APPLE_SIGNING_CERTIFICATE_P12_BASE64 APPLE_SIGNING_CERTIFICATE_PASSWORD APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+          for name in APPLE_SIGNING_CERTIFICATE_P12_BASE64 APPLE_SIGNING_CERTIFICATE_PASSWORD APPLE_TEAM_ID; do
             if [[ -z "${!name:-}" ]]; then
               echo "Missing required macOS candidate secret: $name"
               exit 1
@@ -192,6 +190,31 @@ jobs:
           fi
 
           echo "Developer ID certificate preflight passed and remains valid for at least 24 hours."
+
+      - name: Authenticate Apple notarization credentials
+        timeout-minutes: 5
+        shell: bash
+        env:
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          for name in APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required macOS candidate secret: $name"
+              exit 1
+            fi
+          done
+
+          xcrun notarytool history \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            >/dev/null
+
+          echo "Apple notarization credential preflight passed."
 
       - name: Package, sign, and notarize macOS ${{ matrix.arch }}
         shell: bash


### PR DESCRIPTION
## Description

Protected candidate run [31274913581](https://github.com/webadderallorg/Recordly/actions/runs/31274913581) signed both x64 and arm64 apps with the configured Developer ID certificate, but Apple notarization then failed on both architectures with HTTP 401 invalid credentials.

This PR adds an explicit `notarytool history` authentication preflight after compilation and certificate validation, but before electron-builder packaging. Apple ID and app-specific password are now scoped to that dedicated step and the package step rather than the certificate parser. Successful history output is discarded, the check has a five-minute timeout, and the existing always-run certificate cleanup remains unchanged.

Apple documents `notarytool` authentication with Apple ID, app-specific password, and Team ID in its [custom notarization workflow guidance](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow).

## Safety and scope

- Candidate-only workflow; public `release.yml` is unchanged.
- Exact-main authorization, `--publish never`, fail-closed verdict, and three-day artifact retention are unchanged.
- No secret value was read, copied, logged, or persisted.
- With the current invalid credentials, the next candidate should fail before packaging. A credential holder must replace or correct the Apple notarization secrets before a successful candidate is possible.

## Testing

- Checksum-verified actionlint 1.7.12 passed.
- PyYAML parse and focused policy assertions passed.
- `git diff --check` passed.

## Type of change

- [x] Release engineering / CI hardening
- [ ] Product runtime change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Improved macOS release validation by separating signing certificate and notarization credential checks.
  * Added an independent verification step for Apple notarization access before release processing.
  * Release checks now provide clearer detection of missing or invalid signing and notarization credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->