### PR TITLE
fix(i18n): use Simplified Chinese locale label

### DIFF
--- a/src/components/launch/popovers/MorePopover.tsx
+++ b/src/components/launch/popovers/MorePopover.tsx
@@ -29,7 +29,7 @@ const LOCALE_LABELS: Record<string, string> = {
 	nl: "Nederlands",
 	ko: "한국어",
 	"pt-BR": "Português",
-	"zh-CN": "簡體中文",
+	"zh-CN": "简体中文",
 	"zh-TW": "繁體中文",
 };
 

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -915,7 +915,7 @@ const APP_LANGUAGE_LABELS: Record<AppLocale, string> = {
 	nl: "Nederlands",
 	ko: "한국어",
 	"pt-BR": "Português",
-	"zh-CN": "簡體中文",
+	"zh-CN": "简体中文",
 	"zh-TW": "繁體中文",
 };
 


### PR DESCRIPTION
# Pull Request Template

## Description
Replace the traditional-form label `簡體中文` with the Simplified Chinese label `简体中文` in both application language selectors.

## Motivation
The Simplified Chinese option should identify itself using Simplified Chinese characters.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
None.

## Screenshots / Video
Not applicable for this text-only correction.

## Testing Guide
- Verified both `zh-CN` label maps now use `简体中文`.
- Ran `git diff --check`.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Simplified Chinese language label to use the appropriate characters consistently across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->