### PR TITLE
Allow crop insets to be adjusted in 0.1% increments

### DIFF
--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -1778,10 +1778,10 @@ export function SettingsPanel({
 		width: 1,
 		height: 1,
 	};
-	const cropTop = Math.round(crop.y * 100);
-	const cropLeft = Math.round(crop.x * 100);
-	const cropBottom = Math.round((1 - crop.y - crop.height) * 100);
-	const cropRight = Math.round((1 - crop.x - crop.width) * 100);
+	const cropTop = Math.round(crop.y * 1000) / 10;
+	const cropLeft = Math.round(crop.x * 1000) / 10;
+	const cropBottom = Math.round((1 - crop.y - crop.height) * 1000) / 10;
+	const cropRight = Math.round((1 - crop.x - crop.width) * 1000) / 10;
 	const isCropped = cropTop > 0 || cropLeft > 0 || cropBottom > 0 || cropRight > 0;
 
 	const setCropInset = (side: "top" | "bottom" | "left" | "right", pct: number) => {
@@ -2583,9 +2583,9 @@ export function SettingsPanel({
 					defaultValue={0}
 					min={0}
 					max={50}
-					step={1}
+					step={0.1}
 					onChange={(v) => setCropInset("top", v)}
-					formatValue={(v) => `${Math.round(v)}%`}
+					formatValue={(v) => `${(Math.round(v * 10) / 10).toFixed(1)}%`}
 					parseInput={(text) => parseFloat(text.replace(/%$/, ""))}
 				/>
 				<SliderControl
@@ -2594,9 +2594,9 @@ export function SettingsPanel({
 					defaultValue={0}
 					min={0}
 					max={50}
-					step={1}
+					step={0.1}
 					onChange={(v) => setCropInset("bottom", v)}
-					formatValue={(v) => `${Math.round(v)}%`}
+					formatValue={(v) => `${(Math.round(v * 10) / 10).toFixed(1)}%`}
 					parseInput={(text) => parseFloat(text.replace(/%$/, ""))}
 				/>
 				<SliderControl
@@ -2605,9 +2605,9 @@ export function SettingsPanel({
 					defaultValue={0}
 					min={0}
 					max={50}
-					step={1}
+					step={0.1}
 					onChange={(v) => setCropInset("left", v)}
-					formatValue={(v) => `${Math.round(v)}%`}
+					formatValue={(v) => `${(Math.round(v * 10) / 10).toFixed(1)}%`}
 					parseInput={(text) => parseFloat(text.replace(/%$/, ""))}
 				/>
 				<SliderControl
@@ -2616,9 +2616,9 @@ export function SettingsPanel({
 					defaultValue={0}
 					min={0}
 					max={50}
-					step={1}
+					step={0.1}
 					onChange={(v) => setCropInset("right", v)}
-					formatValue={(v) => `${Math.round(v)}%`}
+					formatValue={(v) => `${(Math.round(v * 10) / 10).toFixed(1)}%`}
 					parseInput={(text) => parseFloat(text.replace(/%$/, ""))}
 				/>
 			</div>


### PR DESCRIPTION
## Summary

The Top/Bottom/Left/Right crop sliders in the editor's settings panel stepped by whole percents, which is too coarse when fine-tuning a crop. This changes them to step by 0.1%:

- `step` on the four crop `SliderControl`s goes from `1` to `0.1`, which applies to both dragging and arrow-key nudges since `SliderControl` quantizes both to the same step.
- The derived inset values (`cropTop`/`cropLeft`/`cropBottom`/`cropRight`) now round to one decimal place instead of whole percents, and the value labels display one decimal (e.g. `12.3%`) so the finer steps are visible.

The canvas crop overlay (dragging the edge handles on the video) was already continuous and is unchanged.

## Testing

- `tsc` passes
- Built and ran the packaged macOS app; verified the crop sliders move in 0.1% steps and display one decimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crop inset controls now support tenth-of-a-percent precision.
  * Crop sliders use finer 0.1% increments and display values with one decimal place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->