### PR TITLE
changed the crop slider increments from 1% to 0.1% for better accuracy

### DIFF
--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -1778,10 +1778,10 @@ export function SettingsPanel({
 		width: 1,
 		height: 1,
 	};
-	const cropTop = Math.round(crop.y * 100);
-	const cropLeft = Math.round(crop.x * 100);
-	const cropBottom = Math.round((1 - crop.y - crop.height) * 100);
-	const cropRight = Math.round((1 - crop.x - crop.width) * 100);
+	const cropTop = Math.round(crop.y * 1000) / 10;
+	const cropLeft = Math.round(crop.x * 1000) / 10;
+	const cropBottom = Math.round((1 - crop.y - crop.height) * 1000) / 10;
+	const cropRight = Math.round((1 - crop.x - crop.width) * 1000) / 10;
 	const isCropped = cropTop > 0 || cropLeft > 0 || cropBottom > 0 || cropRight > 0;
 
 	const setCropInset = (side: "top" | "bottom" | "left" | "right", pct: number) => {
@@ -2583,9 +2583,9 @@ export function SettingsPanel({
 					defaultValue={0}
 					min={0}
 					max={50}
-					step={1}
+					step={0.1}
 					onChange={(v) => setCropInset("top", v)}
-					formatValue={(v) => `${Math.round(v)}%`}
+					formatValue={(v) => `${(Math.round(v * 10) / 10).toFixed(1)}%`}
 					parseInput={(text) => parseFloat(text.replace(/%$/, ""))}
 				/>
 				<SliderControl
@@ -2594,9 +2594,9 @@ export function SettingsPanel({
 					defaultValue={0}
 					min={0}
 					max={50}
-					step={1}
+					step={0.1}
 					onChange={(v) => setCropInset("bottom", v)}
-					formatValue={(v) => `${Math.round(v)}%`}
+					formatValue={(v) => `${(Math.round(v * 10) / 10).toFixed(1)}%`}
 					parseInput={(text) => parseFloat(text.replace(/%$/, ""))}
 				/>
 				<SliderControl
@@ -2605,9 +2605,9 @@ export function SettingsPanel({
 					defaultValue={0}
 					min={0}
 					max={50}
-					step={1}
+					step={0.1}
 					onChange={(v) => setCropInset("left", v)}
-					formatValue={(v) => `${Math.round(v)}%`}
+					formatValue={(v) => `${(Math.round(v * 10) / 10).toFixed(1)}%`}
 					parseInput={(text) => parseFloat(text.replace(/%$/, ""))}
 				/>
 				<SliderControl
@@ -2616,9 +2616,9 @@ export function SettingsPanel({
 					defaultValue={0}
 					min={0}
 					max={50}
-					step={1}
+					step={0.1}
 					onChange={(v) => setCropInset("right", v)}
-					formatValue={(v) => `${Math.round(v)}%`}
+					formatValue={(v) => `${(Math.round(v * 10) / 10).toFixed(1)}%`}
 					parseInput={(text) => parseFloat(text.replace(/%$/, ""))}
 				/>
 			</div>


### PR DESCRIPTION
# Pull Request Template

## Description
changed the crop slider increments from 1% to 0.1%

## Motivation
Better precision, more polished looks of the final result

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
<!-- Link to any related issue(s) (e.g., #123) -->

## Screenshots / Video
<!-- Include screenshots or a short video demonstrating the change. If the change adds a new UI feature, attach an image. If it adds functionality best shown via video, embed a video. -->

**Screenshot** (if applicable):

<img width="1271" height="701" alt="image" src="https://github.com/user-attachments/assets/d9d6b4ed-f59b-4abb-8700-63a60aedb40d" />

## Testing Guide
Change sliders to get accurate results

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Crop controls now support more precise adjustments in 0.1% increments.
  - Crop values are displayed consistently with one decimal place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->